### PR TITLE
MPT-19663 Fix issue with invalid subscription external id

### DIFF
--- a/swo_aws_extension/flows/jobs/billing_journal/models/journal_line.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/journal_line.py
@@ -155,7 +155,7 @@ class JournalLine:
                 source=SearchSource(
                     type="Subscription",
                     criteria="externalIds.vendor",
-                    criteria_value=invoice_details.account_id,
+                    criteria_value=journal_details.mpa_id,
                 ),
             ),
             segment=segment,

--- a/tests/flows/jobs/billing_journal/models/test_journal_line.py
+++ b/tests/flows/jobs/billing_journal/models/test_journal_line.py
@@ -80,7 +80,7 @@ def test_build():
             "source": {
                 "type": "Subscription",
                 "criteria": "externalIds.vendor",
-                "value": "ACC-789",
+                "value": "MPA-456",
             },
         },
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-19663](https://softwareone.atlassian.net/browse/MPT-19663)

## Changes

- Updated `JournalLine.build()` to use `journal_details.mpa_id` instead of `invoice_details.account_id` as the criteria value for vendor-based subscription lookups
- Updated corresponding test expectations to reflect the new MPA ID value used in subscription searches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19663]: https://softwareone.atlassian.net/browse/MPT-19663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ