### PR TITLE
MPT-19674 remove whitespaces in MPA ordering parameter

### DIFF
--- a/swo_aws_extension/flows/order_utils.py
+++ b/swo_aws_extension/flows/order_utils.py
@@ -14,6 +14,7 @@ from mpt_extension_sdk.mpt_http.wrap_http_error import MPTError, wrap_mpt_http_e
 from swo_aws_extension.constants import MptOrderStatus
 from swo_aws_extension.flows.order import InitialAWSContext
 from swo_aws_extension.flows.steps.errors import OrderStatusChangeError
+from swo_aws_extension.parameters import get_mpa_account_id, set_mpa_account_id
 from swo_aws_extension.swo.notifications.mpt import MPTNotificationManager
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,14 @@ def set_template(order, template):
     updated_order = copy.deepcopy(order)
     updated_order["template"] = template
     return updated_order
+
+
+def strip_whitespace_from_mpa_account(order: dict) -> dict:
+    """Strip whitespace from the Master Payer Account ID parameter."""
+    mpa_account_id = get_mpa_account_id(order)
+    if mpa_account_id:
+        return set_mpa_account_id(order, mpa_account_id.strip())
+    return order
 
 
 # TODO: SDK candidate

--- a/swo_aws_extension/flows/steps/setup_context.py
+++ b/swo_aws_extension/flows/steps/setup_context.py
@@ -12,7 +12,10 @@ from swo_aws_extension.constants import (
     PhasesEnum,
 )
 from swo_aws_extension.flows.order import InitialAWSContext
-from swo_aws_extension.flows.order_utils import update_processing_template_and_notify
+from swo_aws_extension.flows.order_utils import (
+    strip_whitespace_from_mpa_account,
+    update_processing_template_and_notify,
+)
 from swo_aws_extension.flows.steps.base import BasePhaseStep
 from swo_aws_extension.flows.steps.errors import ConfigurationStepError, UnexpectedStopError
 from swo_aws_extension.parameters import get_phase, set_fulfillment_parameter_value, set_phase
@@ -38,6 +41,7 @@ class SetupContext(BasePhaseStep):
     def process(self, client: MPTClient, context: InitialAWSContext) -> None:
         self._init_processing_template(client, context)
         self._init_parameter_default_values(client, context)
+        context.order = strip_whitespace_from_mpa_account(context.order)
         try:
             context.aws_client = AWSClient(
                 self._config, context.pm_account_id, self._config.management_role_name

--- a/swo_aws_extension/flows/validation/base.py
+++ b/swo_aws_extension/flows/validation/base.py
@@ -6,6 +6,7 @@ from mpt_extension_sdk.mpt_http.mpt import get_product_items_by_skus
 from mpt_extension_sdk.mpt_http.wrap_http_error import ValidationError
 
 from swo_aws_extension.constants import AWS_ITEMS_SKUS, AccountTypesEnum, OrderParametersEnum
+from swo_aws_extension.flows.order_utils import strip_whitespace_from_mpa_account
 from swo_aws_extension.parameters import (
     get_account_type,
     get_ordering_parameter,
@@ -152,6 +153,7 @@ def validate_order(client: MPTClient, order: dict) -> dict:
     """
     validated_order = copy.deepcopy(order)
     validated_order = reset_ordering_parameters_error(validated_order)
+    validated_order = strip_whitespace_from_mpa_account(validated_order)
     error_order = _validate_new_account_constraints(validated_order)
     if error_order:
         return error_order

--- a/swo_aws_extension/parameters.py
+++ b/swo_aws_extension/parameters.py
@@ -34,6 +34,17 @@ def get_mpa_account_id(source: dict[str, Any]) -> str | None:
     return ordering_param.get("value", None)
 
 
+def set_mpa_account_id(order: dict[str, Any], mpa_account_id: str) -> dict[str, Any]:
+    """Set the Master Payer Account ID on the ordering parameters."""
+    updated_order = copy.deepcopy(order)
+    ordering_param = get_ordering_parameter(
+        OrderParametersEnum.MASTER_PAYER_ACCOUNT_ID.value,
+        updated_order,
+    )
+    ordering_param["value"] = mpa_account_id
+    return updated_order
+
+
 def set_ordering_parameter_error(order: dict, param_external_id: str, error: dict) -> dict:
     """
     Set a validation error on an ordering parameter.

--- a/tests/flows/steps/test_setup_context.py
+++ b/tests/flows/steps/test_setup_context.py
@@ -11,7 +11,7 @@ from swo_aws_extension.constants import (
 )
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.setup_context import SetupContext
-from swo_aws_extension.parameters import get_fulfillment_parameter
+from swo_aws_extension.parameters import get_fulfillment_parameter, get_mpa_account_id
 
 
 def test_setup_context_with_pma(
@@ -434,3 +434,37 @@ def test_init_parameter_default_values_skipped_when_phase_is_informed(
     assert not get_fulfillment_parameter(
         FulfillmentParametersEnum.CHANNEL_HANDSHAKE_APPROVED.value, context.order
     ).get("value")
+
+
+def test_strip_whitespace_from_mpa_account(
+    mocker,
+    config,
+    order_factory,
+    order_parameters_factory,
+    fulfillment_parameters_factory,
+    product_parameters_factory,
+):
+    mpt_client_mock = mocker.MagicMock(spec=MPTClient)
+    next_step_mock = mocker.MagicMock(spec=Step)
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
+    mocker.patch(
+        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.steps.setup_context._paginated",
+        return_value=product_parameters_factory(),
+    )
+    order = order_factory(
+        order_parameters=order_parameters_factory(mpa_id="  651706759263  "),
+        fulfillment_parameters=fulfillment_parameters_factory(phase=""),
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.steps.setup_context.update_order",
+        side_effect=lambda *_args, **kwargs: {**order, "parameters": kwargs["parameters"]},
+    )
+    context = PurchaseContext.from_order_data(order)
+    step = SetupContext(config)
+
+    step(mpt_client_mock, context, next_step_mock)  # act
+
+    assert get_mpa_account_id(context.order) == "651706759263"

--- a/tests/flows/test_order_utils.py
+++ b/tests/flows/test_order_utils.py
@@ -5,12 +5,14 @@ from swo_aws_extension.constants import OrderCompletedTemplate, OrderQueryingTem
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.order_utils import (
     set_order_template,
+    strip_whitespace_from_mpa_account,
     switch_order_status_to_complete,
     switch_order_status_to_failed,
     switch_order_status_to_process,
     switch_order_status_to_query,
     update_processing_template_and_notify,
 )
+from swo_aws_extension.parameters import get_mpa_account_id
 
 
 def test_set_order_template(mocker, order_factory, fulfillment_parameters_factory):
@@ -259,3 +261,23 @@ def test_update_processing_template_no_notify(
         template=new_template,
     )
     notification_mock.assert_not_called()
+
+
+def test_strip_whitespace_from_mpa_account(order_factory, order_parameters_factory):
+    order = order_factory(
+        order_parameters=order_parameters_factory(mpa_id="  651706759263  "),
+    )
+
+    result = strip_whitespace_from_mpa_account(order)
+
+    assert get_mpa_account_id(result) == "651706759263"
+
+
+def test_strip_whitespace_from_mpa_account_without_value(order_factory, order_parameters_factory):
+    order = order_factory(
+        order_parameters=order_parameters_factory(mpa_id=""),
+    )
+
+    result = strip_whitespace_from_mpa_account(order)
+
+    assert not get_mpa_account_id(result)

--- a/tests/flows/validation/test_base.py
+++ b/tests/flows/validation/test_base.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+from mpt_extension_sdk.mpt_http.base import MPTClient
+
 from swo_aws_extension.constants import (
     AccountTypesEnum,
     OrderParametersEnum,
@@ -155,3 +157,26 @@ def test_validate_order_when_product_items_not_found(
     result = validate_order(mock_client, order)
 
     assert result["lines"] == []
+
+
+def test_validate_order_strips_whitespace_from_mpa_account(
+    order_factory, order_parameters_factory, mocker
+):
+    mock_client = MagicMock(spec=MPTClient)
+    order = order_factory(
+        order_parameters=order_parameters_factory(
+            account_type=AccountTypesEnum.EXISTING_AWS_ENVIRONMENT.value,
+            mpa_id="  651706759263  ",
+            constraints={"hidden": None, "required": None, "readonly": None},
+        ),
+        lines=[],
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
+        return_value=[{"id": "ITM-1", "name": "AWS Usage"}],
+    )
+
+    result = validate_order(mock_client, order)
+
+    mpa_param = get_ordering_parameter(OrderParametersEnum.MASTER_PAYER_ACCOUNT_ID.value, result)
+    assert mpa_param["value"] == "651706759263"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-19674](https://softwareone.atlassian.net/browse/MPT-19674)

- Add strip_whitespace_from_mpa_account(order: dict) in swo_aws_extension/flows/order_utils.py to trim leading/trailing whitespace from the Master Payer Account ID and write the cleaned value back into the order
- Add set_mpa_account_id(order: dict[str, Any], mpa_account_id: str) in swo_aws_extension/parameters.py to update the MASTER_PAYER_ACCOUNT_ID ordering parameter in an order copy
- Apply whitespace stripping in setup: call strip_whitespace_from_mpa_account(context.order) inside SetupContext.process() during context initialization
- Apply whitespace stripping in validation: call strip_whitespace_from_mpa_account() at start of validate_order() before constraint checks
- Add unit tests covering whitespace stripping behavior in:
  - tests/flows/test_order_utils.py
  - tests/flows/steps/test_setup_context.py
  - tests/flows/validation/test_base.py
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-19674]: https://softwareone.atlassian.net/browse/MPT-19674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ