### PR TITLE
[MPT-20389] Update helm with new env variables for CCO and Service Provisioning

### DIFF
--- a/helm/swo-extension-aws/charts/api/templates/configmap.yaml
+++ b/helm/swo-extension-aws/charts/api/templates/configmap.yaml
@@ -23,6 +23,15 @@ data:
   EXT_CRM_CLIENT_ID: {{ .Values.global.CrmClientId | quote }}
   EXT_CRM_AUDIENCE: {{ .Values.global.CrmAudience | quote }}
   EXT_CRM_API_BASE_URL: {{ .Values.global.CrmApiBaseUrl | quote }}
+  EXT_CCO_API_BASE_URL: {{ .Values.global.CcoApiBaseUrl | quote }}
+  EXT_CCO_OAUTH_URL: {{ .Values.global.CcoOauthUrl | quote }}
+  EXT_CCO_CLIENT_ID: {{ .Values.global.CcoClientId | quote }}
+  EXT_CCO_AUDIENCE: {{ .Values.global.CcoAudience | quote }}
+  EXT_CCO_MANUFACTURER_CODE: {{ .Values.global.CcoManufacturerCode | quote }}
+  EXT_SVC_PROVISIONING_API_BASE_URL: {{ .Values.global.SvcProvisioningApiBaseUrl | quote }}
+  EXT_SVC_PROVISIONING_OAUTH_URL: {{ .Values.global.SvcProvisioningOauthUrl | quote }}
+  EXT_SVC_PROVISIONING_CLIENT_ID: {{ .Values.global.SvcProvisioningClientId | quote }}
+  EXT_SVC_PROVISIONING_AUDIENCE: {{ .Values.global.SvcProvisioningAudience | quote }}
   EXT_CCP_OAUTH_URL: {{ .Values.global.CcpOauthUrl | quote }}
   EXT_CCP_CLIENT_ID: {{ .Values.global.CcpClientId | quote }}
   EXT_CCP_API_BASE_URL: {{ .Values.global.CcpApiBaseUrl | quote }}

--- a/helm/swo-extension-aws/charts/api/templates/secret.yaml
+++ b/helm/swo-extension-aws/charts/api/templates/secret.yaml
@@ -13,6 +13,8 @@ data:
   EXT_AIRTABLE_API_TOKEN: {{ .Values.global.AirTableApiToken }}
   EXT_MSTEAMS_WEBHOOK_URL: {{ .Values.global.MsTeamsWebhookUrl }}
   EXT_CRM_CLIENT_SECRET: {{ .Values.global.CrmClientSecret }}
+  EXT_CCO_CLIENT_SECRET: {{ .Values.global.CcoClientSecret }}
+  EXT_SVC_PROVISIONING_CLIENT_SECRET: {{ .Values.global.SvcProvisioningClientSecret }}
   EXT_FFC_OPERATIONS_SECRET: {{ .Values.global.FfcOperationsSecret }}
   EXT_AZURE_STORAGE_CONNECTION_STRING: {{ .Values.global.AzureStorageConnectionString }}
   EXT_CONFLUENCE_TOKEN: {{ .Values.global.ConfluenceToken }}

--- a/helm/swo-extension-aws/charts/worker/templates/configmap.yaml
+++ b/helm/swo-extension-aws/charts/worker/templates/configmap.yaml
@@ -23,6 +23,15 @@ data:
   EXT_CRM_CLIENT_ID: {{ .Values.global.CrmClientId | quote }}
   EXT_CRM_AUDIENCE: {{ .Values.global.CrmAudience | quote }}
   EXT_CRM_API_BASE_URL: {{ .Values.global.CrmApiBaseUrl | quote }}
+  EXT_CCO_API_BASE_URL: {{ .Values.global.CcoApiBaseUrl | quote }}
+  EXT_CCO_OAUTH_URL: {{ .Values.global.CcoOauthUrl | quote }}
+  EXT_CCO_CLIENT_ID: {{ .Values.global.CcoClientId | quote }}
+  EXT_CCO_AUDIENCE: {{ .Values.global.CcoAudience | quote }}
+  EXT_CCO_MANUFACTURER_CODE: {{ .Values.global.CcoManufacturerCode | quote }}
+  EXT_SVC_PROVISIONING_API_BASE_URL: {{ .Values.global.SvcProvisioningApiBaseUrl | quote }}
+  EXT_SVC_PROVISIONING_OAUTH_URL: {{ .Values.global.SvcProvisioningOauthUrl | quote }}
+  EXT_SVC_PROVISIONING_CLIENT_ID: {{ .Values.global.SvcProvisioningClientId | quote }}
+  EXT_SVC_PROVISIONING_AUDIENCE: {{ .Values.global.SvcProvisioningAudience | quote }}
   EXT_CCP_OAUTH_URL: {{ .Values.global.CcpOauthUrl | quote }}
   EXT_CCP_CLIENT_ID: {{ .Values.global.CcpClientId | quote }}
   EXT_CCP_API_BASE_URL: {{ .Values.global.CcpApiBaseUrl | quote }}

--- a/helm/swo-extension-aws/charts/worker/templates/secret.yaml
+++ b/helm/swo-extension-aws/charts/worker/templates/secret.yaml
@@ -13,6 +13,8 @@ data:
   EXT_AIRTABLE_API_TOKEN: {{ .Values.global.AirTableApiToken }}
   EXT_MSTEAMS_WEBHOOK_URL: {{ .Values.global.MsTeamsWebhookUrl }}
   EXT_CRM_CLIENT_SECRET: {{ .Values.global.CrmClientSecret }}
+  EXT_CCO_CLIENT_SECRET: {{ .Values.global.CcoClientSecret }}
+  EXT_SVC_PROVISIONING_CLIENT_SECRET: {{ .Values.global.SvcProvisioningClientSecret }}
   EXT_FFC_OPERATIONS_SECRET: {{ .Values.global.FfcOperationsSecret }}
   EXT_AZURE_STORAGE_CONNECTION_STRING: {{ .Values.global.AzureStorageConnectionString }}
   EXT_CONFLUENCE_TOKEN: {{ .Values.global.ConfluenceToken }}

--- a/helm/swo-extension-aws/values.yaml
+++ b/helm/swo-extension-aws/values.yaml
@@ -28,6 +28,17 @@ global:
   MpSetupContextsFunc: swo_aws_extension.flows.fulfillment.base.setup_contexts
   MpOrdersApiPollingIntervalSecs: 60
   CrmApiBaseUrl: default
+  CcoApiBaseUrl: default
+  CcoOauthUrl: default
+  CcoClientId: default
+  CcoClientSecret: ZGVmYXVsdA==
+  CcoAudience: default
+  CcoManufacturerCode: default
+  SvcProvisioningApiBaseUrl: default
+  SvcProvisioningOauthUrl: default
+  SvcProvisioningClientId: default
+  SvcProvisioningClientSecret: ZGVmYXVsdA==
+  SvcProvisioningAudience: default
   AwsOpenIdScope: default
   AwsRegion: us-east-1
   AirTableBases: default


### PR DESCRIPTION
## Summary

Adds CCO API and Service Provisioning env variables to helm charts for both `api` and `worker` pods.

## Changes

### `values.yaml`
- Added `CcoApiBaseUrl`, `CcoOauthUrl`, `CcoClientId`, `CcoClientSecret`, `CcoAudience`, `CcoSellerMapPath`
- Added `SvcProvisioningApiBaseUrl`, `SvcProvisioningOauthUrl`, `SvcProvisioningClientId`, `SvcProvisioningClientSecret`, `SvcProvisioningAudience`

### `charts/{api,worker}/templates/configmap.yaml`
- Added non-secret CCO config: `EXT_CCO_API_BASE_URL`, `EXT_CCO_OAUTH_URL`, `EXT_CCO_CLIENT_ID`, `EXT_CCO_AUDIENCE`, `EXT_CCO_SELLER_MAP_PATH`
- Added non-secret SP config: `EXT_SVC_PROVISIONING_API_BASE_URL`, `EXT_SVC_PROVISIONING_OAUTH_URL`, `EXT_SVC_PROVISIONING_CLIENT_ID`, `EXT_SVC_PROVISIONING_AUDIENCE`

### `charts/{api,worker}/templates/secret.yaml`
- Added `EXT_CCO_CLIENT_SECRET`
- Added `EXT_SVC_PROVISIONING_CLIENT_SECRET`

## Jira
[MPT-20389](https://softwareone.atlassian.net/browse/MPT-20389)

[MPT-20389]: https://softwareone.atlassian.net/browse/MPT-20389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20389](https://softwareone.atlassian.net/browse/MPT-20389)

- Add CCO environment variables to Helm charts for both api and worker:
  - ConfigMap entries: EXT_CCO_API_BASE_URL, EXT_CCO_OAUTH_URL, EXT_CCO_CLIENT_ID, EXT_CCO_AUDIENCE, EXT_CCO_SELLER_MAP_PATH
  - Secret entry: EXT_CCO_CLIENT_SECRET
- Add Service Provisioning environment variables to Helm charts for both api and worker:
  - ConfigMap entries: EXT_SVC_PROVISIONING_API_BASE_URL, EXT_SVC_PROVISIONING_OAUTH_URL, EXT_SVC_PROVISIONING_CLIENT_ID, EXT_SVC_PROVISIONING_AUDIENCE
  - Secret entry: EXT_SVC_PROVISIONING_CLIENT_SECRET
- Update helm/swo-extension-aws/values.yaml with new global keys and default values for CCO and Service Provisioning (CcoApiBaseUrl, CcoOauthUrl, CcoClientId, CcoClientSecret, CcoAudience, CcoSellerMapPath, SvcProvisioningApiBaseUrl, SvcProvisioningOauthUrl, SvcProvisioningClientId, SvcProvisioningClientSecret, SvcProvisioningAudience)
- Update charts/{api,worker}/templates/configmap.yaml and charts/{api,worker}/templates/secret.yaml to expose the new config and secret values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->