### PR TITLE
Update conditions for SBOM and publish jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
   - stage: sbom
     displayName: SBOM
     dependsOn: [prepare, build]
-    # condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))
+    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))
     variables:
       - group: marketplace.dtrack
       - name: buildVersion
@@ -85,7 +85,7 @@ stages:
     jobs:
       - job: publish
         displayName: Publish
-#        condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/release/4'), eq(variables['System.Debug'], true))
+        condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(variables['System.Debug'], true))
         variables:
           - template: aks-docker-templates/acr-creds-group.yaml@templates
           - name: buildVersion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Enabled conditional execution for the `sbom` stage to run when the source branch is `master` or starts with `release/`
- Updated the `publish` job's `condition` to support all release branches by replacing the hardcoded `refs/heads/release/4` check with a prefix match against all `refs/heads/release/` branches, while maintaining `master` and debug gating

<!-- end of auto-generated comment: release notes by coderabbit.ai -->