### PR TITLE
MPT-11920: update ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,12 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.3
     hooks:
-      - id: ruff
+      - id: ruff-check
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml


### PR DESCRIPTION
Update the ruff url and hook in pre-commit -> [https://github.com/astral-sh/ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit)

<img width="684" height="50" alt="image" src="https://github.com/user-attachments/assets/b4287c97-6acd-4187-902f-4fcbb3c3f361" />

Note: this PR also updates the repo versions in the current pre-commit configuration