### PR TITLE
MPT-20521 Remove ordering parameter errors

### DIFF
--- a/swo_aws_extension/flows/steps/setup_context.py
+++ b/swo_aws_extension/flows/steps/setup_context.py
@@ -18,7 +18,12 @@ from swo_aws_extension.flows.order_utils import (
 )
 from swo_aws_extension.flows.steps.base import BasePhaseStep
 from swo_aws_extension.flows.steps.errors import ConfigurationStepError, UnexpectedStopError
-from swo_aws_extension.parameters import get_phase, set_fulfillment_parameter_value, set_phase
+from swo_aws_extension.parameters import (
+    get_phase,
+    reset_ordering_parameters_error,
+    set_fulfillment_parameter_value,
+    set_phase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +46,7 @@ class SetupContext(BasePhaseStep):
     def process(self, client: MPTClient, context: InitialAWSContext) -> None:
         self._init_processing_template(client, context)
         self._init_parameter_default_values(client, context)
+        context.order = reset_ordering_parameters_error(context.order)
         context.order = strip_whitespace_from_mpa_account(context.order)
         try:
             context.aws_client = AWSClient(

--- a/tests/flows/steps/test_setup_context.py
+++ b/tests/flows/steps/test_setup_context.py
@@ -6,12 +6,17 @@ from swo_aws_extension.aws.errors import AWSError
 from swo_aws_extension.constants import (
     AccountTypesEnum,
     FulfillmentParametersEnum,
+    OrderParametersEnum,
     OrderProcessingTemplateEnum,
     PhasesEnum,
 )
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.setup_context import SetupContext
-from swo_aws_extension.parameters import get_fulfillment_parameter, get_mpa_account_id
+from swo_aws_extension.parameters import (
+    get_fulfillment_parameter,
+    get_mpa_account_id,
+    get_ordering_parameter,
+)
 
 
 def test_setup_context_with_pma(
@@ -456,3 +461,36 @@ def test_strip_whitespace_from_mpa_account(
     step(mpt_client_mock, context, next_step_mock)  # act
 
     assert get_mpa_account_id(context.order) == "651706759263"
+
+
+def test_reset_ordering_parameter_error_on_master_payer_id(
+    mocker,
+    config,
+    order_factory,
+    fulfillment_parameters_factory,
+    product_parameters_factory,
+):
+    mpt_client_mock = mocker.MagicMock(spec=MPTClient)
+    next_step_mock = mocker.MagicMock(spec=Step)
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.AWSClient")
+    mocker.patch("swo_aws_extension.flows.steps.setup_context.update_processing_template")
+    mocker.patch(
+        "swo_aws_extension.flows.steps.setup_context._paginated",
+        return_value=product_parameters_factory(),
+    )
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(phase=""),
+    )
+    mpa_external_id = OrderParametersEnum.MASTER_PAYER_ACCOUNT_ID.value
+    get_ordering_parameter(mpa_external_id, order)["error"] = "Some validation error"
+    mocker.patch(
+        "swo_aws_extension.flows.steps.setup_context.update_order",
+        side_effect=lambda *_args, **kwargs: {**order, "parameters": kwargs["parameters"]},
+    )
+    context = PurchaseContext.from_order_data(order)
+    step = SetupContext(config)
+
+    step(mpt_client_mock, context, next_step_mock)  # act
+
+    assert get_ordering_parameter(mpa_external_id, context.order)["error"] is None
+    next_step_mock.assert_called_once_with(mpt_client_mock, context)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20521](https://softwareone.atlassian.net/browse/MPT-20521)

- Reset ordering parameter error state in `SetupContext.process` by calling `reset_ordering_parameters_error()` before applying whitespace stripping
- Added test coverage to verify ordering parameter errors are cleared when `SetupContext` is invoked

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20521]: https://softwareone.atlassian.net/browse/MPT-20521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ