### PR TITLE
#MPT-11549 Billing api to return collections on list methods

### DIFF
--- a/swo_mpt_api/httpquery.py
+++ b/swo_mpt_api/httpquery.py
@@ -1,0 +1,68 @@
+from typing import Annotated, Generic, Self, TypeVar
+
+from mpt_extension_sdk.mpt_http.base import MPTClient
+
+T = TypeVar("T")
+
+
+class HttpQuery(Generic[T]):
+    def __init__(self, client: MPTClient, url: str, query=None):
+        self._client = client
+        self._url = url
+        self._query = query
+
+    def _has_more_pages(self, page):
+        if not page:
+            return True
+        pagination = page["$meta"]["pagination"]
+        return pagination["total"] > pagination["limit"] + pagination["offset"]
+
+    def _paginated(self, limit=10):
+        items = []
+        page = None
+        offset = 0
+        while self._has_more_pages(page):
+            page = self.page(offset, limit)
+            items.extend(page["data"])
+            offset += limit
+        return items
+
+    def all(self) -> list[T]:
+        return self._paginated()
+
+    def one(self) -> T:
+        response_data = self._call(self._url)
+        if len(response_data.get("data")) != 1:
+            raise ValueError(f"Expected 1 item, got {len(response_data.get('data', []))}")
+        return response_data.get("data", [])[0]
+
+    def first(self) -> T:
+        response_data = self._call(self._url)
+        return response_data.get("data", [])[0]
+
+    def page(self, offset=0, limit=10) -> dict:
+        response_data = self._call(f"offset={offset}&limit={limit}")
+        return response_data
+
+    def query(self, query: Annotated[str, None, "Query in RQL format"]) -> Self:
+        if self._query and query:
+            query = f"{self._query}&{query}"
+        elif self._query or query:
+            query = self._query or query
+        return HttpQuery(self._client, self._url, query)
+
+    def _call(self, query=None) -> dict:
+        url = self._url
+        query_parts = []
+        if self._query:
+            query_parts.append(self._query)
+        if query:
+            query_parts.append(query)
+        if query_parts:
+            full_query = "&".join(query_parts)
+            response = self._client.get(f"{url}?{full_query}")
+        else:
+            response = self._client.get(url)
+        response.raise_for_status()
+        response_data = response.json()
+        return response_data

--- a/tests/swo_mpt_api/test_billing_journal_attachemnts.py
+++ b/tests/swo_mpt_api/test_billing_journal_attachemnts.py
@@ -9,13 +9,20 @@ def test_list_attachments(requests_mock, mpt_client):
     ]
     response_data = {
         "data": attachments_data,
+        "$meta": {
+            "pagination": {
+                "total": 2,
+                "limit": 10,
+                "offset": 0,
+            }
+        },
     }
     requests_mock.get(
         f"https://localhost/v1/billing/journals/{journal_id}/attachments", json=response_data
     )
     api = MPTAPIClient(mpt_client)
-    result = api.billing.journal.attachments(journal_id).list()
-    assert result == response_data
+    result = api.billing.journal.attachments(journal_id).all()
+    assert result == attachments_data
 
 
 def test_upload_attachment(requests_mock, mpt_client, tmp_path):

--- a/tests/swo_mpt_api/test_billing_journal_charges_client.py
+++ b/tests/swo_mpt_api/test_billing_journal_charges_client.py
@@ -1,17 +1,27 @@
 from swo_mpt_api import MPTAPIClient
 
 
-def test_list_charges(requests_mock, mpt_client):
+def test_all_charges(requests_mock, mpt_client):
     journal_id = "journal-id"
     charges_data = [
         {"id": "charge-1", "amount": 100},
         {"id": "charge-2", "amount": 200},
     ]
+    response_mock = {
+        "$meta": {
+            "pagination": {
+                "total": 2,
+                "limit": 10,
+                "offset": 0,
+            }
+        },
+        "data": charges_data,
+    }
     requests_mock.get(
-        f"https://localhost/v1/billing/journals/{journal_id}/charges", json=charges_data
+        f"https://localhost/v1/billing/journals/{journal_id}/charges", json=response_mock
     )
     api = MPTAPIClient(mpt_client)
-    result = api.billing.journal.charges(journal_id).list()
+    result = api.billing.journal.charges(journal_id).all()
     assert result == charges_data
 
 

--- a/tests/swo_mpt_api/test_billing_journal_client.py
+++ b/tests/swo_mpt_api/test_billing_journal_client.py
@@ -36,6 +36,8 @@ def test_query_journals(mpt_client, journal_data):
         "$meta": {
             "pagination": {
                 "total": 1,
+                "limit": 10,
+                "offset": 0,
             }
         },
         "data": [journal_data],
@@ -43,7 +45,7 @@ def test_query_journals(mpt_client, journal_data):
     responses.get("https://localhost/v1/billing/journals", json=response_data)
     api = MPTAPIClient(mpt_client)
     journals = api.billing.journal.query("")
-    assert journals == response_data
+    assert journals.all() == [journal_data]
 
 
 @responses.activate

--- a/tests/swo_mpt_api/test_httpquery.py
+++ b/tests/swo_mpt_api/test_httpquery.py
@@ -1,0 +1,146 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from swo_mpt_api.httpquery import HttpQuery
+
+
+class DummyModel(dict):
+    pass
+
+
+def test_one_returns_single_item():
+    mock_client = MagicMock()
+    expected_item = DummyModel({"id": 1, "name": "test"})
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [expected_item]}
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    collection = HttpQuery[DummyModel](mock_client, "http://fake-url")
+    result = collection.one()
+    assert result == expected_item
+
+
+def test_one_raises_if_not_one_item():
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [{"id": 1}, {"id": 2}]}
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    collection = HttpQuery[DummyModel](mock_client, "http://fake-url")
+
+    with pytest.raises(ValueError):
+        collection.one()
+
+
+def test_first_returns_first_item():
+    mock_client = MagicMock()
+    expected_item = DummyModel({"id": 1, "name": "first"})
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [expected_item, {"id": 2}]}
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    collection = HttpQuery[DummyModel](mock_client, "http://fake-url")
+
+    result = collection.first()
+
+    assert result == expected_item
+
+
+def test_page_returns_response_data():
+    mock_client = MagicMock()
+    expected_data = {"data": [{"id": 1}, {"id": 2}], "meta": {"total": 2}}
+    mock_response = MagicMock()
+    mock_response.json.return_value = expected_data
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    collection = HttpQuery[DummyModel](mock_client, "http://fake-url")
+
+    result = collection.page(offset=5, limit=2)
+
+    mock_client.get.assert_called_once_with("http://fake-url?offset=5&limit=2")
+    assert result == expected_data
+
+
+def test_query_combines_existing_and_new_rql():
+    mock_client = MagicMock()
+    base_query = "foo=1"
+    new_rql = "bar=2"
+    hq = HttpQuery(mock_client, "http://fake-url", base_query)
+    result = hq.query(new_rql)
+    assert isinstance(result, HttpQuery)
+    assert result._query == f"{base_query}&{new_rql}"
+    assert result._url == "http://fake-url"
+    assert result._client == mock_client
+
+
+def test_query_uses_existing_query_only():
+    mock_client = MagicMock()
+    base_query = "foo=1"
+    hq = HttpQuery(mock_client, "http://fake-url", base_query)
+    result = hq.query(None)
+    assert result._query == base_query
+
+
+def test_query_uses_new_rql_only():
+    mock_client = MagicMock()
+    new_rql = "bar=2"
+    hq = HttpQuery(mock_client, "http://fake-url")
+    result = hq.query(new_rql)
+    assert result._query == new_rql
+
+
+def test_query_with_no_query_or_rql():
+    mock_client = MagicMock()
+    hq = HttpQuery(mock_client, "http://fake-url")
+    result = hq.query(None)
+    assert result._query is None
+
+
+def test__call_no_query():
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [1]}
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    hq = HttpQuery(mock_client, "http://fake-url")
+    result = hq._call()
+    mock_client.get.assert_called_once_with("http://fake-url")
+    mock_response.raise_for_status.assert_called_once()
+    assert result == {"data": [1]}
+
+
+def test__call_with_self_query():
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [2]}
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    hq = HttpQuery(mock_client, "http://fake-url", "foo=1")
+    result = hq._call()
+    mock_client.get.assert_called_once_with("http://fake-url?foo=1")
+    assert result == {"data": [2]}
+
+
+def test__call_with_query_arg():
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [3]}
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    hq = HttpQuery(mock_client, "http://fake-url")
+    result = hq._call(query="bar=2")
+    mock_client.get.assert_called_once_with("http://fake-url?bar=2")
+    assert result == {"data": [3]}
+
+
+def test__call_with_both_queries():
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [4]}
+    mock_response.raise_for_status.return_value = None
+    mock_client.get.return_value = mock_response
+    hq = HttpQuery(mock_client, "http://fake-url", "foo=1")
+    result = hq._call(query="bar=2")
+    mock_client.get.assert_called_once_with("http://fake-url?foo=1&bar=2")
+    assert result == {"data": [4]}


### PR DESCRIPTION
Update Billing API to use collections instead of returning plane lists.

- Journal.all() -> returns all journals
- Journal.query(rql_query).all() -> returns all() -> Journals
- Journal.query(rql_query).query(second_rql).all()
- Journal.query(rql_query).one() -> returns Journal or exception