### PR TITLE
MPT-20884 AWS extension does not fail when change order is received

### DIFF
--- a/migrations/20260507080455_change_draft_validation.py
+++ b/migrations/20260507080455_change_draft_validation.py
@@ -1,0 +1,78 @@
+import json
+import os
+
+from mpt_tool.migration import SchemaBaseMigration
+from mpt_tool.migration.mixins import MPTAPIClientMixin
+
+
+class Migration(SchemaBaseMigration, MPTAPIClientMixin):
+    """Migration to enable change order draft validation."""
+
+    def run(self):
+        """Run the migration."""
+        raw_ids = os.environ["MPT_PRODUCTS_IDS"].replace(" ", "").split(",")
+        product_ids = list(filter(None, raw_ids))
+        self.log.info(
+            "Starting migration 20260507080455_project_creation_phase for %s product(s)",
+            len(product_ids),
+        )
+
+        if not product_ids:
+            self.log.info("No product IDs found in MPT_PRODUCTS_IDS; nothing to migrate")
+
+        for product_id in product_ids:
+            self._migrate_product(product_id)
+
+        self.log.info("Migration 20260507080455_change_draft_validation completed")
+
+    def _migrate_product(self, product_id: str) -> None:
+        self.log.info("Migrating product '%s'", product_id)
+
+        self._enable_change_order_validation(product_id)
+
+        self._create_change_order_webhook_if_not_exists(product_id)
+
+    def _enable_change_order_validation(self, product_id):
+        product = self.mpt_client.catalog.products.get(product_id).to_dict()
+        self.log.info("product '%s'", product["name"])
+        if product.get("settings", {}).get("preValidation", {}).get("changeOrderDraft"):
+            self.log.info(
+                "Change order draft validation already enabled for product '%s'; skipping",
+                product_id,
+            )
+        else:
+            product["settings"]["preValidation"]["changeOrderDraft"] = True
+            self.log.info(product["settings"])
+            self.mpt_client.catalog.products.update_settings(product_id, product["settings"])
+            self.log.info("Enabled change order draft validation for product '%s'", product_id)
+
+    def _create_change_order_webhook_if_not_exists(self, product_id):
+        webhooks = self.mpt_client.http_client.request(
+            "GET", "public/v1/notifications/webhooks", query_params=f"eq(object.id,{product_id})"
+        ).json()
+
+        webhook_created = False
+        purchase_webhook_url = None
+        for webhook in webhooks["data"]:
+            if webhook["type"] == "ValidatePurchaseOrderDraft":
+                purchase_webhook_url = webhook["url"]
+            if webhook["type"] == "ValidateChangeOrderDraft" and webhook["status"] == "Enabled":
+                webhook_created = True
+        if webhook_created:
+            self.log.info(
+                "Change order draft validation webhook already exists for product '%s'; skipping",
+                product_id,
+            )
+        else:
+            webhook_payload = {
+                "type": "ValidateChangeOrderDraft",
+                "status": "Enabled",
+                "url": purchase_webhook_url,
+                "description": "Change order draft validation",
+                "secret": json.loads(os.environ["EXT_WEBHOOKS_SECRETS"]).get(product_id),
+                "criteria": {"product.id": product_id},
+            }
+            webhooks = self.mpt_client.http_client.request(
+                "POST", "public/v1/notifications/webhooks", json=webhook_payload
+            ).json()
+            self.log.info("Created webhook '%s' for product '%s'", webhooks["url"], product_id)

--- a/swo_aws_extension/extension.py
+++ b/swo_aws_extension/extension.py
@@ -6,12 +6,15 @@ from typing import Annotated, Any
 from django.conf import settings
 from mpt_extension_sdk.core.extension import Extension
 from mpt_extension_sdk.core.security import JWTAuth
+from mpt_extension_sdk.flows.context import ORDER_TYPE_CHANGE
 from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.mpt import get_webhook
+from mpt_extension_sdk.mpt_http.wrap_http_error import ValidationError
 from mpt_extension_sdk.runtime.djapp.conf import get_for_product
 from ninja import Body
 
 from swo_aws_extension.flows.fulfillment.base import fulfill_order
+from swo_aws_extension.flows.order_utils import set_order_error
 from swo_aws_extension.flows.validation.base import validate_order
 
 logger = logging.getLogger(__name__)
@@ -42,6 +45,15 @@ def process_order_fulfillment(client, event):
 )
 def process_order_validation(request, order: Annotated[dict, Body()]):
     """Start order process validation."""
+    if order.get("type") == ORDER_TYPE_CHANGE:
+        order = set_order_error(
+            order,
+            ValidationError(
+                err_id="AWS003",
+                message="Change orders are not supported by the AWS extension.",
+            ).to_dict(),
+        )
+        return HTTPStatus.OK, order
     try:
         validated_order = validate_order(request.client, order)
     except Exception:

--- a/swo_aws_extension/flows/fulfillment/base.py
+++ b/swo_aws_extension/flows/fulfillment/base.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from mpt_extension_sdk.mpt_http.base import MPTClient
+from mpt_extension_sdk.mpt_http.wrap_http_error import ValidationError
 
 from swo_aws_extension.flows.fulfillment.pipelines import (
     pipeline_error_handler,
@@ -10,8 +11,45 @@ from swo_aws_extension.flows.fulfillment.pipelines import (
     terminate,
 )
 from swo_aws_extension.flows.order import InitialAWSContext, PurchaseContext
+from swo_aws_extension.flows.order_utils import switch_order_status_to_failed
 
 logger = logging.getLogger(__name__)
+
+
+def _handle_purchase_order(client: MPTClient, context: InitialAWSContext) -> None:
+    purchase_context = PurchaseContext.from_context(context)
+    if purchase_context.is_type_new_aws_environment():
+        logger.info(
+            "%s - Pipeline - Starting: purchase new AWS environment",
+            purchase_context.order_id,
+        )
+        purchase_new_aws_environment.run(
+            client, purchase_context, error_handler=pipeline_error_handler
+        )
+    elif purchase_context.is_type_existing_aws_environment():
+        logger.info(
+            "%s - Pipeline - Starting: purchase existing AWS environment",
+            purchase_context.order_id,
+        )
+        purchase_existing_aws_environment.run(
+            client, purchase_context, error_handler=pipeline_error_handler
+        )
+
+
+def _fail_unsupported_order(client: MPTClient, context: InitialAWSContext) -> None:
+    logger.error(
+        "%s - Order type %s is not supported, failing order",
+        context.order_id,
+        context.order_type,
+    )
+    switch_order_status_to_failed(
+        client,
+        context,
+        ValidationError(
+            err_id="AWS003",
+            message=f"Order type {context.order_type} is not supported by the AWS extension.",
+        ).to_dict(),
+    )
 
 
 def fulfill_order(client: MPTClient, context: InitialAWSContext) -> None:
@@ -27,24 +65,9 @@ def fulfill_order(client: MPTClient, context: InitialAWSContext) -> None:
     if context.is_termination_order():
         terminate.run(client, context, error_handler=pipeline_error_handler)
     elif context.is_purchase_order():
-        context = PurchaseContext.from_context(context)
-        if context.is_type_new_aws_environment():
-            logger.info(
-                "%s - Pipeline - Starting: purchase new AWS environment",
-                context.order_id,
-            )
-            purchase_new_aws_environment.run(client, context, error_handler=pipeline_error_handler)
-
-        elif context.is_type_existing_aws_environment():
-            logger.info(
-                "%s - Pipeline - Starting: purchase existing AWS environment",
-                context.order_id,
-            )
-            purchase_existing_aws_environment.run(
-                client, context, error_handler=pipeline_error_handler
-            )
+        _handle_purchase_order(client, context)
     else:
-        logger.error("%s - Unsupported order type: %s", context.order_id, context.order_type)
+        _fail_unsupported_order(client, context)
 
 
 def setup_contexts(_: MPTClient, orders: list[dict[str, Any]]) -> list[InitialAWSContext]:

--- a/swo_aws_extension/flows/order_utils.py
+++ b/swo_aws_extension/flows/order_utils.py
@@ -160,3 +160,19 @@ def update_processing_template(
     }
 
     context.order = update_order(client, context.order_id, **kwargs)
+
+
+def set_order_error(order: dict, error: dict) -> dict:
+    """
+    Sets error in MPT order.
+
+    Args:
+        order: MPT order.
+        error: error (id, message).
+
+    Returns:
+        Updated MPT order.
+    """
+    updated_order = copy.deepcopy(order)
+    updated_order["error"] = error
+    return updated_order

--- a/tests/flows/fulfillment/test_base.py
+++ b/tests/flows/fulfillment/test_base.py
@@ -1,3 +1,4 @@
+import pytest
 from mpt_extension_sdk.mpt_http.base import MPTClient
 
 from swo_aws_extension.constants import (
@@ -58,16 +59,25 @@ def test_fulfill_termination_order(mocker, mpt_client, order_factory):
     mock_terminate.assert_called_once()
 
 
-def test_fulfill_unsupported_order_type(mpt_client, order_factory, caplog):
-    unsupported_order = order_factory(
-        order_id="ORD-UNSUP",
-        order_type="Change",
+@pytest.mark.parametrize("order_type", ["Change", "Unknown"])
+def test_fulfill_unsupported_order_type_fails(mocker, order_factory, caplog, order_type):
+    mock_fail = mocker.patch(
+        "swo_aws_extension.flows.fulfillment.base.switch_order_status_to_failed"
     )
-    context = InitialAWSContext.from_order_data(unsupported_order)
+    order = order_factory(order_id="ORD-UNSUP", order_type=order_type)
+    context = InitialAWSContext.from_order_data(order)
 
-    fulfill_order(mpt_client, context)  # act
+    fulfill_order(mocker.MagicMock(spec=MPTClient), context)  # act
 
-    assert "ORD-UNSUP - Unsupported order type: Change" in caplog.text
+    assert f"ORD-UNSUP - Order type {order_type} is not supported, failing order" in caplog.text
+    mock_fail.assert_called_once_with(
+        mocker.ANY,
+        context,
+        {
+            "id": "AWS003",
+            "message": f"Order type {order_type} is not supported by the AWS extension.",
+        },
+    )
 
 
 def test_setup_contexts(mpt_client, order_factory):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -93,3 +93,28 @@ class TestProcessOrderValidation:
         response_data = result.json()
         assert response_data["id"] == "Unexpected error"
         assert "Unexpected validation error" in response_data["message"]
+
+    def test_change_order_rejected(
+        self,
+        client,
+        order_factory,
+        jwt_token,
+        mock_validate_order,
+    ):
+        order = order_factory(order_type="Change")
+
+        result = client.post(
+            "/api/v1/orders/validate",
+            content_type="application/json",
+            headers={
+                "Authorization": f"Bearer {jwt_token}",
+                "X-Forwarded-Host": "aws.ext.s1.com",
+            },
+            data=json.dumps(order),
+        )
+
+        assert result.status_code == HTTPStatus.OK
+        response_data = result.json()
+        assert response_data["id"] == "ORD-0792-5000-2253-4210"
+        assert "Change orders are not supported" in response_data["error"]["message"]
+        mock_validate_order.assert_not_called()


### PR DESCRIPTION
Use ValidationError to build structured error payloads for unsupported order types in both fulfillment and validation flows, and return HTTP 200 with the error set on the order instead of HTTP 400 for change order validation. Add migration to enable change order draft validation webhook for existing products.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20884](https://softwareone.atlassian.net/browse/MPT-20884)

- Return HTTP 200 and attach a structured AWS003 ValidationError to the order for unsupported Change orders during validation (instead of returning HTTP 400)
- Add set_order_error(order, error) utility to embed structured error payloads into orders
- Centralize fulfillment branching: add _handle_purchase_order and _fail_unsupported_order to fail unsupported order types with an AWS003 ValidationError
- Add migration to enable preValidation.changeOrderDraft and create/enable ValidateChangeOrderDraft webhooks for products listed in MPT_PRODUCTS_IDS (uses EXT_WEBHOOKS_SECRETS for per-product secrets)
- Add tests: validate Change order rejection in validation flow and parameterized unsupported-order handling in fulfillment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20884]: https://softwareone.atlassian.net/browse/MPT-20884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ