### PR TITLE
fix: MPT-20862 exclude marketplace charges from linked-account usage …

### DIFF
--- a/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
@@ -126,12 +126,13 @@ class BillingJournalService:
         self, authorization_id: str, generator_result: AuthorizationJournalResult
     ) -> None:
         logger.info(
-            "[DRY-RUN] Generated %d journal lines for authorization %s",
+            "%s - [DRY-RUN] Generated %d journal lines for authorization %s",
+            authorization_id,
             len(generator_result.lines),
             authorization_id,
         )
         logger.info("".join(entry.to_jsonl() for entry in generator_result.lines))
-        self._log_totals_by_mpa(generator_result.lines)
+        self._log_totals_by_mpa(authorization_id, generator_result.lines)
 
         attachments = [
             f"{agr}.json"
@@ -139,16 +140,17 @@ class BillingJournalService:
             if rep.organization_data or rep.accounts_data
         ]
         if attachments:
-            logger.info("[DRY-RUN] Attachments: %s", attachments)
+            logger.info("%s - [DRY-RUN] Attachments: %s", authorization_id, attachments)
 
-    def _log_totals_by_mpa(self, journal_lines: list[JournalLine]) -> None:
+    def _log_totals_by_mpa(self, authorization_id, journal_lines: list[JournalLine]) -> None:
         total_by_mpa: dict[str, Decimal] = defaultdict(Decimal)
         for line in journal_lines:
             total_by_mpa[line.external_ids.vendor] += line.price.pp_x1
 
         for mpa, total_amount in total_by_mpa.items():
             logger.info(
-                "[DRY-RUN] MPA %s total amount: %s",
+                "%s - [DRY-RUN] MPA %s total amount: %s",
+                authorization_id,
                 mpa,
                 total_amount,
             )

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
@@ -1,4 +1,3 @@
-import logging
 from decimal import Decimal
 
 from swo_aws_extension.aws.client import AWSClient
@@ -9,8 +8,9 @@ from swo_aws_extension.flows.jobs.billing_journal.models.invoice import (
     OrganizationInvoice,
     OrganizationInvoiceResult,
 )
+from swo_aws_extension.logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 SPP_DISCOUNT_DESCRIPTION = "Discount (AWS SPP Discount)"
 
 

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
@@ -20,6 +20,10 @@ from swo_aws_extension.logger import get_logger
 logger = get_logger(__name__)
 
 
+def _marketplace_billing_entity_filter() -> dict:
+    return {"Dimensions": {"Key": "BILLING_ENTITY", "Values": [AWS_MARKETPLACE]}}
+
+
 class CostExplorerReportFetcher:
     """Fetches cost and usage reports from AWS Cost Explorer."""
 
@@ -47,7 +51,7 @@ class CostExplorerReportFetcher:
             {"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"},
             {"Type": "DIMENSION", "Key": "SERVICE"},
         ]
-        filter_by = {"Dimensions": {"Key": "BILLING_ENTITY", "Values": [AWS_MARKETPLACE]}}
+        filter_by = _marketplace_billing_entity_filter()
         return self._aws_client.get_cost_and_usage(
             billing_period,
             group_by,
@@ -68,7 +72,12 @@ class CostExplorerReportFetcher:
             {"Type": "DIMENSION", "Key": "RECORD_TYPE"},
             {"Type": "DIMENSION", "Key": "SERVICE"},
         ]
-        filter_by = {"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": [account_id]}}
+        filter_by = {
+            "And": [
+                {"Dimensions": {"Key": "LINKED_ACCOUNT", "Values": [account_id]}},
+                {"Not": _marketplace_billing_entity_filter()},
+            ]
+        }
         return self._aws_client.get_cost_and_usage(
             billing_period,
             group_by,


### PR DESCRIPTION
…queries

Account-level cost queries now apply a NOT marketplace billing entity filter so AWS Marketplace charges are not double-counted alongside the dedicated marketplace billing entity query. Extracts the shared filter into _marketplace_billing_entity_filter() for reuse.

Also adds authorization_id prefix to all dry-run log lines and switches the invoice generator to the repository custom logger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20862](https://softwareone.atlassian.net/browse/MPT-20862)

- Exclude marketplace charges from linked-account usage queries by applying a NOT marketplace billing entity filter to prevent double-counting with dedicated marketplace billing entity queries
- Extract shared marketplace billing entity filter logic into a reusable helper function `_marketplace_billing_entity_filter()` for consistent filtering across usage reports
- Enhance DRY-RUN logging with authorization_id prefixes on all log lines and per-authorization journal JSONL payload output
- Log per-MPA totals with authorization context
- Switch invoice generator to use project-specific logger via `get_logger(__name__)`
- Update `_log_totals_by_mpa()` method signature to accept authorization_id parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20862]: https://softwareone.atlassian.net/browse/MPT-20862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ