### PR TITLE
[MPT-17802] Add comment to ticket when roles are already deployed in query order processor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ per-file-ignores = [
   "swo_aws_extension/default.py: WPS111 WPS407",
   "swo_aws_extension/management/commands_helpers/__init__.py: WPS410 WPS412",
   "swo_aws_extension/parameters.py: WPS204 WPS202",
+  "swo_aws_extension/processors/querying/aws_customer_roles.py: WPS213",
   "swo_aws_extension/swo/ccp/client.py: WPS210 WPS214",
   "swo_aws_extension/flows/fulfillment/pipelines.py: WPS201",
   "swo_aws_extension/flows/validation/base.py: WPS407",

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -268,3 +268,6 @@ class TeamsNotificationType(StrEnum):
 
 CLOUD_ORCHESTRATOR_ONBOARDING_TYPE = "FullCMS"
 DEFAULT_SCU = "DM-SCU-000000"
+
+
+ROLES_DEPLOYED_CRM_TICKET_COMMENT = "Customer roles have been deployed. Please resolve this ticket."

--- a/swo_aws_extension/processors/querying/aws_customer_roles.py
+++ b/swo_aws_extension/processors/querying/aws_customer_roles.py
@@ -5,6 +5,7 @@ from mpt_extension_sdk.mpt_http.mpt import update_order
 
 from swo_aws_extension.config import Config
 from swo_aws_extension.constants import (
+    ROLES_DEPLOYED_CRM_TICKET_COMMENT,
     PhasesEnum,
 )
 from swo_aws_extension.flows.order import PurchaseContext
@@ -12,6 +13,7 @@ from swo_aws_extension.flows.order_utils import switch_order_status_to_process
 from swo_aws_extension.flows.steps.crm_tickets.templates.deploy_roles import DEPLOY_ROLES_TEMPLATE
 from swo_aws_extension.flows.steps.crm_tickets.ticket_manager import TicketManager
 from swo_aws_extension.parameters import (
+    get_crm_customer_role_ticket_id,
     get_formatted_technical_contact,
     get_mpa_account_id,
     set_crm_customer_role_ticket_id,
@@ -21,6 +23,8 @@ from swo_aws_extension.processors.processor import Processor
 from swo_aws_extension.processors.querying.helper import get_template_name, is_querying_timeout
 from swo_aws_extension.swo.cloud_orchestrator.client import CloudOrchestratorClient
 from swo_aws_extension.swo.cloud_orchestrator.errors import CloudOrchestratorError
+from swo_aws_extension.swo.crm_service.client import CRMServiceClient, get_service_client
+from swo_aws_extension.swo.crm_service.errors import CRMError
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +43,7 @@ class AWSCustomerRolesProcessor(Processor):
     def process(self, context: PurchaseContext) -> None:
         """Process AWS customer roles timeout."""
         co_client = CloudOrchestratorClient(self._config)
+        crm_service_client = get_service_client()
         mpa_account_id = get_mpa_account_id(context.order)
         logger.info(
             "%s - Checking customer roles deployment status for MPA account ID %s.",
@@ -53,6 +58,10 @@ class AWSCustomerRolesProcessor(Processor):
             return
 
         if bootstrap_roles_status["deployed"]:
+            ticket_id = get_crm_customer_role_ticket_id(context.order)
+            if ticket_id:
+                self._add_comment_roles_deployed(crm_service_client, context, ticket_id)
+
             logger.info(
                 "%s - Customer roles are deployed. Updating order to processing.", context.order_id
             )
@@ -68,6 +77,27 @@ class AWSCustomerRolesProcessor(Processor):
         logger.info(
             "%s - Customer roles are not deployed yet. Waiting for next check.", context.order_id
         )
+
+    def _add_comment_roles_deployed(
+        self, crm_service_client: CRMServiceClient, context: PurchaseContext, ticket_id: str
+    ) -> None:
+        try:
+            crm_service_client.add_comment(
+                context.order_id, ticket_id, ROLES_DEPLOYED_CRM_TICKET_COMMENT
+            )
+        except CRMError:
+            logger.exception(
+                "%s - Failed to add comment to CRM ticket %s.",
+                context.order_id,
+                ticket_id,
+            )
+        else:
+            logger.info(
+                "%s - Added comment to CRM ticket %s to resolve because "
+                "customer roles are deployed.",
+                context.order_id,
+                ticket_id,
+            )
 
     def _manage_querying_timeout(self, context: PurchaseContext):
         logger.info(

--- a/swo_aws_extension/swo/crm_service/client.py
+++ b/swo_aws_extension/swo/crm_service/client.py
@@ -72,6 +72,17 @@ class ServiceRequest:
         }
 
 
+@dataclass
+class CommentRequest:
+    """Comment request API entity."""
+
+    comment: str = ""
+
+    def to_api_dict(self) -> dict:
+        """Converts to dict for CRM API."""
+        return {"value": self.comment}
+
+
 class CRMServiceClient(requests.Session):
     """Client to interact with CRM system."""
 
@@ -128,6 +139,28 @@ class CRMServiceClient(requests.Session):
         """
         response = self.get(
             url=f"/ticketing/ServiceRequests/{service_request_id}",
+            headers={"x-correlation-id": order_id},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @wrap_http_error
+    def add_comment(self, order_id: str, service_request_id: str, comment: str) -> dict:
+        """
+        Adds a comment to a service request.
+
+        Args:
+            order_id: MPT order id
+            service_request_id: Service request id
+            comment: Comment text
+
+        Returns:
+            Dictionary with updated service request details
+        """
+        comment_request = CommentRequest(comment=comment)
+        response = self.post(
+            url=f"/ticketing/ServiceRequests/{service_request_id}/comments",
+            json=comment_request.to_api_dict(),
             headers={"x-correlation-id": order_id},
         )
         response.raise_for_status()

--- a/tests/processor/querying/test_aws_customer_roles.py
+++ b/tests/processor/querying/test_aws_customer_roles.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -6,6 +7,7 @@ from mpt_extension_sdk.mpt_http.base import MPTClient
 
 from swo_aws_extension.constants import (
     CRM_TICKET_RESOLVED_STATE,
+    ROLES_DEPLOYED_CRM_TICKET_COMMENT,
     PhasesEnum,
 )
 from swo_aws_extension.flows.order import PurchaseContext
@@ -13,6 +15,7 @@ from swo_aws_extension.processors.querying.aws_customer_roles import (
     AWSCustomerRolesProcessor,
 )
 from swo_aws_extension.swo.cloud_orchestrator.errors import CloudOrchestratorError
+from swo_aws_extension.swo.crm_service.errors import CRMHttpError
 
 
 @pytest.fixture
@@ -72,9 +75,109 @@ def test_process_customer_roles_deployed(
         "swo_aws_extension.processors.querying.aws_customer_roles.get_template_name",
         return_value="TEMPLATE_NAME",
     )
+    mock_service_client = mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_service_client"
+    )
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_crm_customer_role_ticket_id",
+        return_value=None,
+    )
 
     processor.process(mock_context)  # act
 
+    mock_switch.assert_called_once_with(processor.client, mock_context, "TEMPLATE_NAME")
+    mock_service_client.return_value.add_comment.assert_not_called()
+
+
+def test_process_customer_roles_deployed_with_ticket_id(
+    mocker: Any,
+    processor: AWSCustomerRolesProcessor,
+    mock_context: MagicMock,
+    order_factory,
+    fulfillment_parameters_factory,
+    caplog: Any,
+) -> None:
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(
+            crm_customer_role_ticket_id="TICKET-123"
+        )
+    )
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_mpa_account_id",
+        return_value="mpa-account-123",
+    )
+    mock_co_client = MagicMock()
+    mock_co_client.get_bootstrap_role_status.return_value = {"deployed": True}
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.CloudOrchestratorClient",
+        return_value=mock_co_client,
+    )
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.switch_order_status_to_process"
+    )
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_template_name",
+        return_value="TEMPLATE_NAME",
+    )
+    mock_service_client = mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_service_client"
+    )
+    mock_context.order = order
+
+    processor.process(mock_context)  # act
+
+    mock_service_client.return_value.add_comment.assert_called_once_with(
+        mock_context.order_id, "TICKET-123", ROLES_DEPLOYED_CRM_TICKET_COMMENT
+    )
+    assert (
+        f"{mock_context.order_id} - Added comment to CRM ticket TICKET-123 to resolve because "
+        "customer roles are deployed."
+    ) in caplog.text
+
+
+def test_process_customer_roles_deployed_with_ticket_id_crm_error(
+    mocker: Any,
+    processor: AWSCustomerRolesProcessor,
+    mock_context: MagicMock,
+    order_factory,
+    fulfillment_parameters_factory,
+    caplog: Any,
+) -> None:
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(
+            crm_customer_role_ticket_id="TICKET-123"
+        )
+    )
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_mpa_account_id",
+        return_value="mpa-account-123",
+    )
+    mock_co_client = MagicMock()
+    mock_co_client.get_bootstrap_role_status.return_value = {"deployed": True}
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.CloudOrchestratorClient",
+        return_value=mock_co_client,
+    )
+    mock_switch = mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.switch_order_status_to_process"
+    )
+    mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_template_name",
+        return_value="TEMPLATE_NAME",
+    )
+    mock_service_client = mocker.patch(
+        "swo_aws_extension.processors.querying.aws_customer_roles.get_service_client"
+    )
+    mock_service_client.return_value.add_comment.side_effect = CRMHttpError(
+        HTTPStatus.INTERNAL_SERVER_ERROR, "server error"
+    )
+    mock_context.order = order
+
+    processor.process(mock_context)  # act
+
+    assert (
+        f"{mock_context.order_id} - Failed to add comment to CRM ticket TICKET-123."
+    ) in caplog.text
     mock_switch.assert_called_once_with(processor.client, mock_context, "TEMPLATE_NAME")
 
 
@@ -100,6 +203,7 @@ def test_process_cr_not_deployed_no_timeout(
     mock_switch = mocker.patch(
         "swo_aws_extension.processors.querying.aws_customer_roles.switch_order_status_to_process"
     )
+    mocker.patch("swo_aws_extension.processors.querying.aws_customer_roles.get_service_client")
 
     processor.process(mock_context)  # act
 
@@ -151,6 +255,7 @@ def test_process_cr_not_deployed_timeout_reached(
     mock_crm_client.return_value.get_service_request.return_value = {
         "state": "Active",
     }
+    mocker.patch("swo_aws_extension.processors.querying.aws_customer_roles.get_service_client")
 
     processor.process(mock_context)  # act
 
@@ -203,6 +308,7 @@ def test_process_cr_not_deployed_timeout_reached_to_create_new_ticket(
         "state": CRM_TICKET_RESOLVED_STATE,
     }
     mock_crm_client.return_value.create_service_request.return_value = {"id": "TICKET-999"}
+    mocker.patch("swo_aws_extension.processors.querying.aws_customer_roles.get_service_client")
 
     processor.process(mock_context)  # act
 
@@ -227,6 +333,7 @@ def test_process_cloud_orchestrator_error(
     mock_switch = mocker.patch(
         "swo_aws_extension.processors.querying.aws_customer_roles.switch_order_status_to_process"
     )
+    mocker.patch("swo_aws_extension.processors.querying.aws_customer_roles.get_service_client")
 
     processor.process(mock_context)  # act
 

--- a/tests/swo/crm_service/test_client.py
+++ b/tests/swo/crm_service/test_client.py
@@ -232,6 +232,34 @@ def test_service_request_default_values():
     assert "serviceType" in result
 
 
+def test_add_comment_success(crm_client, mock_crm_api, mock_oauth_token):
+    expected_response = {"id": "CS0004728", "comments": [{"value": "Roles deployed"}]}
+    mock_crm_api.add(
+        responses.POST,
+        f"{BASE_URL}ticketing/ServiceRequests/CS0004728/comments",
+        json=expected_response,
+        status=HTTPStatus.OK,
+    )
+
+    result = crm_client.add_comment("ORD-001", "CS0004728", "Roles deployed")
+
+    assert result == expected_response
+
+
+def test_add_comment_http_error(crm_client, mock_crm_api, mock_oauth_token):
+    mock_crm_api.add(
+        responses.POST,
+        f"{BASE_URL}ticketing/ServiceRequests/CS0004728/comments",
+        json={"error": "Bad Request"},
+        status=HTTPStatus.BAD_REQUEST,
+    )
+
+    with pytest.raises(CRMHttpError) as exc_info:
+        crm_client.add_comment("ORD-001", "CS0004728", "Roles deployed")
+
+    assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+
+
 def test_request_with_empty_url(crm_client, mock_crm_api, mock_oauth_token):
     mock_crm_api.add(
         responses.GET,


### PR DESCRIPTION
This pull request adds the ability to automatically comment on CRM service requests when AWS customer roles have been deployed, and includes supporting changes to the CRM client and associated tests. The changes ensure that when customer roles are deployed, a comment is added to the relevant CRM ticket to prompt resolution, and this behavior is thoroughly tested.

**Enhancements to CRM integration and customer roles processing:**

* Added a new constant `ROLES_DEPLOYED_CRM_TICKET_COMMENT` and logic in `aws_customer_roles.py` to post a comment on the CRM ticket when customer roles are deployed, using the CRM service client. [[1]](diffhunk://#diff-1517ff3b6f40bb2dbdbf93e232710c6df7583fcd9fa1e5b68c350b1603f14830R247-R249) [[2]](diffhunk://#diff-c1759f288c0ea76e934052ad5b368694d6646e133762bc4302747ad9ab163fe2R8-R16) [[3]](diffhunk://#diff-c1759f288c0ea76e934052ad5b368694d6646e133762bc4302747ad9ab163fe2R26) [[4]](diffhunk://#diff-c1759f288c0ea76e934052ad5b368694d6646e133762bc4302747ad9ab163fe2R45) [[5]](diffhunk://#diff-c1759f288c0ea76e934052ad5b368694d6646e133762bc4302747ad9ab163fe2R60-R73)
* Introduced the `add_comment` method to `CRMServiceClient` and a new `CommentRequest` entity for posting comments to service requests. [[1]](diffhunk://#diff-62148223ebb479e577316de55471c5b91ef3e224e23ffa94f49139f3f9b754b1R75-R85) [[2]](diffhunk://#diff-62148223ebb479e577316de55471c5b91ef3e224e23ffa94f49139f3f9b754b1R147-R168)

**Testing improvements:**

* Expanded tests in `test_aws_customer_roles.py` to cover scenarios where a comment should or should not be added to a CRM ticket, and to ensure correct logging. [[1]](diffhunk://#diff-0e73519b85e6579bf33fa2fcd7b55f9149ce38bb02e7b2496142c2a63abb6153R9) [[2]](diffhunk://#diff-0e73519b85e6579bf33fa2fcd7b55f9149ce38bb02e7b2496142c2a63abb6153R76-R133)
* Added tests for the new `add_comment` method in the CRM client, including both success and HTTP error scenarios.

**Linting and configuration:**

* Updated `pyproject.toml` to ignore linter warning WPS213 for `aws_customer_roles.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-17802](https://softwareone.atlassian.net/browse/MPT-17802)

- Automatically post a CRM comment when AWS customer roles are detected as already deployed in the query order processor
- Added ROLES_DEPLOYED_CRM_TICKET_COMMENT constant ("Customer roles have been deployed. Please resolve this ticket.")
- Extended CRMServiceClient with add_comment(order_id, service_request_id, comment) and added CommentRequest dataclass for payload serialization
- AWSCustomerRolesProcessor now resolves a CRM ticket ID and attempts to add the predefined comment (logs success; catches and logs CRMHttpError without re-raising) before switching the order to processing
- Tests added/expanded to cover comment posting success and HTTP error scenarios and to verify related logging and behavior
- Updated pyproject.toml to ignore WPS213 for aws_customer_roles.py
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-17802]: https://softwareone.atlassian.net/browse/MPT-17802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ