### PR TITLE
MPT-20195 remove MPTNotificationManager and associated notify logic

### DIFF
--- a/swo_aws_extension/flows/order_utils.py
+++ b/swo_aws_extension/flows/order_utils.py
@@ -15,7 +15,6 @@ from swo_aws_extension.constants import MptOrderStatus
 from swo_aws_extension.flows.order import InitialAWSContext
 from swo_aws_extension.flows.steps.errors import OrderStatusChangeError
 from swo_aws_extension.parameters import get_mpa_account_id, set_mpa_account_id
-from swo_aws_extension.swo.notifications.mpt import MPTNotificationManager
 
 logger = logging.getLogger(__name__)
 MPT_ORDER_STATUS_QUERYING = "Querying"
@@ -149,9 +148,9 @@ def switch_order_status_to_complete(
     logger.info("%s - Action - Set order to completed", context.order_id)
 
 
-def update_processing_template_and_notify(
-    client: MPTClient, context: InitialAWSContext, template_name: str, *, notify: bool = True
-):
+def update_processing_template(
+    client: MPTClient, context: InitialAWSContext, template_name: str
+) -> None:
     """Update the order parameters and template from a template name."""
     context.order = set_order_template(client, context, MPT_ORDER_STATUS_PROCESSING, template_name)
 
@@ -161,5 +160,3 @@ def update_processing_template_and_notify(
     }
 
     context.order = update_order(client, context.order_id, **kwargs)
-    if notify:
-        MPTNotificationManager(client).send_notification(context)

--- a/swo_aws_extension/flows/steps/setup_context.py
+++ b/swo_aws_extension/flows/steps/setup_context.py
@@ -14,7 +14,7 @@ from swo_aws_extension.constants import (
 from swo_aws_extension.flows.order import InitialAWSContext
 from swo_aws_extension.flows.order_utils import (
     strip_whitespace_from_mpa_account,
-    update_processing_template_and_notify,
+    update_processing_template,
 )
 from swo_aws_extension.flows.steps.base import BasePhaseStep
 from swo_aws_extension.flows.steps.errors import ConfigurationStepError, UnexpectedStopError
@@ -92,9 +92,7 @@ class SetupContext(BasePhaseStep):
             template_name = OrderProcessingTemplateEnum.TERMINATE
 
         if template_name and context.template["name"] != template_name:
-            # Only notify the first time the template is set
-            notify = not get_phase(context.order)
-            update_processing_template_and_notify(client, context, template_name, notify=notify)
+            update_processing_template(client, context, template_name)
 
     def _init_parameter_default_values(self, client: MPTClient, context: InitialAWSContext) -> None:
         phase = get_phase(context.order)

--- a/swo_aws_extension/swo/notifications/mpt.py
+++ b/swo_aws_extension/swo/notifications/mpt.py
@@ -2,17 +2,11 @@ import datetime as dt
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from django.conf import settings
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from markdown_it import MarkdownIt
-from mpt_extension_sdk.mpt_http.base import MPTClient
-from mpt_extension_sdk.mpt_http.mpt import get_rendered_template, notify
 
 NotifyCategories = Enum("NotifyCategories", settings.MPT_NOTIFY_CATEGORIES)
-if TYPE_CHECKING:
-    from swo_aws_extension.flows.order import InitialAWSContext
 
 logger = logging.getLogger(__name__)
 
@@ -28,79 +22,3 @@ env = Environment(
 )
 
 env.filters["dateformat"] = dateformat
-
-
-class MPTNotificationManager:
-    """Notification manager used by business logic to send notifications through MPT API."""
-
-    _notify_categories = NotifyCategories.ORDERS.value
-
-    def __init__(self, client: MPTClient) -> None:
-        self.client = client
-
-    def send_notification(self, order_context: "InitialAWSContext") -> None:
-        """Sends notification through MPT API based on order context."""
-        template_context = {
-            "order": order_context.order,
-            "activation_template": self._md2html(
-                get_rendered_template(self.client, order_context.order_id)
-            ),
-            "api_base_url": settings.MPT_API_BASE_URL,
-            "portal_base_url": settings.MPT_PORTAL_BASE_URL,
-        }
-
-        buyer_name = order_context.buyer["name"]
-        subject = f"Order status update {order_context.order_id} for {buyer_name}"
-
-        if order_context.order_status == "Querying":
-            subject = f"This order need your attention {order_context.order_id} for {buyer_name}"
-
-        self._notify(
-            order_context.agreement["client"]["id"],
-            order_context.buyer["id"],
-            subject,
-            "notification",
-            template_context,
-        )
-
-    def _notify(
-        self,
-        account_id: str,
-        buyer_id: str,
-        subject: str,
-        template_name: str,
-        context: dict,
-    ) -> None:
-        template = env.get_template(f"{template_name}.html")
-        rendered_template = template.render(context)
-
-        try:
-            notify(
-                self.client,
-                self._notify_categories,
-                account_id,
-                buyer_id,
-                subject,
-                rendered_template,
-            )
-        except Exception:
-            logger.exception(
-                "Cannot send MPT API notification: Category: '%s', Account ID: '%s',"
-                " Buyer ID: '%s', Subject: '%s', Message: '%s'",
-                self._notify_categories,
-                account_id,
-                buyer_id,
-                subject,
-                rendered_template,
-            )
-
-    def _md2html(self, template):
-        md = MarkdownIt("commonmark", {"breaks": True, "html": True})
-
-        def custom_h1_renderer(tokens, idx, options, env):  # noqa: WPS430
-            tokens[idx].attrSet("style", "line-height: 1.2em;")
-            return md.renderer.renderToken(tokens, idx, options, env)
-
-        md.renderer.rules["heading_open"] = custom_h1_renderer
-
-        return md.render(template)

--- a/tests/flows/steps/test_setup_context.py
+++ b/tests/flows/steps/test_setup_context.py
@@ -25,9 +25,7 @@ def test_setup_context_with_pma(
     mpt_client_mock = mocker.MagicMock(spec=MPTClient)
     next_step_mock = mocker.MagicMock(spec=Step)
     aws_client_mock = mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
-    mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
-    )
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.update_processing_template")
     order = order_factory()
     updated_order = order_factory(
         fulfillment_parameters=fulfillment_parameters_factory(
@@ -100,9 +98,7 @@ def test_setup_context_invalid_aws_credentials(
     one_time_notification_mock = mocker.patch(
         "swo_aws_extension.flows.steps.base.notify_one_time_error",
     )
-    mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
-    )
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.update_processing_template")
     mocker.patch(
         "swo_aws_extension.flows.steps.setup_context._paginated",
         return_value=product_parameters_factory(),
@@ -132,9 +128,7 @@ def test_setup_context_invalid_apn_credentials(
     one_time_notification_mock = mocker.patch(
         "swo_aws_extension.flows.steps.base.notify_one_time_error",
     )
-    mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
-    )
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.update_processing_template")
     mocker.patch(
         "swo_aws_extension.flows.steps.setup_context._paginated",
         return_value=product_parameters_factory(),
@@ -157,7 +151,7 @@ def test_init_template_new_account(
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
     update_template_mock = mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
+        "swo_aws_extension.flows.steps.setup_context.update_processing_template"
     )
     order = order_factory(
         order_type="Purchase",
@@ -178,7 +172,7 @@ def test_init_template_new_account(
     step(mpt_client_mock, context, next_step_mock)  # act
 
     update_template_mock.assert_called_once_with(
-        mpt_client_mock, context, OrderProcessingTemplateEnum.NEW_ACCOUNT, notify=False
+        mpt_client_mock, context, OrderProcessingTemplateEnum.NEW_ACCOUNT
     )
 
 
@@ -189,7 +183,7 @@ def test_init_template_existing_account(
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
     update_template_mock = mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
+        "swo_aws_extension.flows.steps.setup_context.update_processing_template"
     )
     order = order_factory(
         order_type="Purchase",
@@ -210,7 +204,7 @@ def test_init_template_existing_account(
     step(mpt_client_mock, context, next_step_mock)  # act
 
     update_template_mock.assert_called_once_with(
-        mpt_client_mock, context, OrderProcessingTemplateEnum.EXISTING_ACCOUNT, notify=False
+        mpt_client_mock, context, OrderProcessingTemplateEnum.EXISTING_ACCOUNT
     )
 
 
@@ -219,7 +213,7 @@ def test_init_template_terminate(mocker, config, order_factory, fulfillment_para
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
     update_template_mock = mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
+        "swo_aws_extension.flows.steps.setup_context.update_processing_template"
     )
     order = order_factory(
         order_type="Termination",
@@ -237,7 +231,7 @@ def test_init_template_terminate(mocker, config, order_factory, fulfillment_para
     step(mpt_client_mock, context, next_step_mock)  # act
 
     update_template_mock.assert_called_once_with(
-        mpt_client_mock, context, OrderProcessingTemplateEnum.TERMINATE, notify=False
+        mpt_client_mock, context, OrderProcessingTemplateEnum.TERMINATE
     )
 
 
@@ -253,7 +247,7 @@ def test_init_template_notify_when_no_phase(
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
     update_template_mock = mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
+        "swo_aws_extension.flows.steps.setup_context.update_processing_template"
     )
     order = order_factory(
         order_type="Purchase",
@@ -278,7 +272,7 @@ def test_init_template_notify_when_no_phase(
     step(mpt_client_mock, context, next_step_mock)  # act
 
     update_template_mock.assert_called_once_with(
-        mpt_client_mock, context, OrderProcessingTemplateEnum.NEW_ACCOUNT, notify=True
+        mpt_client_mock, context, OrderProcessingTemplateEnum.NEW_ACCOUNT
     )
 
 
@@ -294,7 +288,7 @@ def test_init_template_skipped_when_same(
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
     update_template_mock = mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
+        "swo_aws_extension.flows.steps.setup_context.update_processing_template"
     )
     template = template_factory(name=OrderProcessingTemplateEnum.EXISTING_ACCOUNT.value)
     order = order_factory(
@@ -325,9 +319,7 @@ def test_init_parameter_default_values_sets_fulfillment_defaults(
     mpt_client_mock = mocker.MagicMock(spec=MPTClient)
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
-    mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
-    )
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.update_processing_template")
     mocked_paginated = mocker.patch(
         "swo_aws_extension.flows.steps.setup_context._paginated",
         return_value=product_parameters_factory(),
@@ -394,9 +386,7 @@ def test_init_parameter_default_values_skipped_when_phase_is_informed(
     mpt_client_mock = mocker.MagicMock(spec=MPTClient)
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
-    mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
-    )
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.update_processing_template")
     mocked_paginated = mocker.patch(
         "swo_aws_extension.flows.steps.setup_context._paginated",
         return_value=product_parameters_factory(),
@@ -447,9 +437,7 @@ def test_strip_whitespace_from_mpa_account(
     mpt_client_mock = mocker.MagicMock(spec=MPTClient)
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
-    mocker.patch(
-        "swo_aws_extension.flows.steps.setup_context.update_processing_template_and_notify"
-    )
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.update_processing_template")
     mocker.patch(
         "swo_aws_extension.flows.steps.setup_context._paginated",
         return_value=product_parameters_factory(),

--- a/tests/flows/test_order_utils.py
+++ b/tests/flows/test_order_utils.py
@@ -10,7 +10,7 @@ from swo_aws_extension.flows.order_utils import (
     switch_order_status_to_failed,
     switch_order_status_to_process,
     switch_order_status_to_query,
-    update_processing_template_and_notify,
+    update_processing_template,
 )
 from swo_aws_extension.parameters import get_mpa_account_id
 
@@ -161,13 +161,8 @@ def test_switch_order_to_process_and_notify_error(
         "swo_aws_extension.flows.order_utils.process_order",
         side_effect=MPTError("error"),
     )
-    notification_mock = mocker.patch(
-        "swo_aws_extension.flows.order_utils.MPTNotificationManager",
-    )
 
     switch_order_status_to_process(mpt_client, context, "TemplateName")  # act
-
-    notification_mock.assert_not_called()
 
 
 def test_switch_order_status_to_complete(
@@ -197,7 +192,7 @@ def test_switch_order_status_to_complete(
     )
 
 
-def test_update_processing_template_and_notify(
+def test_update_processing_template(
     mocker, order_factory, fulfillment_parameters_factory, template_factory
 ):
     client = mocker.MagicMock(spec=MPTClient)
@@ -215,11 +210,8 @@ def test_update_processing_template_and_notify(
         "swo_aws_extension.flows.order_utils.update_order",
         return_value=order,
     )
-    notification_mock = mocker.patch(
-        "swo_aws_extension.flows.order_utils.MPTNotificationManager",
-    )
 
-    update_processing_template_and_notify(client, context, "TemplateName")  # act
+    update_processing_template(client, context, "TemplateName")  # act
 
     update_order_mock.assert_called_once_with(
         client,
@@ -227,7 +219,6 @@ def test_update_processing_template_and_notify(
         parameters=context.order["parameters"],
         template=new_template,
     )
-    notification_mock.assert_called_once()
 
 
 def test_update_processing_template_no_notify(
@@ -248,11 +239,8 @@ def test_update_processing_template_no_notify(
         "swo_aws_extension.flows.order_utils.update_order",
         return_value=order,
     )
-    notification_mock = mocker.patch(
-        "swo_aws_extension.flows.order_utils.MPTNotificationManager",
-    )
 
-    update_processing_template_and_notify(client, context, "TemplateName", notify=False)  # act
+    update_processing_template(client, context, "TemplateName")  # act
 
     update_order_mock.assert_called_once_with(
         client,
@@ -260,7 +248,6 @@ def test_update_processing_template_no_notify(
         parameters=context.order["parameters"],
         template=new_template,
     )
-    notification_mock.assert_not_called()
 
 
 def test_strip_whitespace_from_mpa_account(order_factory, order_parameters_factory):

--- a/tests/swo/notifications/test_mpt.py
+++ b/tests/swo/notifications/test_mpt.py
@@ -1,12 +1,4 @@
-from http import HTTPStatus
-
-from mpt_extension_sdk.mpt_http.wrap_http_error import MPTHttpError
-
-from swo_aws_extension.flows.order import (
-    InitialAWSContext,
-)
-from swo_aws_extension.flows.order_utils import MPT_ORDER_STATUS_QUERYING
-from swo_aws_extension.swo.notifications.mpt import MPTNotificationManager, dateformat
+from swo_aws_extension.swo.notifications.mpt import dateformat
 
 
 def test_dateformat():
@@ -15,51 +7,3 @@ def test_dateformat():
     assert result == "16 May 2024"
     assert not dateformat("")
     assert not dateformat(None)
-
-
-def test_send_mpt_notification(mocker, mpt_client, order_factory, order_parameters_factory, buyer):
-    mock_mpt_notify = mocker.patch(
-        "swo_aws_extension.swo.notifications.mpt.notify", return_value=True
-    )
-    mock_get_rendered_template = mocker.patch(
-        "swo_aws_extension.swo.notifications.mpt.get_rendered_template",
-        return_value="rendered-template",
-    )
-    context = InitialAWSContext.from_order_data(
-        order_factory(
-            order_parameters=order_parameters_factory(),
-            buyer=buyer,
-            status=MPT_ORDER_STATUS_QUERYING,
-        )
-    )
-    mpt_manager = MPTNotificationManager(mpt_client)
-
-    mpt_manager.send_notification(context)  # act
-
-    mock_mpt_notify.assert_called_once()
-    mock_get_rendered_template.assert_called_once()
-
-
-def test_send_mpt_notification_error(
-    mocker, mpt_client, order_factory, order_parameters_factory, buyer
-):
-    mock_mpt_notify = mocker.patch(
-        "swo_aws_extension.swo.notifications.mpt.notify",
-        side_effect=MPTHttpError(HTTPStatus.BAD_REQUEST, "Error"),
-    )
-    mocker.patch(
-        "swo_aws_extension.swo.notifications.mpt.get_rendered_template",
-        return_value="rendered-template",
-    )
-    context = InitialAWSContext.from_order_data(
-        order_factory(
-            order_parameters=order_parameters_factory(),
-            buyer=buyer,
-            status=MPT_ORDER_STATUS_QUERYING,
-        )
-    )
-    mpt_manager = MPTNotificationManager(mpt_client)
-
-    mpt_manager.send_notification(context)  # act
-
-    mock_mpt_notify.assert_called_once()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20195](https://softwareone.atlassian.net/browse/MPT-20195)

- Remove MPTNotificationManager and all notification-related helpers, imports, and tests from swo_aws_extension.swo.notifications.mpt
- Remove notification flow from order utilities: replace update_processing_template_and_notify(...) with update_processing_template(client, context, template_name) (notify parameter removed)
- Update SetupContext._init_processing_template to call update_processing_template without a notify flag
- Update tests to mock/assert update_processing_template and remove tests and assertions that exercised MPTNotificationManager or notification sending
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20195]: https://softwareone.atlassian.net/browse/MPT-20195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ