### PR TITLE
MPT-11643 - Upload all aws reports as attachment to the journal

### DIFF
--- a/swo_aws_extension/management/commands/upload_journal_attachment.py
+++ b/swo_aws_extension/management/commands/upload_journal_attachment.py
@@ -1,0 +1,101 @@
+import io
+import os
+import pathlib
+import zipfile
+from datetime import date
+from mimetypes import guess_type
+
+from django.core.management import CommandError
+from mpt_extension_sdk.core.utils import setup_client
+from requests import HTTPError
+
+from swo_aws_extension.management.commands_helpers import StyledPrintCommand
+from swo_mpt_api import MPTAPIClient
+from swo_mpt_api.models.hints import JournalAttachment
+
+
+class Command(StyledPrintCommand):
+    """
+    Upload a journal attachment file or zipped folder to the marketplace
+
+    Arguments:
+        path: The file or folder to upload as attachment. In case of a folder, it will be zipped
+        journal: The journal id, it will create
+
+    Example:
+        swoext django upload_journal_attachment BJO-0005-0005 cloud_explorer.jsonl
+        swoext django upload_journal_attachment BJO-0005-0005 export/reports-2025-03-01/
+    """
+
+    help = "Upload journal attachments files to MPT"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "journal", type=str, default=None, help="Existing journal ID to upload to"
+        )
+        parser.add_argument(
+            "path",
+            type=str,
+            help="Path to the file to upload. If provided a folder it will zip it and upload it",
+        )
+
+    def _upload(self, journal_id, *args, **kwargs) -> JournalAttachment:
+        client = setup_client()
+        api = MPTAPIClient(client)
+        return api.billing.journal.attachments(journal_id).upload(*args, **kwargs)
+
+    def zip_add_path(self, zip, path) -> io.BytesIO:
+        for root, _dirs, files in os.walk(path):
+            for file in files:
+                file_path = os.path.join(root, file)
+                zip.write(file_path, file_path)
+
+    def upload_zip(self, path, journal_id):
+        self.info(f"Zipping and Uploading `{path}` to `{journal_id}`")
+        filename = f"{journal_id}-{date.today().isoformat()}-{pathlib.Path(path).name}.zip"
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            self.zip_add_path(zip_file, path)
+
+        mimetype = "application/zip"
+        try:
+            zip_buffer.seek(0)
+            response = self._upload(
+                journal_id, filename=filename, mimetype=mimetype, file=zip_buffer
+            )
+            self.info(str(response))
+            self.success(f"Successfully uploaded zip to journal {journal_id}")
+        except HTTPError as e:
+            error_message = f"Error uploading zip file to journal {journal_id}: {e}"
+            self.error(error_message)
+            self.info(e.response.text)
+            raise CommandError(error_message, returncode=3)
+
+    def upload_file(self, path, journal_id):
+        self.info(f"Uploading `{path}` to `{journal_id}`")
+        filename = pathlib.Path(path).name
+        filetype = guess_type(path)[0]
+        self.info(f"Filetype: {filetype}")
+        with open(path) as fd:
+            try:
+                response = self._upload(journal_id, fd, "application/octet-stream")
+                self.info(str(response))
+                self.success(f"Successfully uploaded file `{filename}` to journal {journal_id}")
+            except HTTPError as e:
+                self.error(f"Error uploading file to journal {journal_id}: {e}")
+                self.info(e.response.text)
+                if e.response:
+                    raise CommandError(e.response.text, returncode=3)
+                raise CommandError(str(e), returncode=3)
+
+    def handle(self, *args, **options):
+        journal_id = options["journal"]
+        path = options["path"]
+
+        if pathlib.Path(path).is_dir():
+            self.upload_zip(path, journal_id)
+        elif pathlib.Path(path).is_file():
+            self.upload_file(path, journal_id)
+        else:
+            self.error(f"Path `{path}` does not exist")
+            raise CommandError(f"Path `{path}` does not exist", returncode=2)

--- a/swo_mpt_api/billing/journal_client.py
+++ b/swo_mpt_api/billing/journal_client.py
@@ -1,3 +1,4 @@
+import json
 from functools import lru_cache
 from typing import IO, Annotated
 
@@ -17,10 +18,31 @@ class AttachmentsClient:
         url = f"/billing/journals/{self.journal_id}/attachments"
         return HttpQuery(self._client, url, rql)
 
-    def upload(self, attachment: IO) -> JournalAttachment:
-        response = self._client.post(
-            f"/billing/journals/{self.journal_id}/attachments", files={"file": attachment}
-        )
+    def upload(
+        self, file, mimetype:str, filename:str|None=None, attachment:JournalAttachment|None=None
+    ) -> JournalAttachment:
+        """
+        Uploads attachment files to the Journal
+
+        Parameters:
+            attachment: A file-like object (supporting read operations) to be uploaded.
+            filename: The name of the file to be uploaded.
+            mimetype: The MIME type of the file to be uploaded.
+            file: A file-like object (supporting read operations) to be uploaded.
+
+        Returns:
+            Dict: A dictionary containing the response data from the upload operation.
+
+        Raises:
+            HTTPError: If the upload request fails, an exception will be raised.
+        """
+
+        url = f"/billing/journals/{self.journal_id}/attachments"
+        filename = filename or file.name
+        attachment = attachment or JournalAttachment(name="", description="")
+
+        files = {"file": (filename, file, mimetype)}
+        response = self._client.post(url, data={"attachment": json.dumps(attachment)}, files=files)
         response.raise_for_status()
         return response.json()
 

--- a/tests/management/commands/test_upload_journal_attachment.py
+++ b/tests/management/commands/test_upload_journal_attachment.py
@@ -1,0 +1,83 @@
+import json
+from unittest.mock import mock_open
+
+import pytest
+from django.core.management import CommandError, call_command
+from requests import HTTPError, Response
+
+
+def test_upload_journal_attachment_command(mocker):
+    mocked_handle = mocker.patch(
+        "swo_aws_extension.management.commands.upload_journal_attachment.Command.handle"
+    )
+    mocked_handle.return_value = None
+
+    call_command("upload_journal_attachment", "BJO-3828-0982", "test_file.txt")
+    mocked_handle.assert_called()
+
+
+def test_upload_file(mocker, tmp_path):
+    file = tmp_path / "file1.txt"
+    file.write_text("content1")
+    journal_id = "JRN-123"
+    mocker.patch("builtins.open", mock_open(read_data="test content"))
+
+    upload_mock = mocker.patch("swo_mpt_api.billing.journal_client.AttachmentsClient.upload")
+    call_command("upload_journal_attachment", journal_id, str(file))
+    upload_mock.assert_called_once_with(mocker.ANY, "application/octet-stream")
+
+
+def test_upload_zip_file(mocker, tmp_path):
+    test_folder = tmp_path / "test_folder"
+    test_folder.mkdir()
+    (test_folder / "file1.txt").write_text("content1")
+    (test_folder / "file2.txt").write_text("content2")
+
+    journal_id = "JRN-123"
+    upload_mock = mocker.patch("swo_mpt_api.billing.journal_client.AttachmentsClient.upload")
+    call_command("upload_journal_attachment", journal_id, test_folder)
+    upload_mock.assert_called_once()
+
+
+def test_upload_file_fail(mocker, tmp_path):
+    file = tmp_path / "file1.txt"
+    file.write_text("content1")
+    journal_id = "JRN-123"
+    mocker.patch("builtins.open", mock_open(read_data="test content"))
+
+    error_response = Response()
+    error_response.status_code = 400
+    error_response._content = json.dumps({"error": True, "message": "Test error"}).encode("utf-8")
+
+    mocker.patch(
+        "swo_mpt_api.billing.journal_client.AttachmentsClient.upload",
+        side_effect=HTTPError(response=error_response),
+    )
+    with pytest.raises(CommandError):
+        call_command("upload_journal_attachment", journal_id, file)
+
+
+def test_upload_zip_file_fail(mocker, tmp_path):
+    test_folder = tmp_path / "test_folder"
+    test_folder.mkdir()
+    (test_folder / "file1.txt").write_text("content1")
+    (test_folder / "file2.txt").write_text("content2")
+
+    journal_id = "JRN-123"
+    error_response = Response()
+    error_response.status_code = 400
+    error_response._content = json.dumps({"error": True, "message": "Test error"}).encode("utf-8")
+
+    mocker.patch(
+        "swo_mpt_api.billing.journal_client.AttachmentsClient.upload",
+        side_effect=HTTPError(response=error_response),
+    )
+
+    with pytest.raises(CommandError):
+        call_command("upload_journal_attachment", journal_id, str(test_folder))
+
+
+def test_upload_non_existing_path_fail(mocker):
+    journal_id = "JRN-123"
+    with pytest.raises(CommandError):
+        call_command("upload_journal_attachment", journal_id, "/tmp/non-existing-folder")

--- a/tests/swo_mpt_api/test_billing_journal_attachemnts.py
+++ b/tests/swo_mpt_api/test_billing_journal_attachemnts.py
@@ -31,6 +31,7 @@ def test_upload_attachment(requests_mock, mpt_client, tmp_path):
     file_path = tmp_path / "test.pdf"
     file_path.write_bytes(file_content)
     response_data = {"id": "attachment-1", "filename": "test.pdf"}
+
     requests_mock.post(
         f"https://localhost/v1/billing/journals/{journal_id}/attachments",
         json=response_data,
@@ -38,7 +39,9 @@ def test_upload_attachment(requests_mock, mpt_client, tmp_path):
     )
     api = MPTAPIClient(mpt_client)
     with open(file_path, "rb") as f:
-        result = api.billing.journal.attachments(journal_id).upload(f)
+        result = api.billing.journal.attachments(journal_id).upload(
+            f, "application/pdf", "test.pdf"
+        )
     assert result == response_data
 
 


### PR DESCRIPTION
Added command upload_journal_attachment to upload a journal attachment file or zipped folder to the marketplace

Usage to upload a file:

```
   swoext django upload_journal_attachment BJO-0005-0005 cloud_explorer.jsonl
   
```

Usage to upload a zip:

```   
   swoext django upload_journal_attachment BJO-0005-0005 export/reports-2025-03-01/
   
```