### PR TITLE
MPT-20028 Run the billing process only if transfer billing is enabled…

### DIFF
--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -13,7 +13,7 @@ from swo_aws_extension.config import Config
 from swo_aws_extension.swo.openid.client import OpenIDClient
 
 MINIMUM_DAYS_MONTH = 28
-MAX_RESULTS_PER_PAGE = 100
+MAX_RESULTS_PER_PAGE = 20
 
 logger = logging.getLogger(__name__)
 

--- a/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from decimal import Decimal
+
 from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
 from swo_aws_extension.flows.jobs.billing_journal.billing_report_creator import (
     BillingReportCreator,
@@ -7,6 +10,7 @@ from swo_aws_extension.flows.jobs.billing_journal.generators.authorization impor
 )
 from swo_aws_extension.flows.jobs.billing_journal.journal_manager import JournalManager
 from swo_aws_extension.flows.jobs.billing_journal.models.context import BillingJournalContext
+from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import JournalLine
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AuthorizationJournalResult,
 )
@@ -121,19 +125,30 @@ class BillingJournalService:
     def _log_dry_run_results(
         self, authorization_id: str, generator_result: AuthorizationJournalResult
     ) -> None:
-        journal_lines = generator_result.lines
         logger.info(
             "[DRY-RUN] Generated %d journal lines for authorization %s",
-            len(journal_lines),
+            len(generator_result.lines),
             authorization_id,
         )
-        logger.info("".join(entry.to_jsonl() for entry in journal_lines))
+        logger.info("".join(entry.to_jsonl() for entry in generator_result.lines))
+        self._log_totals_by_mpa(generator_result.lines)
 
-        if generator_result.reports_by_agreement:
-            attachments = [
-                f"{agr}.json"
-                for agr, rep in generator_result.reports_by_agreement.items()
-                if rep.organization_data or rep.accounts_data
-            ]
-            if attachments:
-                logger.info("[DRY-RUN] Attachments: %s", attachments)
+        attachments = [
+            f"{agr}.json"
+            for agr, rep in generator_result.reports_by_agreement.items()
+            if rep.organization_data or rep.accounts_data
+        ]
+        if attachments:
+            logger.info("[DRY-RUN] Attachments: %s", attachments)
+
+    def _log_totals_by_mpa(self, journal_lines: list[JournalLine]) -> None:
+        total_by_mpa: dict[str, Decimal] = defaultdict(Decimal)
+        for line in journal_lines:
+            total_by_mpa[line.external_ids.vendor] += line.price.pp_x1
+
+        for mpa, total_amount in total_by_mpa.items():
+            logger.info(
+                "[DRY-RUN] MPA %s total amount: %s",
+                mpa,
+                total_amount,
+            )

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
@@ -1,6 +1,8 @@
+import datetime as dt
+
 from mpt_extension_sdk.runtime.tracer import dynamic_trace_span
 
-from swo_aws_extension.constants import SupportTypesEnum
+from swo_aws_extension.constants import ResponsibilityTransferStatus, SupportTypesEnum
 from swo_aws_extension.flows.jobs.billing_journal.generators.billing_report_rows import (
     ReportContext,
     generate_billing_report_rows,
@@ -31,7 +33,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.usage import OrganizationUsageResult
 from swo_aws_extension.logger import get_logger
-from swo_aws_extension.parameters import get_support_type
+from swo_aws_extension.parameters import get_responsibility_transfer_id, get_support_type
 from swo_aws_extension.utils.decorators import with_log_context
 
 logger = get_logger(__name__)
@@ -67,8 +69,8 @@ class AgreementJournalGenerator:
             AgreementJournalResult object containing a list of JournalLine objects and reports.
         """
         mpa_account = agreement.get("externalIds", {}).get("vendor", "")
-        if not mpa_account:
-            logger.info("No MPA account found for agreement. Skipping journal generation.")
+
+        if not self._validate_agreement(agreement, mpa_account):
             return AgreementJournalResult()
 
         logger.info("Generating billing journal for MPA account %s", mpa_account)
@@ -76,10 +78,6 @@ class AgreementJournalGenerator:
             mpa_account,
             self._billing_period,
             self._auth_context.currency,
-        )
-        logger.info(
-            "Found %d invoice entities",
-            len(invoice_result.invoice.entities),
         )
 
         usage_result = self._usage_generator.run(
@@ -128,7 +126,7 @@ class AgreementJournalGenerator:
         )
 
         # If PLS is active, calculate and add the PLS charge line.
-        is_pls = get_support_type(agreement) == SupportTypesEnum.AWS_RESOLD_SUPPORT
+        is_pls = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
         if is_pls:
             all_lines.extend(
                 PlSChargeManager().process(
@@ -159,7 +157,7 @@ class AgreementJournalGenerator:
         journal_details: JournalDetails,
         organization_invoice,
     ) -> list[JournalLine]:
-        is_pls = get_support_type(agreement) == SupportTypesEnum.AWS_RESOLD_SUPPORT
+        is_pls = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
         line_generator = JournalLineGenerator(is_pls=is_pls)
 
         lines: list[JournalLine] = []
@@ -173,3 +171,40 @@ class AgreementJournalGenerator:
                 )
             )
         return lines
+
+    def _validate_agreement(self, agreement, mpa_account):
+        if not mpa_account:
+            logger.info("No MPA account found for agreement. Skipping journal generation.")
+            return False
+
+        responsibility_transfer_id = get_responsibility_transfer_id(agreement)
+        responsibility_transfer = self._auth_context.aws_client.get_responsibility_transfer_details(
+            responsibility_transfer_id,
+        )
+
+        status = responsibility_transfer.get("ResponsibilityTransfer", {}).get("Status")
+        if status != ResponsibilityTransferStatus.ACCEPTED:
+            logger.info(
+                "%s - Skipping because responsibility transfer invitation is not"
+                " accepted. Current status: %s",
+                agreement.get("id"),
+                status,
+            )
+            return False
+
+        start_timestamp = responsibility_transfer.get("ResponsibilityTransfer", {}).get(
+            "StartTimestamp"
+        )
+        billing_start = dt.datetime.strptime(
+            self._billing_period.start_date,
+            "%Y-%m-%d",
+        ).replace(tzinfo=dt.UTC)
+        if start_timestamp and start_timestamp > billing_start:
+            logger.info(
+                "%s - Skipping agreement because responsibility transfer has not started yet. "
+                "Start date: %s",
+                agreement.get("id"),
+                start_timestamp,
+            )
+            return False
+        return True

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
@@ -2,17 +2,12 @@ from mpt_extension_sdk.mpt_http.mpt import get_agreements_by_query
 from mpt_extension_sdk.runtime.tracer import dynamic_trace_span
 
 from swo_aws_extension.aws.client import AWSClient
-from swo_aws_extension.constants import (
-    BILLING_JOURNAL_ERROR_TITLE,
-    AgreementStatusEnum,
-)
+from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE, AgreementStatusEnum
 from swo_aws_extension.flows.jobs.billing_journal.generators.agreement import (
     AgreementJournalGenerator,
 )
 from swo_aws_extension.flows.jobs.billing_journal.generators.invoice import InvoiceGenerator
-from swo_aws_extension.flows.jobs.billing_journal.generators.usage import (
-    CostExplorerUsageGenerator,
-)
+from swo_aws_extension.flows.jobs.billing_journal.generators.usage import CostExplorerUsageGenerator
 from swo_aws_extension.flows.jobs.billing_journal.models.context import (
     AuthorizationContext,
     BillingJournalContext,
@@ -65,13 +60,16 @@ class AuthorizationJournalGenerator:
             logger.info("No agreements found")
             return AuthorizationJournalResult()
         logger.info("Found %d agreements", len(agreements))
-        aws_client = AWSClient(self._config, pma_account, self._config.billing_role_name)
 
+        # TODO update billing role to check responsibility transfers
         auth_context = AuthorizationContext(
             id=auth_id or "",
             pma_account=pma_account,
             currency=authorization.get("currency", ""),
+            aws_client=AWSClient(self._config, pma_account, self._config.management_role_name),
         )
+
+        aws_client = AWSClient(self._config, pma_account, self._config.billing_role_name)
 
         return self._process_agreements(
             auth_context,

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/billing_report_rows.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/billing_report_rows.py
@@ -83,11 +83,6 @@ def _group_service_metrics(
 def _resolve_exchange_rate(inv_entity: str, org_invoice: OrganizationInvoice) -> Decimal:
     if inv_entity and inv_entity in org_invoice.entities:
         return org_invoice.entities[inv_entity].exchange_rate
-    if inv_entity:
-        logger.warning(
-            "No exchange rate found for invoice entity '%s'. Defaulting to 1.0",
-            inv_entity,
-        )
     return Decimal("1.0")
 
 

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/discount/extra_discounts.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/discount/extra_discounts.py
@@ -78,8 +78,8 @@ class BaseExtraDiscountProcessor(ABC):
             service_name=self._service_name,
             amount=refund_amount,
             account_id=journal_details.mpa_id,
-            invoice_entity="",
-            invoice_id="invoice_id",
+            invoice_entity=organization_invoice.primary_entity_name,
+            invoice_id=organization_invoice.primary_invoice_id,
         )
         return [JournalLine.build(ITEM_SKU, journal_details, invoice_details)]
 

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
@@ -1,3 +1,4 @@
+import logging
 from decimal import Decimal
 
 from swo_aws_extension.aws.client import AWSClient
@@ -9,6 +10,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.invoice import (
     OrganizationInvoiceResult,
 )
 
+logger = logging.getLogger(__name__)
 SPP_DISCOUNT_DESCRIPTION = "Discount (AWS SPP Discount)"
 
 
@@ -81,6 +83,16 @@ class InvoiceGenerator:
 
         invoice = self._build_organization_invoice(raw_invoices, authorization_currency)
 
+        for entity_name, entity in invoice.entities.items():
+            logger.info(
+                "Invoice entity: %s | invoice_id=%s | base=%s | payment=%s | exchange_rate=%s",
+                entity_name,
+                entity.invoice_id,
+                entity.base_currency_code,
+                entity.payment_currency_code,
+                entity.exchange_rate,
+            )
+
         return OrganizationInvoiceResult(raw_data=raw_invoices, invoice=invoice)
 
     def _build_organization_invoice(
@@ -118,6 +130,7 @@ class InvoiceGenerator:
                     base_currency_code=existing.base_currency_code,
                     payment_currency_code=existing.payment_currency_code,
                     exchange_rate=existing.exchange_rate,
+                    primary=self._is_primary_invoice(invoice) or existing.primary,
                 )
             else:
                 entity_name = invoice.get("Entity", {}).get("InvoicingEntity")
@@ -130,23 +143,14 @@ class InvoiceGenerator:
                     ),
                     payment_currency_code=resolver.get_payment_currency(exchange_rate),
                     exchange_rate=exchange_rate,
+                    primary=self._is_primary_invoice(invoice),
                 )
 
         return entities
 
     def _get_principal_amount(self, raw_invoices: list[dict]) -> Decimal | None:
         for invoice in raw_invoices:
-            breakdowns = (
-                invoice
-                .get("BaseCurrencyAmount", {})
-                .get("AmountBreakdown", {})
-                .get("Discounts", {})
-                .get("Breakdown", [])
-            )
-            has_spp_discount = any(
-                breakdown.get("Description") == SPP_DISCOUNT_DESCRIPTION for breakdown in breakdowns
-            )
-            if has_spp_discount:
+            if self._is_primary_invoice(invoice):
                 return Decimal(invoice.get("BaseCurrencyAmount", {}).get("TotalAmount", 0))
         return None
 
@@ -154,4 +158,16 @@ class InvoiceGenerator:
         return sum(
             (Decimal(inv.get(currency_key, {}).get(amount_key, 0)) for inv in invoices),
             DEC_ZERO,
+        )
+
+    def _is_primary_invoice(self, invoice: dict) -> bool:
+        breakdowns = (
+            invoice
+            .get("BaseCurrencyAmount", {})
+            .get("AmountBreakdown", {})
+            .get("Discounts", {})
+            .get("Breakdown", [])
+        )
+        return any(
+            breakdown.get("Description") == SPP_DISCOUNT_DESCRIPTION for breakdown in breakdowns
         )

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/credit.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/credit.py
@@ -52,7 +52,7 @@ class CreditJournalLineProcessor(JournalLineProcessor):
 
     def _should_add_spp_line(self, context: LineProcessorContext) -> bool:
         principal_amount = context.organization_invoice.principal_invoice_amount
-        return principal_amount is None or principal_amount == DEC_ZERO
+        return principal_amount == DEC_ZERO
 
     def _find_spp_for_service(
         self,

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/pls_charge_manager.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/pls_charge_manager.py
@@ -46,26 +46,29 @@ class PlSChargeManager:
         Returns:
             List containing the PLS Charge journal line, if applicable.
         """
+        logger.info("Processing '%s' charge with %s", self._service_name, charge_percentage)
         principal_amount = organization_invoice.principal_invoice_amount
-        if principal_amount is None or principal_amount == DEC_ZERO:
+        if principal_amount == DEC_ZERO:
             return []
 
         if charge_percentage <= DEC_ZERO:
             return []
 
         base_amount = self._calculate_base_amount(usage_result, organization_invoice)
+        logger.info("Usage amount: %s", base_amount)
         if base_amount <= DEC_ZERO:
             return []
 
         charge_amount = self._calculate_charge_amount(base_amount, charge_percentage)
+        logger.info("PLS Charge amount: %s ", charge_amount)
 
         invoice_details = InvoiceDetails(
             item_sku=ITEM_SKU,
             service_name=self._service_name,
             amount=charge_amount,
             account_id=journal_details.mpa_id,
-            invoice_entity="",
-            invoice_id="invoice_id",
+            invoice_entity=organization_invoice.primary_entity_name,
+            invoice_id=organization_invoice.primary_invoice_id,
         )
         return [JournalLine.build(ITEM_SKU, journal_details, invoice_details)]
 

--- a/swo_aws_extension/flows/jobs/billing_journal/journal_manager.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/journal_manager.py
@@ -127,12 +127,12 @@ class JournalManager:  # noqa: WPS214
     def _build_external_id(self) -> str:
         year = self._billing_period.year
         month_name = calendar.month_name[self._billing_period.month]
-        return f"AWS-{year}-{month_name}"
+        return f"AWS-{year}-{month_name}-BT"
 
     def _build_journal_name(self, index: int) -> str:
         year = self._billing_period.year
         month_name = calendar.month_name[self._billing_period.month]
-        return f"1 {month_name} {year} #{index}"
+        return f"1 {month_name} {year} BT #{index}"
 
     def _query_pending_journal(self, external_id: str) -> Journal | None:
         rql_query = (

--- a/swo_aws_extension/flows/jobs/billing_journal/models/context.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/context.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
 
+from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
 from swo_aws_extension.flows.jobs.billing_journal.models.invoice import OrganizationInvoice
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import JournalDetails
@@ -15,6 +16,7 @@ class AuthorizationContext:
     id: str
     pma_account: str
     currency: str
+    aws_client: AWSClient
 
 
 @dataclass

--- a/swo_aws_extension/flows/jobs/billing_journal/models/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/invoice.py
@@ -12,6 +12,7 @@ class InvoiceEntity:
     base_currency_code: str = ""
     payment_currency_code: str = ""
     exchange_rate: Decimal = field(default_factory=lambda: Decimal(0))
+    primary: bool = field(default=False)
 
 
 @dataclass
@@ -24,6 +25,22 @@ class OrganizationInvoice:
     payment_currency_total_amount: Decimal = field(default_factory=lambda: Decimal(0))
     payment_currency_total_amount_before_tax: Decimal = field(default_factory=lambda: Decimal(0))
     principal_invoice_amount: Decimal | None = None
+
+    @property
+    def primary_entity_name(self) -> str:
+        """Return the name of the entity marked as primary, or empty string."""
+        for name, entity in self.entities.items():
+            if entity.primary:
+                return name
+        return ""
+
+    @property
+    def primary_invoice_id(self) -> str:
+        """Return the invoice ID of the entity marked as primary."""
+        for entity in self.entities.values():
+            if entity.primary:
+                return entity.invoice_id
+        return "invoice_id"
 
 
 @dataclass

--- a/tests/flows/jobs/billing_journal/generators/line_processors/test_credit.py
+++ b/tests/flows/jobs/billing_journal/generators/line_processors/test_credit.py
@@ -100,16 +100,18 @@ def test_process_does_not_add_spp_for_non_applicable_scenarios(
     assert result[0].description.value1 == f"{CREDIT_PREFIX}Amazon S3"
 
 
-@pytest.mark.parametrize("principal_invoice_amount", [None, Decimal(0)])
 def test_process_adds_spp_when_principal_zero(
-    processor, credit_metric, spp_metric, journal_details, principal_invoice_amount
+    processor,
+    credit_metric,
+    spp_metric,
+    journal_details,
 ):
     context = LineProcessorContext(
         account_id="ACC-001",
         account_usage=AccountUsage(metrics=[credit_metric, spp_metric]),
         journal_details=journal_details,
         organization_invoice=OrganizationInvoice(
-            principal_invoice_amount=principal_invoice_amount,
+            principal_invoice_amount=Decimal(0),
         ),
     )
 

--- a/tests/flows/jobs/billing_journal/generators/test_agreement.py
+++ b/tests/flows/jobs/billing_journal/generators/test_agreement.py
@@ -1,5 +1,9 @@
+import datetime as dt
+
 import pytest
 
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.constants import ResponsibilityTransferStatus
 from swo_aws_extension.flows.jobs.billing_journal.generators.agreement import (
     AgreementJournalGenerator,
 )
@@ -33,6 +37,37 @@ from swo_aws_extension.flows.jobs.billing_journal.models.usage import (
 
 MODULE = "swo_aws_extension.flows.jobs.billing_journal.generators.agreement"
 
+BILLING_YEAR = 2025
+MONTH_BEFORE_BILLING = 9
+BILLING_MONTH = 10
+MONTH_AFTER_BILLING = 11
+
+
+@pytest.fixture
+def accepted_transfer_response():
+    return {
+        "ResponsibilityTransfer": {
+            "Status": ResponsibilityTransferStatus.ACCEPTED,
+            "StartTimestamp": dt.datetime(BILLING_YEAR, MONTH_BEFORE_BILLING, 1, tzinfo=dt.UTC),
+        },
+    }
+
+
+@pytest.fixture
+def mock_aws_client(mocker, accepted_transfer_response):
+    mock = mocker.MagicMock(spec=AWSClient)
+    mock.get_responsibility_transfer_details.return_value = accepted_transfer_response
+    return mock
+
+
+@pytest.fixture
+def mock_get_responsibility_transfer_id(mocker):
+    return mocker.patch(
+        f"{MODULE}.get_responsibility_transfer_id",
+        autospec=True,
+        return_value="RT-123",
+    )
+
 
 @pytest.fixture
 def mock_line_generator_cls(mocker):
@@ -49,24 +84,39 @@ def mock_pls_charge_manager_cls(mocker):
     return mocker.patch(f"{MODULE}.PlSChargeManager", autospec=True)
 
 
-def test_run(
-    mocker,
-    mock_context,
-    mock_line_generator_cls,
-    mock_extra_discounts_manager_cls,
-    mock_pls_charge_manager_cls,
-):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
-    agreement = {
+def _build_agreement(support_type="ResoldSupport"):
+    return {
         "id": "AGR-1",
         "externalIds": {"vendor": "MPA"},
         "parameters": {
             "ordering": [
-                {"externalId": "supportType", "value": "ResoldSupport"},
+                {"externalId": "supportType", "value": support_type},
             ],
             "fulfillment": [],
         },
     }
+
+
+def _build_auth_context(mock_aws_client):
+    return AuthorizationContext(
+        id="AUTH-1",
+        pma_account="PMA-1",
+        currency="USD",
+        aws_client=mock_aws_client,
+    )
+
+
+def test_run(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    mock_line_generator_cls,
+    mock_extra_discounts_manager_cls,
+    mock_pls_charge_manager_cls,
+):
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True, return_value=[])
+    agreement = _build_agreement(support_type="PartnerLedSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_discount_line = mocker.MagicMock(spec=JournalLine)
     mock_pls_line = mocker.MagicMock(spec=JournalLine)
@@ -90,7 +140,7 @@ def test_run(
         invoice=OrganizationInvoice(),
     )
     generator = AgreementJournalGenerator(
-        AuthorizationContext(id="AUTH-1", pma_account="PMA-1", currency="USD"),
+        _build_auth_context(mock_aws_client),
         mock_context,
         mock_usage_generator,
         mock_invoice_generator,
@@ -112,21 +162,14 @@ def test_run(
 def test_run_without_pls(
     mocker,
     mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
     mock_line_generator_cls,
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
-    agreement = {
-        "id": "AGR-1",
-        "externalIds": {"vendor": "MPA"},
-        "parameters": {
-            "ordering": [
-                {"externalId": "supportType", "value": "DeveloperSupport"},
-            ],
-            "fulfillment": [],
-        },
-    }
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True, return_value=[])
+    agreement = _build_agreement(support_type="DeveloperSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
@@ -144,7 +187,7 @@ def test_run_without_pls(
         invoice=OrganizationInvoice(),
     )
     generator = AgreementJournalGenerator(
-        AuthorizationContext(id="AUTH-1", pma_account="PMA-1", currency="USD"),
+        _build_auth_context(mock_aws_client),
         mock_context,
         mock_usage_generator,
         mock_invoice_generator,
@@ -156,12 +199,17 @@ def test_run_without_pls(
     mock_pls_charge_manager_cls.assert_not_called()
 
 
-def test_run_returns_empty_when_no_mpa_account(mocker, mock_context, mock_line_generator_cls):
+def test_run_returns_empty_when_no_mpa_account(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_line_generator_cls,
+):
     agreement = {"id": "AGR-1", "externalIds": {}, "parameters": {"ordering": []}}
     mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
     mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
     generator = AgreementJournalGenerator(
-        AuthorizationContext(id="AUTH-1", pma_account="PMA-1", currency="USD"),
+        _build_auth_context(mock_aws_client),
         mock_context,
         mock_usage_generator,
         mock_invoice_generator,
@@ -174,3 +222,135 @@ def test_run_returns_empty_when_no_mpa_account(mocker, mock_context, mock_line_g
     mock_usage_generator.run.assert_not_called()
     mock_invoice_generator.run.assert_not_called()
     mock_line_generator_cls.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ResponsibilityTransferStatus.REQUESTED,
+        ResponsibilityTransferStatus.DECLINED,
+        ResponsibilityTransferStatus.CANCELED,
+        ResponsibilityTransferStatus.EXPIRED,
+        ResponsibilityTransferStatus.WITHDRAWN,
+    ],
+)
+def test_run_returns_empty_when_transfer_not_accepted(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    status,
+):
+    agreement = _build_agreement()
+    mock_aws_client.get_responsibility_transfer_details.return_value = {
+        "ResponsibilityTransfer": {
+            "Status": status,
+            "StartTimestamp": dt.datetime(
+                BILLING_YEAR,
+                MONTH_BEFORE_BILLING,
+                1,
+                tzinfo=dt.UTC,
+            ),
+        },
+    }
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)
+
+    assert result.lines == []
+    assert result.report is None
+    mock_usage_generator.run.assert_not_called()
+    mock_invoice_generator.run.assert_not_called()
+
+
+def test_run_returns_empty_when_transfer_not_started_yet(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+):
+    agreement = _build_agreement()
+    mock_aws_client.get_responsibility_transfer_details.return_value = {
+        "ResponsibilityTransfer": {
+            "Status": ResponsibilityTransferStatus.ACCEPTED,
+            "StartTimestamp": dt.datetime(
+                BILLING_YEAR,
+                MONTH_AFTER_BILLING,
+                1,
+                tzinfo=dt.UTC,
+            ),
+        },
+    }
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)
+
+    assert result.lines == []
+    assert result.report is None
+    mock_usage_generator.run.assert_not_called()
+    mock_invoice_generator.run.assert_not_called()
+
+
+def test_run_processes_when_transfer_started_on_billing_start(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    mock_line_generator_cls,
+    mock_extra_discounts_manager_cls,
+    mock_pls_charge_manager_cls,
+):
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True, return_value=[])
+    agreement = _build_agreement()
+    mock_aws_client.get_responsibility_transfer_details.return_value = {
+        "ResponsibilityTransfer": {
+            "Status": ResponsibilityTransferStatus.ACCEPTED,
+            "StartTimestamp": dt.datetime(
+                BILLING_YEAR,
+                BILLING_MONTH,
+                1,
+                tzinfo=dt.UTC,
+            ),
+        },
+    }
+    mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
+    mock_generator_instance.generate.return_value = []
+    mock_line_generator_cls.return_value = mock_generator_instance
+    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
+    mock_discounts_instance.process.return_value = []
+    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
+    mock_usage_result.reports = OrganizationReport()
+    mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_generator.run.return_value = mock_usage_result
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
+        invoice=OrganizationInvoice(),
+    )
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)
+
+    mock_invoice_generator.run.assert_called_once()
+    mock_usage_generator.run.assert_called_once()
+    assert result.lines is not None

--- a/tests/flows/jobs/billing_journal/generators/test_billing_report_rows.py
+++ b/tests/flows/jobs/billing_journal/generators/test_billing_report_rows.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.constants import AWSRecordTypeEnum
 from swo_aws_extension.flows.jobs.billing_journal.generators.billing_report_rows import (
     ReportContext,
@@ -69,8 +70,13 @@ def test_generate_billing_report_rows_aggregates_metrics():
     assert result[0] == expected_row
 
 
-def test_report_context_from_contexts_builds_correctly():
-    auth_context = AuthorizationContext(id="AUTH-1", pma_account="PMA-1", currency="USD")
+def test_report_context_from_contexts_builds_correctly(mocker):
+    auth_context = AuthorizationContext(
+        id="AUTH-1",
+        pma_account="PMA-1",
+        currency="USD",
+        aws_client=mocker.MagicMock(spec=AWSClient),
+    )
     journal_details = JournalDetails(
         agreement_id="AGR-1",
         mpa_id="MPA-1",
@@ -87,9 +93,7 @@ def test_report_context_from_contexts_builds_correctly():
     assert context.currency == "USD"
 
 
-def test_generate_billing_report_rows_defaults_exchange_rate_and_warns_for_unknown_entity(
-    caplog,
-):
+def test_generate_billing_report_rows_defaults_exchange_rate_for_unknown_entity():
     metric = ServiceMetric(
         "EC2", AWSRecordTypeEnum.USAGE, Decimal(MEDIUM_AMOUNT), "UNKNOWN-ENTITY", "INV-X"
     )
@@ -100,8 +104,7 @@ def test_generate_billing_report_rows_defaults_exchange_rate_and_warns_for_unkno
     org_invoice = OrganizationInvoice(entities={})
     context = ReportContext("AUTH-1", "PMA-1", "AGR-1", "MPA-1", "USD")
 
-    result = generate_billing_report_rows(context, usage_result, org_invoice)  # act
+    result = generate_billing_report_rows(context, usage_result, org_invoice)
 
     assert len(result) == 1
     assert result[0].exchange_rate == Decimal("1.0")
-    assert "No exchange rate found for invoice entity 'UNKNOWN-ENTITY'" in caplog.text

--- a/tests/flows/jobs/billing_journal/generators/test_pls_charge_manager.py
+++ b/tests/flows/jobs/billing_journal/generators/test_pls_charge_manager.py
@@ -176,15 +176,3 @@ def test_process_returns_empty_when_invoice_amount_is_zero(journal_details, orga
     result = manager.process(Decimal("5.0"), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 0
-
-
-def test_process_returns_empty_when_invoice_amount_is_none(journal_details, organization_invoice):
-    organization_invoice.principal_invoice_amount = None
-    usage_result = build_usage_result({
-        "ACC-1": [create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00")],
-    })
-    manager = PlSChargeManager()
-
-    result = manager.process(Decimal("5.0"), usage_result, journal_details, organization_invoice)
-
-    assert len(result) == 0

--- a/tests/flows/jobs/billing_journal/models/test_invoice.py
+++ b/tests/flows/jobs/billing_journal/models/test_invoice.py
@@ -1,0 +1,102 @@
+from decimal import Decimal
+
+import pytest
+
+from swo_aws_extension.flows.jobs.billing_journal.models.invoice import (
+    InvoiceEntity,
+    OrganizationInvoice,
+)
+
+PRIMARY_ENTITY_NAME = "AWS EMEA SARL"
+PRIMARY_INVOICE_ID = "INV-001"
+SECONDARY_ENTITY_NAME = "AWS Inc."
+SECONDARY_INVOICE_ID = "INV-002"
+
+
+@pytest.fixture
+def primary_entity():
+    return InvoiceEntity(
+        invoice_id=PRIMARY_INVOICE_ID,
+        base_currency_code="USD",
+        payment_currency_code="EUR",
+        exchange_rate=Decimal("0.87"),
+        primary=True,
+    )
+
+
+@pytest.fixture
+def secondary_entity():
+    return InvoiceEntity(
+        invoice_id=SECONDARY_INVOICE_ID,
+        base_currency_code="USD",
+        payment_currency_code="USD",
+        exchange_rate=Decimal("1.0"),
+    )
+
+
+def test_primary_entity_name_returns_name_when_primary_exists(
+    primary_entity,
+    secondary_entity,
+):
+    invoice = OrganizationInvoice(
+        entities={
+            SECONDARY_ENTITY_NAME: secondary_entity,
+            PRIMARY_ENTITY_NAME: primary_entity,
+        },
+    )
+
+    result = invoice.primary_entity_name
+
+    assert result == PRIMARY_ENTITY_NAME
+
+
+def test_primary_entity_name_returns_empty_when_no_primary(secondary_entity):
+    invoice = OrganizationInvoice(
+        entities={SECONDARY_ENTITY_NAME: secondary_entity},
+    )
+
+    result = invoice.primary_entity_name
+
+    assert not result
+
+
+def test_primary_entity_name_returns_empty_when_no_entities():
+    invoice = OrganizationInvoice()
+
+    result = invoice.primary_entity_name
+
+    assert not result
+
+
+def test_primary_invoice_id_returns_id_when_primary_exists(
+    primary_entity,
+    secondary_entity,
+):
+    invoice = OrganizationInvoice(
+        entities={
+            SECONDARY_ENTITY_NAME: secondary_entity,
+            PRIMARY_ENTITY_NAME: primary_entity,
+        },
+    )
+
+    result = invoice.primary_invoice_id
+
+    assert result == PRIMARY_INVOICE_ID
+
+
+def test_primary_invoice_id_returns_default_when_no_primary(secondary_entity):
+    invoice = OrganizationInvoice(
+        entities={SECONDARY_ENTITY_NAME: secondary_entity},
+    )
+
+    result = invoice.primary_invoice_id
+
+    assert result == "invoice_id"
+
+
+def test_primary_invoice_id_returns_default_when_no_entities():
+    invoice = OrganizationInvoice()
+
+    result = invoice.primary_invoice_id
+
+    assert result == "invoice_id"

--- a/tests/flows/jobs/billing_journal/test_billing_journal_service.py
+++ b/tests/flows/jobs/billing_journal/test_billing_journal_service.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
@@ -7,7 +9,11 @@ from swo_aws_extension.flows.jobs.billing_journal.billing_journal_service import
 from swo_aws_extension.flows.jobs.billing_journal.generators.authorization import (
     AuthorizationJournalGenerator,
 )
-from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import JournalLine
+from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import (
+    ExternalIds,
+    JournalLine,
+    Price,
+)
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AuthorizationJournalResult,
     BillingReportRow,
@@ -210,6 +216,8 @@ def test_dry_run_skips_upload(
     mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
     mock_line = mocker.MagicMock(spec=JournalLine)
     mock_line.to_jsonl.return_value = '{"test": 1}\n'
+    mock_line.external_ids = ExternalIds(invoice="INV-1", reference="AGR-1", vendor="MPA-1")
+    mock_line.price = Price(pp_x1=Decimal("100.00"), unit_pp=Decimal("100.00"))
     report = OrganizationReport(organization_data={"usage": [{"key": "val"}]})
     mock_auth_gen.run.return_value = AuthorizationJournalResult(
         lines=[mock_line],
@@ -233,6 +241,8 @@ def test_dry_run_skips_upload_with_empty_reports(
     mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
     mock_line = mocker.MagicMock(spec=JournalLine)
     mock_line.to_jsonl.return_value = '{"test": 1}\n'
+    mock_line.external_ids = ExternalIds(invoice="INV-1", reference="AGR-1", vendor="MPA-1")
+    mock_line.price = Price(pp_x1=Decimal("100.00"), unit_pp=Decimal("100.00"))
     mock_auth_gen.run.return_value = AuthorizationJournalResult(
         lines=[mock_line],
         reports_by_agreement={},
@@ -255,6 +265,8 @@ def test_dry_run_skips_upload_with_empty_report_data(
     mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
     mock_line = mocker.MagicMock(spec=JournalLine)
     mock_line.to_jsonl.return_value = '{"test": 1}\n'
+    mock_line.external_ids = ExternalIds(invoice="INV-1", reference="AGR-1", vendor="MPA-1")
+    mock_line.price = Price(pp_x1=Decimal("100.00"), unit_pp=Decimal("100.00"))
     empty_report = OrganizationReport(organization_data={}, accounts_data={})
     mock_auth_gen.run.return_value = AuthorizationJournalResult(
         lines=[mock_line],

--- a/tests/flows/jobs/billing_journal/test_journal_manager.py
+++ b/tests/flows/jobs/billing_journal/test_journal_manager.py
@@ -34,17 +34,17 @@ def test_create_new_journal(manager, mock_billing_client):
     }
     mock_billing_client.journal.create.return_value = {
         "id": "JRN-NEW",
-        "name": "1 October 2025 #1",
+        "name": "1 October 2025 BT #1",
     }
 
     result = manager.create_new_journal()  # act
 
     assert result.id == "JRN-NEW"
     expected_payload = {
-        "name": "1 October 2025 #1",
+        "name": "1 October 2025 BT #1",
         "authorization": {"id": "AUTH-123"},
         "dueDate": "2025-10-01",
-        "externalIds": {"vendor": "AWS-2025-October"},
+        "externalIds": {"vendor": "AWS-2025-October-BT"},
     }
     mock_billing_client.journal.create.assert_called_once_with(expected_payload)
 
@@ -55,17 +55,17 @@ def test_create_new_journal_increments_index(manager, mock_billing_client):
     }
     mock_billing_client.journal.create.return_value = {
         "id": "JRN-NEW",
-        "name": "1 October 2025 #2",
+        "name": "1 October 2025 BT #2",
     }
 
     result = manager.create_new_journal()  # act
 
     assert result.id == "JRN-NEW"
     expected_payload = {
-        "name": "1 October 2025 #2",
+        "name": "1 October 2025 BT #2",
         "authorization": {"id": "AUTH-123"},
         "dueDate": "2025-10-01",
-        "externalIds": {"vendor": "AWS-2025-October"},
+        "externalIds": {"vendor": "AWS-2025-October-BT"},
     }
     mock_billing_client.journal.create.assert_called_once_with(expected_payload)
 


### PR DESCRIPTION
… for the entire month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20028](https://softwareone.atlassian.net/browse/MPT-20028)

## Changes

- Updated pagination constant `MAX_RESULTS_PER_PAGE` from 100 to 20 for AWS API calls
- Enhanced billing journal service to log MPA totals grouped by vendor during dry-run operations
- Added responsibility transfer validation to agreement generator:
  - Validates that responsibility transfer status is `ACCEPTED`
  - Skips billing if transfer start timestamp is after billing period start
  - Returns empty results when validation fails
- Changed PLS activation logic to use `PARTNER_LED_SUPPORT` instead of `AWS_RESOLD_SUPPORT`
- Updated authorization generator to properly instantiate separate AWS clients for management and billing roles
- Enhanced invoice processing with primary invoice detection based on SPP discount descriptions
- Added `primary_entity_name` and `primary_invoice_id` computed properties to `OrganizationInvoice` model
- Updated extra discount processor to use actual primary invoice identity instead of placeholders
- Tightened SPP credit line eligibility to only include cases where principal invoice amount equals zero
- Updated journal external IDs and names to include `-BT` marker (e.g., `AWS-2025-October-BT`, `1 October 2025 BT #1`)
- Removed warning log when exchange rate cannot be resolved for unknown invoice entities
- Added `aws_client` field to `AuthorizationContext` model
- Extended test coverage for responsibility transfer validation and new invoice model properties
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20028]: https://softwareone.atlassian.net/browse/MPT-20028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ