### PR TITLE
MPT-20051 Get usage report with daily granurality

### DIFF
--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -10,6 +10,7 @@ from swo_aws_extension.aws.errors import (
     wrap_boto3_error,
 )
 from swo_aws_extension.config import Config
+from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
 from swo_aws_extension.swo.openid.client import OpenIDClient
 
 MINIMUM_DAYS_MONTH = 28
@@ -126,16 +127,16 @@ class AWSClient:
     @wrap_boto3_error
     def get_cost_and_usage(
         self,
-        start_date: str,
-        end_date: str,
+        billing_period: BillingPeriod,
         group_by: list[dict] | None = None,
         filter_by: dict | None = None,
         view_arn: str | None = None,
+        granularity: str = "MONTHLY",
     ) -> list[dict]:
         """Get cost and usage data for the specified date range."""
         kwarg: dict = {
-            "TimePeriod": {"Start": start_date, "End": end_date},
-            "Granularity": "MONTHLY",
+            "TimePeriod": {"Start": billing_period.start_date, "End": billing_period.end_date},
+            "Granularity": granularity,
             "Metrics": ["UnblendedCost"],
         }
         if group_by:

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
@@ -2,9 +2,14 @@ from mpt_extension_sdk.mpt_http.mpt import get_agreements_by_query
 from mpt_extension_sdk.runtime.tracer import dynamic_trace_span
 
 from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.aws.errors import AWSError
 from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE, AgreementStatusEnum
 from swo_aws_extension.flows.jobs.billing_journal.generators.agreement import (
     AgreementJournalGenerator,
+)
+from swo_aws_extension.flows.jobs.billing_journal.generators.billing_report_rows import (
+    ReportContext,
+    generate_billing_report_rows,
 )
 from swo_aws_extension.flows.jobs.billing_journal.generators.invoice import InvoiceGenerator
 from swo_aws_extension.flows.jobs.billing_journal.generators.usage import CostExplorerUsageGenerator
@@ -12,9 +17,11 @@ from swo_aws_extension.flows.jobs.billing_journal.models.context import (
     AuthorizationContext,
     BillingJournalContext,
 )
+from swo_aws_extension.flows.jobs.billing_journal.models.invoice import OrganizationInvoice
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AuthorizationJournalResult,
 )
+from swo_aws_extension.flows.jobs.billing_journal.models.usage import OrganizationUsageResult
 from swo_aws_extension.logger import get_logger
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
 from swo_aws_extension.utils.decorators import with_log_context
@@ -93,28 +100,91 @@ class AuthorizationJournalGenerator:
             invoice_generator,
         )
         for agreement in agreements:
-            agreement_id = agreement.get("id")
-            try:
-                agreement_result = generator.run(agreement)
-            # TODO: Catch specific exceptions and handle them accordingly
-            except Exception as exc:
-                logger.exception(
-                    "%s - Failed to synchronize agreement",
-                    agreement_id,
-                )
-                self._notifier.send_error(
-                    BILLING_JOURNAL_ERROR_TITLE,
-                    f"Failed to generate billing journal for {agreement_id}: {exc}",
-                )
-                continue
+            self._process_single_agreement(generator, agreement, result)
 
-            result.lines.extend(agreement_result.lines)
-            if agreement_result.report:
-                result.reports_by_agreement[agreement_id] = agreement_result.report
-            if agreement_result.billing_report_rows:
-                result.billing_report_rows.extend(agreement_result.billing_report_rows)
+        self._apply_pma_usage_to_report(
+            auth_context,
+            cost_explorer_usage_generator,
+            invoice_generator,
+            result,
+        )
 
         return result
+
+    def _process_single_agreement(
+        self,
+        generator: AgreementJournalGenerator,
+        agreement: dict,
+        result: AuthorizationJournalResult,
+    ) -> None:
+        agreement_id = agreement.get("id")
+        try:
+            agreement_result = generator.run(agreement)
+        except Exception as exc:
+            logger.exception("%s - Failed to synchronize agreement", agreement_id)
+            self._notifier.send_error(
+                BILLING_JOURNAL_ERROR_TITLE,
+                f"Failed to generate billing journal for {agreement_id}: {exc}",
+            )
+            return
+
+        result.lines.extend(agreement_result.lines)
+        if agreement_result.report:
+            result.reports_by_agreement[agreement_id] = agreement_result.report
+        if agreement_result.billing_report_rows:
+            result.billing_report_rows.extend(agreement_result.billing_report_rows)
+
+    def _apply_pma_usage_to_report(
+        self,
+        auth_context: AuthorizationContext,
+        cost_explorer_usage_generator: CostExplorerUsageGenerator,
+        invoice_generator: InvoiceGenerator,
+        result: AuthorizationJournalResult,
+    ) -> None:
+        try:
+            pma_invoice, pma_usage = self._fetch_raw_pma_usage(
+                auth_context, cost_explorer_usage_generator, invoice_generator
+            )
+        except AWSError:
+            logger.exception(
+                "Failed to generate billing report rows for PMA account %s",
+                auth_context.pma_account,
+            )
+            return
+
+        pma_report_context = ReportContext(
+            authorization_id=auth_context.id,
+            pma=auth_context.pma_account,
+            agreement_id="N/A",
+            mpa=auth_context.pma_account,
+            currency=auth_context.currency,
+        )
+        pma_report_rows = generate_billing_report_rows(
+            context=pma_report_context,
+            usage_result=pma_usage,
+            organization_invoice=pma_invoice,
+        )
+        result.billing_report_rows.extend(pma_report_rows)
+
+    def _fetch_raw_pma_usage(
+        self,
+        auth_context: AuthorizationContext,
+        cost_explorer_usage_generator: CostExplorerUsageGenerator,
+        invoice_generator: InvoiceGenerator,
+    ) -> tuple[OrganizationInvoice, OrganizationUsageResult]:
+        logger.info("Generating raw usage for PMA account to include in billing report")
+        pma_invoice_result = invoice_generator.run(
+            auth_context.pma_account,
+            self._billing_period,
+            auth_context.currency,
+        )
+        pma_usage_result = cost_explorer_usage_generator.run_for_pma(
+            auth_context.pma_account,
+            self._billing_period,
+            organization_invoice=pma_invoice_result.invoice,
+            granularity="MONTHLY",
+        )
+        return pma_invoice_result.invoice, pma_usage_result
 
     def _get_authorization_agreements(self, authorization: dict) -> list[dict]:
         select = "&select=subscriptions,subscriptions.lines,parameters"

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/discount/extra_discounts.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/discount/extra_discounts.py
@@ -80,6 +80,8 @@ class BaseExtraDiscountProcessor(ABC):
             account_id=journal_details.mpa_id,
             invoice_entity=organization_invoice.primary_entity_name,
             invoice_id=organization_invoice.primary_invoice_id,
+            start_date=journal_details.start_date,
+            end_date=journal_details.end_date,
         )
         return [JournalLine.build(ITEM_SKU, journal_details, invoice_details)]
 

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/base.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/base.py
@@ -56,5 +56,7 @@ class JournalLineProcessor:
             account_id=context.account_id,
             invoice_entity=metric.invoice_entity or "",
             invoice_id=metric.invoice_id or "invoice_id",
+            start_date=metric.start_date,
+            end_date=metric.end_date,
         )
         return JournalLine.build(ITEM_SKU, context.journal_details, invoice_details)

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/pls_charge_manager.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/pls_charge_manager.py
@@ -69,6 +69,8 @@ class PlSChargeManager:
             account_id=journal_details.mpa_id,
             invoice_entity=organization_invoice.primary_entity_name,
             invoice_id=organization_invoice.primary_invoice_id,
+            start_date=journal_details.start_date,
+            end_date=journal_details.end_date,
         )
         return [JournalLine.build(ITEM_SKU, journal_details, invoice_details)]
 

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/report_processor.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/report_processor.py
@@ -1,6 +1,13 @@
 from decimal import Decimal
 
 from swo_aws_extension.constants import DEC_ZERO
+from swo_aws_extension.flows.jobs.billing_journal.models.usage import ExtractedMetric
+
+
+def _get_time_period(result_by_time: dict) -> tuple[str, str]:
+    """Extract start and end date from a time period."""
+    time_period = result_by_time.get("TimePeriod", {})
+    return time_period.get("Start", ""), time_period.get("End", "")
 
 
 class ReportProcessor:
@@ -16,30 +23,25 @@ class ReportProcessor:
                     result[keys[0]] = keys[1]
         return result
 
-    def extract_metrics(self, report: list[dict], key: str) -> dict[str, Decimal]:
+    def extract_metrics(self, report: list[dict], key: str) -> list[ExtractedMetric]:
         """Extract metrics filtered by key from report."""
-        result: dict[str, Decimal] = {}
+        result: list[ExtractedMetric] = []
         for result_by_time in report:
+            start_date, end_date = _get_time_period(result_by_time)
             for group in result_by_time.get("Groups", []):
-                keys = group.get("Keys", [])
-                if key not in keys:
-                    continue
-                amount = self.parse_amount(
-                    group.get("Metrics", {}).get("UnblendedCost", {}).get("Amount", "0")
-                )
-                if amount != Decimal(0):
-                    result[keys[1]] = amount
+                self._conditional_append_metric(group, key, start_date, end_date, result)
         return result
 
     def extract_all_metrics_by_record_type(
         self, record_type_report: list[dict]
-    ) -> dict[str, dict[str, Decimal]]:
+    ) -> list[ExtractedMetric]:
         """Extract all metrics from report, organizing by record type dynamically."""
-        result: dict[str, dict[str, Decimal]] = {}
+        result: list[ExtractedMetric] = []
 
         for result_by_time in record_type_report:
+            start_date, end_date = _get_time_period(result_by_time)
             for group in result_by_time.get("Groups", []):
-                self._process_metric_group(group, result)
+                self._process_metric_group(group, result, start_date, end_date)
 
         return result
 
@@ -64,12 +66,47 @@ class ReportProcessor:
         """Convert a string amount to Decimal, handling comma and dot separators."""
         return Decimal(amount.replace(",", ".") if "," in amount else amount)
 
+    def _conditional_append_metric(
+        self,
+        group: dict,
+        key: str,
+        start_date: str,
+        end_date: str,
+        result: list[ExtractedMetric],
+    ) -> None:
+        keys = group.get("Keys", [])
+        if key not in keys:
+            return
+
+        amount = self.parse_amount(
+            group.get("Metrics", {}).get("UnblendedCost", {}).get("Amount", "0")
+        )
+        if amount != Decimal(0):
+            result.append(
+                ExtractedMetric(
+                    service_name=keys[1],
+                    amount=amount,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+            )
+
     def _process_metric_group(
         self,
         group: dict,
-        result: dict[str, dict[str, Decimal]],
+        result: list[ExtractedMetric],
+        start_date: str,
+        end_date: str,
     ) -> None:
         parsed = self.parse_group_metrics(group)
         if parsed:
             record_type, service_name, amount = parsed
-            result.setdefault(record_type, {})[service_name] = amount
+            result.append(
+                ExtractedMetric(
+                    service_name=service_name,
+                    amount=amount,
+                    start_date=start_date,
+                    end_date=end_date,
+                    record_type=record_type,
+                )
+            )

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from decimal import Decimal
 
 from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.aws.errors import AWSError
@@ -11,6 +10,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import B
 from swo_aws_extension.flows.jobs.billing_journal.models.invoice import OrganizationInvoice
 from swo_aws_extension.flows.jobs.billing_journal.models.usage import (
     AccountUsage,
+    ExtractedMetric,
     OrganizationReport,
     OrganizationUsageResult,
     ServiceMetric,
@@ -33,15 +33,14 @@ class CostExplorerReportFetcher:
     ) -> list[str]:
         """Get list of accounts with usage for a billing view."""
         cost_and_usage = self._aws_client.get_cost_and_usage(
-            start_date=billing_period.start_date,
-            end_date=billing_period.end_date,
+            billing_period=billing_period,
             view_arn=billing_view_arn,
             group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
         )
         return self._extract_account_keys(cost_and_usage)
 
     def get_marketplace_usage_report(
-        self, billing_view_arn: str, billing_period: BillingPeriod
+        self, billing_view_arn: str, billing_period: BillingPeriod, granularity: str = "DAILY"
     ) -> list[dict]:
         """Get marketplace usage report."""
         group_by = [
@@ -50,11 +49,11 @@ class CostExplorerReportFetcher:
         ]
         filter_by = {"Dimensions": {"Key": "BILLING_ENTITY", "Values": [AWS_MARKETPLACE]}}
         return self._aws_client.get_cost_and_usage(
-            billing_period.start_date,
-            billing_period.end_date,
+            billing_period,
             group_by,
             filter_by,
             view_arn=billing_view_arn,
+            granularity=granularity,
         )
 
     def get_record_type_and_service_cost_report(
@@ -62,6 +61,7 @@ class CostExplorerReportFetcher:
         account_id: str,
         billing_view_arn: str,
         billing_period: BillingPeriod,
+        granularity: str = "DAILY",
     ) -> list[dict]:
         """Get record type and service cost report for an account."""
         group_by = [
@@ -70,11 +70,11 @@ class CostExplorerReportFetcher:
         ]
         filter_by = {"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": [account_id]}}
         return self._aws_client.get_cost_and_usage(
-            billing_period.start_date,
-            billing_period.end_date,
+            billing_period,
             group_by,
             filter_by,
             view_arn=billing_view_arn,
+            granularity=granularity,
         )
 
     def get_service_invoice_entity_report(
@@ -82,6 +82,7 @@ class CostExplorerReportFetcher:
         account_id: str,
         billing_view_arn: str,
         billing_period: BillingPeriod,
+        granularity: str = "DAILY",
     ) -> list[dict]:
         """Get service invoice entity report for an account."""
         group_by = [
@@ -90,11 +91,11 @@ class CostExplorerReportFetcher:
         ]
         filter_by = {"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": [account_id]}}
         return self._aws_client.get_cost_and_usage(
-            billing_period.start_date,
-            billing_period.end_date,
+            billing_period,
             group_by,
             filter_by,
             view_arn=billing_view_arn,
+            granularity=granularity,
         )
 
     def _extract_account_keys(self, cost_and_usage: list[dict]) -> list[str]:
@@ -120,8 +121,19 @@ class BaseOrganizationUsageGenerator(ABC):
         mpa_account: str,
         billing_period: BillingPeriod,
         organization_invoice: OrganizationInvoice,
+        granularity: str = "DAILY",
     ) -> OrganizationUsageResult:
         """Extract RAW information and process it into AccountUsage."""
+
+    @abstractmethod
+    def run_for_pma(
+        self,
+        pma_account: str,
+        billing_period: BillingPeriod,
+        organization_invoice: OrganizationInvoice,
+        granularity: str = "DAILY",
+    ) -> OrganizationUsageResult:
+        """Extract RAW information and process it for the PMA account."""
 
 
 class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
@@ -129,6 +141,7 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
 
     def __init__(self, aws_client):
         super().__init__(aws_client)
+        self._organization_invoice: OrganizationInvoice | None = None
         self._report_fetcher = None
         self._processor = ReportProcessor()
 
@@ -138,6 +151,7 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
         mpa_account: str,
         billing_period: BillingPeriod,
         organization_invoice: OrganizationInvoice,
+        granularity: str = "DAILY",
     ) -> OrganizationUsageResult:
         """Extract usage from Cost Explorer and process it."""
         self._usage_by_account = {}
@@ -155,7 +169,35 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
         logger.info("Found %d billing views", len(billing_views))
 
         for billing_view in billing_views:
-            self._process_billing_view(billing_view, billing_period)
+            self._process_billing_view(billing_view, billing_period, granularity)
+
+        return OrganizationUsageResult(
+            reports=self._reports, usage_by_account=self._usage_by_account
+        )
+
+    def run_for_pma(
+        self,
+        pma_account: str,
+        billing_period: BillingPeriod,
+        organization_invoice: OrganizationInvoice,
+        granularity: str = "DAILY",
+    ) -> OrganizationUsageResult:
+        """Extract usage from Cost Explorer for the PMA account and process it."""
+        self._usage_by_account = {}
+        self._reports = OrganizationReport()
+        self._organization_invoice = organization_invoice
+
+        logger.info("Generating usage report for PMA account %s", pma_account)
+        self._report_fetcher = CostExplorerReportFetcher(self._aws_client)
+
+        marketplace_report = self._report_fetcher.get_marketplace_usage_report(
+            "", billing_period, granularity
+        )
+        self._reports.organization_data["MARKETPLACE"] = marketplace_report
+
+        self._process_accounts_for_billing_view(
+            [pma_account], {"arn": None}, billing_period, marketplace_report, granularity
+        )
 
         return OrganizationUsageResult(
             reports=self._reports, usage_by_account=self._usage_by_account
@@ -165,6 +207,7 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
         self,
         billing_view: dict,
         billing_period: BillingPeriod,
+        granularity: str,
     ) -> None:
         try:
             accounts = self._report_fetcher.get_accounts_with_usage(
@@ -183,12 +226,12 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
             billing_view.get("arn"),
         )
         marketplace_report = self._report_fetcher.get_marketplace_usage_report(
-            billing_view.get("arn"), billing_period
+            billing_view.get("arn"), billing_period, granularity
         )
         self._reports.organization_data["MARKETPLACE"] = marketplace_report
 
         self._process_accounts_for_billing_view(
-            accounts, billing_view, billing_period, marketplace_report
+            accounts, billing_view, billing_period, marketplace_report, granularity
         )
 
     def _process_accounts_for_billing_view(
@@ -197,6 +240,7 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
         billing_view: dict,
         billing_period: BillingPeriod,
         marketplace_report: list[dict],
+        granularity: str,
     ) -> None:
         for account_id in accounts:
             logger.info("Getting usage for account: %s", account_id)
@@ -204,14 +248,14 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
                 self._reports.accounts_data[account_id] = {}
 
             service_invoice_entity = self._report_fetcher.get_service_invoice_entity_report(
-                account_id, billing_view.get("arn"), billing_period
+                account_id, billing_view.get("arn"), billing_period, granularity
             )
             self._reports.accounts_data[account_id]["SERVICE_INVOICE_ENTITY"] = (
                 service_invoice_entity
             )
 
             record_type_report = self._report_fetcher.get_record_type_and_service_cost_report(
-                account_id, billing_view.get("arn"), billing_period
+                account_id, billing_view.get("arn"), billing_period, granularity
             )
             self._reports.accounts_data[account_id]["RECORD_TYPE_AND_SERVICE_COST"] = (
                 record_type_report
@@ -231,48 +275,37 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
         entities: dict[str, str],
     ) -> AccountUsage:
         account_usage = AccountUsage()
-        for service_name, amount in self._processor.extract_metrics(
+        for metric_data in self._processor.extract_metrics(
             marketplace_report,
             account_id,
-        ).items():
+        ):
             account_usage.add_metric(
-                self._create_metric(
-                    service_name,
-                    "MARKETPLACE",
-                    amount,
-                    entities,
-                ),
+                self._create_metric(metric_data, "MARKETPLACE", entities),
             )
-
-        for record_type, metrics in self._processor.extract_all_metrics_by_record_type(
+        for rt_data in self._processor.extract_all_metrics_by_record_type(
             record_type_report,
-        ).items():
-            for service_name, amount in metrics.items():
-                account_usage.add_metric(
-                    self._create_metric(
-                        service_name,
-                        record_type,
-                        amount,
-                        entities,
-                    ),
-                )
+        ):
+            account_usage.add_metric(
+                self._create_metric(rt_data, rt_data.record_type, entities),
+            )
 
         return account_usage
 
     def _create_metric(
         self,
-        service_name: str,
+        metric_data: ExtractedMetric,
         record_type: str,
-        amount: Decimal,
         entities: dict[str, str],
     ) -> ServiceMetric:
 
-        entity_name = entities.get(service_name)
+        entity_name = entities.get(metric_data.service_name)
         invoice_entity = self._organization_invoice.entities.get(entity_name, None)
         return ServiceMetric(
-            service_name=service_name,
+            service_name=metric_data.service_name,
             record_type=record_type,
-            amount=amount,
+            amount=metric_data.amount,
             invoice_entity=entity_name,
             invoice_id=invoice_entity.invoice_id if invoice_entity else "",
+            start_date=metric_data.start_date,
+            end_date=metric_data.end_date,
         )

--- a/swo_aws_extension/flows/jobs/billing_journal/models/journal_line.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/journal_line.py
@@ -64,6 +64,8 @@ class InvoiceDetails:
     amount: Decimal
     account_id: str
     invoice_entity: str
+    start_date: str
+    end_date: str
     invoice_id: str = ""
     error: str | None = None
 
@@ -139,8 +141,8 @@ class JournalLine:
                 vendor=journal_details.mpa_id,
             ),
             period=Period(
-                start=journal_details.start_date,
-                end=journal_details.end_date,
+                start=invoice_details.start_date,
+                end=invoice_details.end_date,
             ),
             price=Price(
                 pp_x1=invoice_details.amount,

--- a/swo_aws_extension/flows/jobs/billing_journal/models/usage.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/usage.py
@@ -5,6 +5,17 @@ type AccountDataAlias = dict[str, list[dict]]
 
 
 @dataclass
+class ExtractedMetric:
+    """A single dynamically extracted metric from Cost Explorer raw output."""
+
+    service_name: str
+    amount: Decimal
+    start_date: str
+    end_date: str
+    record_type: str | None = None
+
+
+@dataclass
 class ServiceMetric:
     """A single cost metric for a service (e.g., usage, support, refund, etc.)."""
 
@@ -13,6 +24,8 @@ class ServiceMetric:
     amount: Decimal = field(default_factory=lambda: Decimal(0))
     invoice_entity: str | None = None
     invoice_id: str | None = None
+    start_date: str | None = None
+    end_date: str | None = None
 
 
 @dataclass

--- a/swo_aws_extension/flows/jobs/finops_entitlements_processor.py
+++ b/swo_aws_extension/flows/jobs/finops_entitlements_processor.py
@@ -10,6 +10,7 @@ from swo_aws_extension.aws.client import MINIMUM_DAYS_MONTH, AWSClient
 from swo_aws_extension.aws.errors import AWSError
 from swo_aws_extension.config import Config
 from swo_aws_extension.constants import FinOpsStatusEnum
+from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
 from swo_aws_extension.swo.finops.client import get_ffc_client
 from swo_aws_extension.swo.finops.errors import FinOpsError
 from swo_aws_extension.swo.notifications.teams import TeamsNotificationManager
@@ -166,15 +167,12 @@ class FinOpsEntitlementsProcessor:  # noqa: WPS214
     def _get_accounts_with_usage(
         self, agreement_id: str, billing_views: list[dict], aws_client: AWSClient
     ) -> list[str]:
-        today = dt.datetime.now(dt.UTC).date()
-        next_month = today.replace(day=MINIMUM_DAYS_MONTH) + dt.timedelta(days=4)
         accounts_with_usage = []
-
+        billing_period = self._get_billing_period()
         for billing_view in billing_views:
             try:
                 cost_and_usage = aws_client.get_cost_and_usage(
-                    start_date=today.replace(day=1).isoformat(),
-                    end_date=next_month.replace(day=1).isoformat(),
+                    billing_period=billing_period,
                     view_arn=billing_view.get("arn"),
                     group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
                 )
@@ -265,4 +263,11 @@ class FinOpsEntitlementsProcessor:  # noqa: WPS214
         existing.entitlement_id = entitlement.get("id") if entitlement else existing.entitlement_id
         self.entitlements_table.update_status_and_usage_date(
             existing, FinOpsStatusEnum.ACTIVE, dt.datetime.now(dt.UTC).isoformat()
+        )
+
+    def _get_billing_period(self) -> BillingPeriod:
+        today = dt.datetime.now(dt.UTC).date()
+        next_month = today.replace(day=MINIMUM_DAYS_MONTH) + dt.timedelta(days=4)
+        return BillingPeriod(
+            today.replace(day=1).isoformat(), next_month.replace(day=1).isoformat()
         )

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -8,6 +8,7 @@ from swo_aws_extension.aws.errors import (
     AWSError,
     InvalidDateInTerminateResponsibilityError,
 )
+from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
 
 
 # InvalidInputException is the name given by AWS boto3 to the error we are testing:
@@ -309,8 +310,7 @@ def test_get_cost_and_usage_success(config, aws_client_factory, mock_get_paged_r
     ]
 
     result = mock_aws_client.get_cost_and_usage(
-        start_date="2025-12-01",
-        end_date="2025-12-31",
+        billing_period=BillingPeriod(start_date="2025-12-01", end_date="2025-12-31"),
     )
 
     assert result == [
@@ -325,8 +325,7 @@ def test_get_cost_and_usage_with_group(config, aws_client_factory, mock_get_page
     ]
 
     result = mock_aws_client.get_cost_and_usage(
-        start_date="2025-12-01",
-        end_date="2025-12-31",
+        billing_period=BillingPeriod(start_date="2025-12-01", end_date="2025-12-31"),
         group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
     )
 
@@ -340,8 +339,7 @@ def test_get_cost_and_usage_with_filter(config, aws_client_factory, mock_get_pag
     mock_get_paged_response.return_value = []
 
     result = mock_aws_client.get_cost_and_usage(
-        start_date="2025-12-01",
-        end_date="2025-12-31",
+        billing_period=BillingPeriod(start_date="2025-12-01", end_date="2025-12-31"),
         filter_by={"Dimensions": {"Key": "SERVICE", "Values": ["Amazon EC2"]}},
     )
 
@@ -355,8 +353,7 @@ def test_get_cost_and_usage_with_arn(config, aws_client_factory, mock_get_paged_
     ]
 
     result = mock_aws_client.get_cost_and_usage(
-        start_date="2025-12-01",
-        end_date="2025-12-31",
+        billing_period=BillingPeriod(start_date="2025-12-01", end_date="2025-12-31"),
         view_arn="arn:aws:billing::123456789:billingview/test",
     )
 
@@ -370,8 +367,7 @@ def test_get_cost_and_usage_empty(config, aws_client_factory, mock_get_paged_res
     mock_get_paged_response.return_value = []
 
     result = mock_aws_client.get_cost_and_usage(
-        start_date="2025-12-01",
-        end_date="2025-12-31",
+        billing_period=BillingPeriod(start_date="2025-12-01", end_date="2025-12-31"),
     )
 
     assert result == []

--- a/tests/flows/jobs/billing_journal/generators/discount_processors/test_extra_discounts.py
+++ b/tests/flows/jobs/billing_journal/generators/discount_processors/test_extra_discounts.py
@@ -33,6 +33,8 @@ def create_metric(service_name, record_type, amount, invoice_entity="Entity1"):
         amount=Decimal(amount),
         invoice_entity=invoice_entity,
         invoice_id="INV-123",
+        start_date="2025-10-01",
+        end_date="2025-10-31",
     )
 
 

--- a/tests/flows/jobs/billing_journal/generators/test_agreement.py
+++ b/tests/flows/jobs/billing_journal/generators/test_agreement.py
@@ -64,7 +64,6 @@ def mock_aws_client(mocker, accepted_transfer_response):
 def mock_get_responsibility_transfer_id(mocker):
     return mocker.patch(
         f"{MODULE}.get_responsibility_transfer_id",
-        autospec=True,
         return_value="RT-123",
     )
 
@@ -115,7 +114,7 @@ def test_run(
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True, return_value=[])
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
     agreement = _build_agreement(support_type="PartnerLedSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_discount_line = mocker.MagicMock(spec=JournalLine)
@@ -168,7 +167,7 @@ def test_run_without_pls(
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True, return_value=[])
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
     agreement = _build_agreement(support_type="DeveloperSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
@@ -314,7 +313,7 @@ def test_run_processes_when_transfer_started_on_billing_start(
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True, return_value=[])
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
     agreement = _build_agreement()
     mock_aws_client.get_responsibility_transfer_details.return_value = {
         "ResponsibilityTransfer": {

--- a/tests/flows/jobs/billing_journal/generators/test_authorization.py
+++ b/tests/flows/jobs/billing_journal/generators/test_authorization.py
@@ -1,6 +1,7 @@
 import pytest
 
 from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.aws.errors import AWSError
 from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
 from swo_aws_extension.flows.jobs.billing_journal.generators.agreement import (
     AgreementJournalGenerator,
@@ -57,6 +58,11 @@ def mock_aws_client_cls(mocker):
     mock = mocker.patch(f"{MODULE}.AWSClient", autospec=True)
     mock.return_value = mocker.MagicMock(spec=AWSClient)
     return mock
+
+
+@pytest.fixture
+def mock_generate_billing_report_rows(mocker):
+    return mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True)
 
 
 def test_no_agreements_returns_empty_list(
@@ -150,3 +156,72 @@ def test_includes_report_in_result(
 
     assert result.reports_by_agreement == {"AGR-1": report}
     assert result.billing_report_rows == [mock_row]
+
+
+def test_pma_usage_included_in_report_rows(
+    mocker,
+    mock_context,
+    mock_get_agreements,
+    mock_agreement_generator_cls,
+    mock_usage_generator_cls,
+    mock_invoice_generator_cls,
+    mock_aws_client_cls,
+    mock_generate_billing_report_rows,
+    authorization,
+):
+    mock_get_agreements.return_value = [{"id": "AGR-1"}]
+    mock_agr_gen = mocker.MagicMock(spec=AgreementJournalGenerator)
+    mock_agr_gen.run.return_value = AgreementJournalResult(
+        lines=[], report=None, billing_report_rows=[]
+    )
+    mock_agreement_generator_cls.return_value = mock_agr_gen
+    mock_invoice_gen = mock_invoice_generator_cls.return_value
+    mock_usage_gen = mock_usage_generator_cls.return_value
+    mock_pma_invoice_result = mocker.MagicMock()
+    mock_pma_usage_result = mocker.MagicMock()
+    mock_invoice_gen.run.return_value = mock_pma_invoice_result
+    mock_usage_gen.run_for_pma.return_value = mock_pma_usage_result
+    mock_row = mocker.MagicMock(spec=BillingReportRow)
+    mock_generate_billing_report_rows.return_value = [mock_row]
+    generator = AuthorizationJournalGenerator(mock_context)
+
+    result = generator.run(authorization)
+
+    mock_invoice_gen.run.assert_any_call("MPA-123", mock_context.billing_period, "USD")
+    mock_usage_gen.run_for_pma.assert_called_once_with(
+        "MPA-123",
+        mock_context.billing_period,
+        organization_invoice=mock_pma_invoice_result.invoice,
+        granularity="MONTHLY",
+    )
+    mock_generate_billing_report_rows.assert_called_once()
+    assert mock_row in result.billing_report_rows
+
+
+def test_pma_usage_error_does_not_crash(
+    mocker,
+    mock_context,
+    mock_get_agreements,
+    mock_agreement_generator_cls,
+    mock_usage_generator_cls,
+    mock_invoice_generator_cls,
+    mock_aws_client_cls,
+    mock_generate_billing_report_rows,
+    authorization,
+):
+    mock_get_agreements.return_value = [{"id": "AGR-1"}]
+    mock_agr_gen = mocker.MagicMock(spec=AgreementJournalGenerator)
+    mock_agr_gen.run.return_value = AgreementJournalResult(
+        lines=[],
+        report=None,
+        billing_report_rows=[],
+    )
+    mock_agreement_generator_cls.return_value = mock_agr_gen
+    mock_invoice_gen = mock_invoice_generator_cls.return_value
+    mock_invoice_gen.run.side_effect = AWSError("PMA invoice fetch failed")
+    generator = AuthorizationJournalGenerator(mock_context)
+
+    result = generator.run(authorization)
+
+    assert result.billing_report_rows == []
+    mock_generate_billing_report_rows.assert_not_called()

--- a/tests/flows/jobs/billing_journal/generators/test_pls_charge_manager.py
+++ b/tests/flows/jobs/billing_journal/generators/test_pls_charge_manager.py
@@ -26,6 +26,8 @@ def create_metric(service_name, record_type, amount, invoice_entity="Entity1"):
         amount=Decimal(amount),
         invoice_entity=invoice_entity,
         invoice_id="INV-123",
+        start_date="2025-10-01",
+        end_date="2025-10-31",
     )
 
 

--- a/tests/flows/jobs/billing_journal/generators/test_report_processor.py
+++ b/tests/flows/jobs/billing_journal/generators/test_report_processor.py
@@ -5,6 +5,7 @@ import pytest
 from swo_aws_extension.flows.jobs.billing_journal.generators.report_processor import (
     ReportProcessor,
 )
+from swo_aws_extension.flows.jobs.billing_journal.models.usage import ExtractedMetric
 
 
 def build_report_group(keys: list, amount: str = "100.00") -> dict:
@@ -15,9 +16,11 @@ def build_report_group(keys: list, amount: str = "100.00") -> dict:
     }
 
 
-def build_report(groups: list[dict]) -> list[dict]:
+def build_report(
+    groups: list[dict], start: str = "2026-03-01", end: str = "2026-03-02"
+) -> list[dict]:
     """Factory function to create reports for testing."""
-    return [{"Groups": groups}]
+    return [{"TimePeriod": {"Start": start, "End": end}, "Groups": groups}]
 
 
 @pytest.fixture
@@ -54,40 +57,63 @@ def test_extract_metrics(processor):
 
     result = processor.extract_metrics(report, "Amazon S3")
 
-    assert result == {"100.50": Decimal("100.50")}
+    assert result == [
+        ExtractedMetric(
+            service_name="100.50",
+            amount=Decimal("100.50"),
+            start_date="2026-03-01",
+            end_date="2026-03-02",
+        )
+    ]
 
 
 def test_extract_metrics_skips_zero_and_multiple_periods(processor):
     report = [
         {
+            "TimePeriod": {"Start": "2026-03-01", "End": "2026-03-02"},
             "Groups": [
                 {
                     "Keys": ["Amazon S3", "amount"],
                     "Metrics": {"UnblendedCost": {"Amount": "100.00"}},
                 }
-            ]
+            ],
         },
         {
+            "TimePeriod": {"Start": "2026-03-02", "End": "2026-03-03"},
             "Groups": [
                 {
                     "Keys": ["Amazon S3", "amount"],
                     "Metrics": {"UnblendedCost": {"Amount": "0.0"}},
                 }
-            ]
+            ],
         },
         {
+            "TimePeriod": {"Start": "2026-03-03", "End": "2026-03-04"},
             "Groups": [
                 {
                     "Keys": ["Amazon S3", "amount"],
                     "Metrics": {"UnblendedCost": {"Amount": "50.00"}},
                 }
-            ]
+            ],
         },
     ]
 
     result = processor.extract_metrics(report, "Amazon S3")
 
-    assert result == {"amount": Decimal("50.00")}
+    assert result == [
+        ExtractedMetric(
+            service_name="amount",
+            amount=Decimal("100.00"),
+            start_date="2026-03-01",
+            end_date="2026-03-02",
+        ),
+        ExtractedMetric(
+            service_name="amount",
+            amount=Decimal("50.00"),
+            start_date="2026-03-03",
+            end_date="2026-03-04",
+        ),
+    ]
 
 
 def test_extract_metrics_comma_decimal(processor):
@@ -97,7 +123,14 @@ def test_extract_metrics_comma_decimal(processor):
 
     result = processor.extract_metrics(report, "Amazon S3")
 
-    assert result == {"100,50": Decimal("100.50")}
+    assert result == [
+        ExtractedMetric(
+            service_name="100,50",
+            amount=Decimal("100.50"),
+            start_date="2026-03-01",
+            end_date="2026-03-02",
+        )
+    ]
 
 
 def test_extract_all_metrics_by_record_type(processor):
@@ -109,15 +142,29 @@ def test_extract_all_metrics_by_record_type(processor):
 
     result = processor.extract_all_metrics_by_record_type(report)
 
-    assert result == {
-        "Usage": {
-            "Amazon S3": Decimal("100.00"),
-            "Amazon EC2": Decimal("200.00"),
-        },
-        "Support": {
-            "Amazon S3": Decimal("10.00"),
-        },
-    }
+    assert result == [
+        ExtractedMetric(
+            service_name="Amazon S3",
+            amount=Decimal("100.00"),
+            start_date="2026-03-01",
+            end_date="2026-03-02",
+            record_type="Usage",
+        ),
+        ExtractedMetric(
+            service_name="Amazon EC2",
+            amount=Decimal("200.00"),
+            start_date="2026-03-01",
+            end_date="2026-03-02",
+            record_type="Usage",
+        ),
+        ExtractedMetric(
+            service_name="Amazon S3",
+            amount=Decimal("10.00"),
+            start_date="2026-03-01",
+            end_date="2026-03-02",
+            record_type="Support",
+        ),
+    ]
 
 
 def test_extract_all_metrics_skips_zero(processor):
@@ -125,7 +172,7 @@ def test_extract_all_metrics_skips_zero(processor):
 
     result = processor.extract_all_metrics_by_record_type(report)
 
-    assert result == {}
+    assert result == []
 
 
 def test_parse_group_metrics_valid(processor):

--- a/tests/flows/jobs/billing_journal/generators/test_usage.py
+++ b/tests/flows/jobs/billing_journal/generators/test_usage.py
@@ -46,26 +46,38 @@ def single_billing_view():
 @pytest.fixture
 def single_account_usage():
     return [
-        [{"Groups": [{"Keys": ["ACT-1"]}]}],
         [
             {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [{"Keys": ["ACT-1"]}],
+            }
+        ],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
                 "Groups": [
                     {
                         "Keys": ["ACT-1", "AmazonEC2"],
                         "Metrics": {"UnblendedCost": {"Amount": "10,25"}},
                     }
-                ]
+                ],
             }
         ],
-        [{"Groups": [{"Keys": ["AmazonEC2", "Amazon Web Services, Inc."]}]}],
         [
             {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [{"Keys": ["AmazonEC2", "Amazon Web Services, Inc."]}],
+            }
+        ],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
                 "Groups": [
                     {
                         "Keys": [AWSRecordTypeEnum.USAGE, "AmazonEC2"],
                         "Metrics": {"UnblendedCost": {"Amount": "50,75"}},
                     }
-                ]
+                ],
             }
         ],
     ]
@@ -128,7 +140,12 @@ def test_generate_processes_single_account(
     assert len(metrics) > 0
     marketplace_metrics = [metric for metric in metrics if metric.record_type == "MARKETPLACE"]
     assert len(marketplace_metrics) == 1
-    assert marketplace_metrics[0].amount == Decimal("10.25")
+    metric = marketplace_metrics[0]
+    assert (metric.amount, metric.start_date, metric.end_date) == (
+        Decimal("10.25"),
+        "2025-10-01",
+        "2025-10-02",
+    )
 
 
 def test_generate_returns_correct_invoice_entity(
@@ -254,3 +271,24 @@ def test_generate_sets_invoice_id_from_organization_invoice(
     account_usage = result.usage_by_account["ACT-1"]
     metrics = [metric for metric in account_usage.metrics if metric.service_name == "AmazonEC2"]
     assert metrics[0].invoice_id == "INV-001,INV-002"
+
+
+def test_run_for_pma_fetches_correct_usage(
+    generator,
+    mock_aws_client,
+    billing_period,
+    organization_invoice,
+    single_account_usage,
+):
+    mock_aws_client.get_cost_and_usage.side_effect = single_account_usage[1:]
+
+    result = generator.run_for_pma("ACT-1", billing_period, organization_invoice)
+
+    assert isinstance(result, OrganizationUsageResult)
+    assert "ACT-1" in result.usage_by_account
+    account_usage = result.usage_by_account["ACT-1"]
+    metrics = [metric for metric in account_usage.metrics if metric.service_name == "AmazonEC2"]
+    assert len(metrics) > 0
+    assert mock_aws_client.get_cost_and_usage.call_count == 3
+    first_call_kwargs = mock_aws_client.get_cost_and_usage.call_args_list[0].kwargs
+    assert "view_arn" not in first_call_kwargs or first_call_kwargs["view_arn"] in {None, ""}

--- a/tests/flows/jobs/billing_journal/models/test_journal_line.py
+++ b/tests/flows/jobs/billing_journal/models/test_journal_line.py
@@ -58,6 +58,8 @@ def test_build():
         account_id="ACC-789",
         invoice_entity="ENT-0",
         invoice_id="INV-111",
+        start_date="2025-10-01",
+        end_date="2025-10-31",
     )
 
     result = JournalLine.build(
@@ -96,6 +98,8 @@ def test_build_with_error_and_no_item():
         account_id="ACC",
         invoice_entity="ENT",
         invoice_id="INV",
+        start_date="START",
+        end_date="END",
         error="Missing Item",
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20051](https://softwareone.atlassian.net/browse/MPT-20051)

- AWSClient.get_cost_and_usage now accepts a BillingPeriod object and an optional granularity (was separate start_date/end_date strings; default granularity preserved as "MONTHLY" on the client)
- Cost Explorer fetchers and usage generators updated to accept billing_period + granularity (generators default to "DAILY") and thread granularity through report requests
- Added ExtractedMetric dataclass (service_name, amount, start_date, end_date, optional record_type) and extended ServiceMetric with optional start_date/end_date to carry date bounds
- ReportProcessor.extract_metrics and extract_all_metrics_by_record_type now return lists of ExtractedMetric and derive start/end from Cost Explorer TimePeriod
- InvoiceDetails model extended with start_date and end_date; JournalLine.build now uses invoice-level dates for the resulting period
- Usage pipeline refactored to consume ExtractedMetric records; created CostExplorerUsageGenerator.run_for_pma to fetch PMA-specific usage
- Authorization journal generator enhanced to fetch and include PMA usage (new _apply_pma_usage_to_report/_fetch_raw_pma_usage helpers) with AWSError-safe handling
- Discount processors, line builders and PLS charge manager updated to propagate invoice date ranges into final JournalLine outputs
- finops_entitlements_processor and other callers updated to compute/pass BillingPeriod to AWS client
- Tests updated across the suite to use BillingPeriod, include TimePeriod in mock reports, and assert date-range propagation and new PMA behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20051]: https://softwareone.atlassian.net/browse/MPT-20051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ