### PR TITLE
MPT-20916 aws extension enables pls based on ordering parameters instead aws account state

### DIFF
--- a/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
@@ -10,7 +10,6 @@ from swo_aws_extension.flows.jobs.billing_journal.generators.authorization impor
 )
 from swo_aws_extension.flows.jobs.billing_journal.journal_manager import JournalManager
 from swo_aws_extension.flows.jobs.billing_journal.models.context import BillingJournalContext
-from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import JournalLine
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AuthorizationJournalResult,
 )
@@ -19,6 +18,40 @@ from swo_aws_extension.swo.mpt.authorization import get_authorizations
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
 
 logger = get_logger(__name__)
+
+
+def _log_totals_by_mpa(authorization_id: str, generator_result: AuthorizationJournalResult) -> None:
+    total_by_mpa: dict[str, Decimal] = defaultdict(Decimal)
+    for line in generator_result.lines:
+        total_by_mpa[line.external_ids.vendor] += line.price.pp_x1
+    for mpa, total_amount in total_by_mpa.items():
+        logger.info(
+            "%s - [DRY-RUN] MPA %s total amount: %s",
+            authorization_id,
+            mpa,
+            total_amount,
+        )
+
+
+def _log_dry_run_results(
+    authorization_id: str, generator_result: AuthorizationJournalResult
+) -> None:
+    logger.info(
+        "%s - [DRY-RUN] Generated %d journal lines for authorization %s",
+        authorization_id,
+        len(generator_result.lines),
+        authorization_id,
+    )
+    logger.info("".join(entry.to_jsonl() for entry in generator_result.lines))
+    _log_totals_by_mpa(authorization_id, generator_result)
+
+    attachments = [
+        f"{agr}.json"
+        for agr, rep in generator_result.reports_by_agreement.items()
+        if rep.organization_data or rep.accounts_data
+    ]
+    if attachments:
+        logger.info("%s - [DRY-RUN] Attachments: %s", authorization_id, attachments)
 
 
 class BillingJournalService:
@@ -39,30 +72,41 @@ class BillingJournalService:
                 "Starting execution in DRY-RUN mode. No journals will be created or uploaded."
             )
 
-        logger.info(
-            "Generating billing journals for %s",
-            self._context.billing_period,
-        )
+        logger.info("Generating billing journals for %s", self._context.billing_period)
 
         authorizations = get_authorizations(self._mpt_client, self._build_rql_query())
         if not authorizations:
             logger.info("No authorizations found")
             return
 
-        all_report_rows = []
-        for authorization in authorizations:
-            generator_result = self._process_authorization(authorization)
-            if generator_result and generator_result.billing_report_rows:
-                all_report_rows.extend(generator_result.billing_report_rows)
+        journal_results = [
+            auth_result
+            for auth in authorizations
+            if (auth_result := self._process_authorization(auth)) is not None
+        ]
 
-        if all_report_rows and not self._context.dry_run:
-            report_creator = BillingReportCreator(self._context.config, self._context.notifier)
-            report_creator.create_and_notify_teams(
-                str(self._context.billing_period), all_report_rows
+        self._process_journal_results(journal_results)
+
+    def _process_journal_results(self, journal_results: list[AuthorizationJournalResult]) -> None:
+        pls_mismatches = [
+            mismatch for auth_result in journal_results for mismatch in auth_result.pls_mismatches
+        ]
+        if pls_mismatches:
+            details = "\n\n".join(f"• {mismatch.description}" for mismatch in pls_mismatches)
+            self._notifier.send_warning(
+                title="PLS Mismatch Summary",
+                text=f"{len(pls_mismatches)} agreement(s) with PLS mismatch:\n\n{details}",
             )
 
+        report_rows = [
+            row for auth_result in journal_results for row in auth_result.billing_report_rows
+        ]
+        if report_rows and not self._context.dry_run:
+            report_creator = BillingReportCreator(self._context.config, self._context.notifier)
+            report_creator.create_and_notify_teams(str(self._context.billing_period), report_rows)
+
     def _process_authorization(self, authorization: dict) -> AuthorizationJournalResult | None:
-        authorization_id = authorization.get("id")
+        authorization_id = authorization.get("id", "")
 
         generator_result = self._generate_journal_lines(authorization, authorization_id)
         if not generator_result or not generator_result.lines:
@@ -79,7 +123,7 @@ class BillingJournalService:
         )
 
         if self._context.dry_run:
-            self._log_dry_run_results(authorization_id, generator_result)
+            _log_dry_run_results(authorization_id, generator_result)
             return None
 
         journal_manager = JournalManager(self._context, authorization_id)
@@ -121,36 +165,3 @@ class BillingJournalService:
             unique_ids = list(set(self._authorizations))
             rql_query = RQLQuery(id__in=unique_ids) & rql_query
         return rql_query
-
-    def _log_dry_run_results(
-        self, authorization_id: str, generator_result: AuthorizationJournalResult
-    ) -> None:
-        logger.info(
-            "%s - [DRY-RUN] Generated %d journal lines for authorization %s",
-            authorization_id,
-            len(generator_result.lines),
-            authorization_id,
-        )
-        logger.info("".join(entry.to_jsonl() for entry in generator_result.lines))
-        self._log_totals_by_mpa(authorization_id, generator_result.lines)
-
-        attachments = [
-            f"{agr}.json"
-            for agr, rep in generator_result.reports_by_agreement.items()
-            if rep.organization_data or rep.accounts_data
-        ]
-        if attachments:
-            logger.info("%s - [DRY-RUN] Attachments: %s", authorization_id, attachments)
-
-    def _log_totals_by_mpa(self, authorization_id, journal_lines: list[JournalLine]) -> None:
-        total_by_mpa: dict[str, Decimal] = defaultdict(Decimal)
-        for line in journal_lines:
-            total_by_mpa[line.external_ids.vendor] += line.price.pp_x1
-
-        for mpa, total_amount in total_by_mpa.items():
-            logger.info(
-                "%s - [DRY-RUN] MPA %s total amount: %s",
-                authorization_id,
-                mpa,
-                total_amount,
-            )

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
@@ -30,6 +30,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import (
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AgreementJournalResult,
+    PlsMismatch,
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.usage import OrganizationUsageResult
 from swo_aws_extension.logger import get_logger
@@ -111,9 +112,7 @@ class AgreementJournalGenerator:
         journal_details: JournalDetails,
         organization_invoice,
     ) -> AgreementJournalResult:
-        all_lines = self._generate_usage_lines(
-            agreement, usage_result, journal_details, organization_invoice
-        )
+        all_lines = self._generate_usage_lines(usage_result, journal_details, organization_invoice)
 
         # Process extra discounts after generating all usage lines.
         all_lines.extend(
@@ -125,9 +124,20 @@ class AgreementJournalGenerator:
             )
         )
 
-        # If PLS is active, calculate and add the PLS charge line.
-        is_pls = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
-        if is_pls:
+        pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
+        report_has_enterprise = usage_result.has_enterprise_support()
+
+        pls_mismatches: list[PlsMismatch] = []
+        if pls_in_order != report_has_enterprise:
+            pls_mismatches.append(
+                PlsMismatch(
+                    agreement_id=agreement.get("id", ""),
+                    pls_in_order=pls_in_order,
+                    report_has_enterprise=report_has_enterprise,
+                )
+            )
+
+        if report_has_enterprise:
             all_lines.extend(
                 PlSChargeManager().process(
                     self._pls_charge_percentage,
@@ -137,9 +147,8 @@ class AgreementJournalGenerator:
                 )
             )
 
-        context = ReportContext.from_contexts(self._auth_context, journal_details)
         report_rows = generate_billing_report_rows(
-            context=context,
+            context=ReportContext.from_contexts(self._auth_context, journal_details),
             usage_result=usage_result,
             organization_invoice=organization_invoice,
         )
@@ -148,16 +157,16 @@ class AgreementJournalGenerator:
             lines=all_lines,
             report=usage_result.reports,
             billing_report_rows=report_rows,
+            pls_mismatches=pls_mismatches,
         )
 
     def _generate_usage_lines(
         self,
-        agreement: dict,
         usage_result: OrganizationUsageResult,
         journal_details: JournalDetails,
         organization_invoice,
     ) -> list[JournalLine]:
-        is_pls = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
+        is_pls = usage_result.has_enterprise_support()
         line_generator = JournalLineGenerator(is_pls=is_pls)
 
         lines: list[JournalLine] = []

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
@@ -117,7 +117,7 @@ class AuthorizationJournalGenerator:
         agreement: dict,
         result: AuthorizationJournalResult,
     ) -> None:
-        agreement_id = agreement.get("id")
+        agreement_id = agreement.get("id", "")
         try:
             agreement_result = generator.run(agreement)
         except Exception as exc:
@@ -133,6 +133,8 @@ class AuthorizationJournalGenerator:
             result.reports_by_agreement[agreement_id] = agreement_result.report
         if agreement_result.billing_report_rows:
             result.billing_report_rows.extend(agreement_result.billing_report_rows)
+        if agreement_result.pls_mismatches:
+            result.pls_mismatches.extend(agreement_result.pls_mismatches)
 
     def _apply_pma_usage_to_report(
         self,

--- a/swo_aws_extension/flows/jobs/billing_journal/models/journal_result.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/journal_result.py
@@ -23,12 +23,32 @@ class BillingReportRow:
 
 
 @dataclass
+class PlsMismatch:
+    """Records a PLS mismatch between order parameter and usage report."""
+
+    agreement_id: str
+    pls_in_order: bool
+    report_has_enterprise: bool
+
+    @property
+    def description(self) -> str:
+        """Description of the mismatch for reporting purposes."""
+        param_label = "PLS" if self.pls_in_order else "Resold Support"
+        report_label = "has" if self.report_has_enterprise else "does not have"
+        return (
+            f"Agreement {self.agreement_id}: parameter={param_label} "
+            f"but report {report_label} 'AWS Support (Enterprise)'."
+        )
+
+
+@dataclass
 class AgreementJournalResult:
     """Result of generating an agreement journal."""
 
     lines: list[JournalLine] = field(default_factory=list)
     report: OrganizationReport | None = None
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
+    pls_mismatches: list[PlsMismatch] = field(default_factory=list)
 
 
 @dataclass
@@ -38,3 +58,4 @@ class AuthorizationJournalResult:
     lines: list[JournalLine] = field(default_factory=list)
     reports_by_agreement: dict[str, OrganizationReport] = field(default_factory=dict)
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
+    pls_mismatches: list[PlsMismatch] = field(default_factory=list)

--- a/swo_aws_extension/flows/jobs/billing_journal/models/usage.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/usage.py
@@ -68,3 +68,10 @@ class OrganizationUsageResult:
 
     reports: OrganizationReport
     usage_by_account: dict[str, AccountUsage] = field(default_factory=dict)
+
+    def has_enterprise_support(self) -> bool:
+        """Check if any account has 'AWS Support (Enterprise)' in its metrics."""
+        return any(
+            account.get_metrics_by_service("AWS Support (Enterprise)")
+            for account in self.usage_by_account.values()
+        )

--- a/tests/flows/jobs/billing_journal/generators/test_agreement.py
+++ b/tests/flows/jobs/billing_journal/generators/test_agreement.py
@@ -133,6 +133,7 @@ def test_run(
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()
     mock_usage_result.usage_by_account = {"ACC-1": mock_account_usage}
+    mock_usage_result.has_enterprise_support.return_value = True
     mock_usage_generator.run.return_value = mock_usage_result
     mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
     mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
@@ -180,6 +181,7 @@ def test_run_without_pls(
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()
     mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_result.has_enterprise_support.return_value = False
     mock_usage_generator.run.return_value = mock_usage_result
     mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
     mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
@@ -336,6 +338,7 @@ def test_run_processes_when_transfer_started_on_billing_start(
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()
     mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_result.has_enterprise_support.return_value = False
     mock_usage_generator.run.return_value = mock_usage_result
     mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
     mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
@@ -353,3 +356,95 @@ def test_run_processes_when_transfer_started_on_billing_start(
     mock_invoice_generator.run.assert_called_once()
     mock_usage_generator.run.assert_called_once()
     assert result.lines is not None
+
+
+def test_pls_mismatch_param_pls_but_no_enterprise_in_report(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    mock_line_generator_cls,
+    mock_extra_discounts_manager_cls,
+    mock_pls_charge_manager_cls,
+):
+    """When param says PLS but report has no Enterprise Support, record mismatch."""
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
+    agreement = _build_agreement(support_type="PartnerLedSupport")
+    mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
+    mock_generator_instance.generate.return_value = []
+    mock_line_generator_cls.return_value = mock_generator_instance
+    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
+    mock_discounts_instance.process.return_value = []
+    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
+    mock_usage_result.reports = OrganizationReport()
+    mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_result.has_enterprise_support.return_value = False
+    mock_usage_generator.run.return_value = mock_usage_result
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
+        invoice=OrganizationInvoice(),
+    )
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)  # act
+
+    assert len(result.pls_mismatches) == 1
+    assert result.pls_mismatches[0].pls_in_order is True
+    assert result.pls_mismatches[0].report_has_enterprise is False
+    mock_pls_charge_manager_cls.assert_not_called()
+
+
+def test_pls_mismatch_param_resold_but_enterprise_in_report(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    mock_line_generator_cls,
+    mock_extra_discounts_manager_cls,
+    mock_pls_charge_manager_cls,
+):
+    """When param says Resold but report has Enterprise Support, record mismatch and apply PLS."""
+    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
+    agreement = _build_agreement(support_type="ResoldSupport")
+    mock_journal_line = mocker.MagicMock(spec=JournalLine)
+    mock_pls_line = mocker.MagicMock(spec=JournalLine)
+    mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
+    mock_generator_instance.generate.return_value = [mock_journal_line]
+    mock_line_generator_cls.return_value = mock_generator_instance
+    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
+    mock_discounts_instance.process.return_value = []
+    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
+    mock_pls_instance = mocker.MagicMock(spec=PlSChargeManager)
+    mock_pls_instance.process.return_value = [mock_pls_line]
+    mock_pls_charge_manager_cls.return_value = mock_pls_instance
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
+    mock_usage_result.reports = OrganizationReport()
+    mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_result.has_enterprise_support.return_value = True
+    mock_usage_generator.run.return_value = mock_usage_result
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
+        invoice=OrganizationInvoice(),
+    )
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)  # act
+
+    assert len(result.pls_mismatches) == 1
+    assert result.pls_mismatches[0].pls_in_order is False
+    assert result.pls_mismatches[0].report_has_enterprise is True
+    mock_pls_instance.process.assert_called_once()
+    assert mock_pls_line in result.lines

--- a/tests/flows/jobs/billing_journal/generators/test_authorization.py
+++ b/tests/flows/jobs/billing_journal/generators/test_authorization.py
@@ -18,6 +18,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AgreementJournalResult,
     AuthorizationJournalResult,
     BillingReportRow,
+    PlsMismatch,
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.usage import OrganizationReport
 
@@ -156,6 +157,31 @@ def test_includes_report_in_result(
 
     assert result.reports_by_agreement == {"AGR-1": report}
     assert result.billing_report_rows == [mock_row]
+
+
+def test_includes_pls_mismatches_in_result(
+    mocker,
+    mock_context,
+    mock_get_agreements,
+    mock_agreement_generator_cls,
+    mock_usage_generator_cls,
+    mock_invoice_generator_cls,
+    mock_aws_client_cls,
+    authorization,
+):
+    mismatch = PlsMismatch(agreement_id="AGR-1", pls_in_order=True, report_has_enterprise=False)
+    mock_get_agreements.return_value = [{"id": "AGR-1"}]
+    mock_journal_line = mocker.MagicMock(spec=JournalLine)
+    mock_agr_gen = mocker.MagicMock(spec=AgreementJournalGenerator)
+    mock_agr_gen.run.return_value = AgreementJournalResult(
+        lines=[mock_journal_line], pls_mismatches=[mismatch]
+    )
+    mock_agreement_generator_cls.return_value = mock_agr_gen
+    generator = AuthorizationJournalGenerator(mock_context)
+
+    result = generator.run(authorization)
+
+    assert result.pls_mismatches == [mismatch]
 
 
 def test_pma_usage_included_in_report_rows(

--- a/tests/flows/jobs/billing_journal/models/test_journal_result.py
+++ b/tests/flows/jobs/billing_journal/models/test_journal_result.py
@@ -1,0 +1,41 @@
+import pytest
+
+from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import PlsMismatch
+
+
+@pytest.mark.parametrize(
+    ("pls_in_order", "report_has_enterprise", "expected"),
+    [
+        (
+            True,
+            True,
+            "Agreement AGR-1: parameter=PLS but report has 'AWS Support (Enterprise)'.",
+        ),
+        (
+            True,
+            False,
+            "Agreement AGR-1: parameter=PLS but report does not have 'AWS Support (Enterprise)'.",
+        ),
+        (
+            False,
+            True,
+            "Agreement AGR-1: parameter=Resold Support but report has 'AWS Support (Enterprise)'.",
+        ),
+        (
+            False,
+            False,
+            (
+                "Agreement AGR-1: parameter=Resold Support but report does not have 'AWS Support "
+                "(Enterprise)'."
+            ),
+        ),
+    ],
+)
+def test_pls_mismatch_description(pls_in_order, report_has_enterprise, expected):
+    result = PlsMismatch(
+        agreement_id="AGR-1",
+        pls_in_order=pls_in_order,
+        report_has_enterprise=report_has_enterprise,
+    )
+
+    assert result.description == expected

--- a/tests/flows/jobs/billing_journal/models/test_usage.py
+++ b/tests/flows/jobs/billing_journal/models/test_usage.py
@@ -137,3 +137,34 @@ def test_organization_usage_result(metric):
     assert result.reports == report
     assert "ACT-1" in result.usage_by_account
     assert len(result.usage_by_account["ACT-1"].metrics) == 1
+
+
+def test_has_enterprise_support_true():
+    account_usage = AccountUsage(
+        metrics=[
+            ServiceMetric(
+                service_name="AWS Support (Enterprise)",
+                record_type="Usage",
+            ),
+        ]
+    )
+    usage_result = OrganizationUsageResult(
+        reports=OrganizationReport(),
+        usage_by_account={"ACT-1": account_usage},
+    )
+
+    result = usage_result.has_enterprise_support()  # act
+
+    assert result is True
+
+
+def test_has_enterprise_support_false(metric):
+    account_usage = AccountUsage(metrics=[metric])
+    usage_result = OrganizationUsageResult(
+        reports=OrganizationReport(),
+        usage_by_account={"ACT-1": account_usage},
+    )
+
+    result = usage_result.has_enterprise_support()  # act
+
+    assert result is False

--- a/tests/flows/jobs/billing_journal/test_billing_journal_service.py
+++ b/tests/flows/jobs/billing_journal/test_billing_journal_service.py
@@ -17,6 +17,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import (
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AuthorizationJournalResult,
     BillingReportRow,
+    PlsMismatch,
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.usage import OrganizationReport
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
@@ -254,6 +255,30 @@ def test_dry_run_skips_upload_with_empty_reports(
     service.run()  # act
 
     mock_journal_manager_cls.assert_not_called()
+
+
+def test_pls_mismatch_sends_warning(
+    mocker, mock_context, mock_get_authorizations, mock_auth_generator_cls
+):
+    mock_context.dry_run = False
+    authorization = {"id": "AUTH-1"}
+    mock_get_authorizations.return_value = [authorization]
+    mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
+    mock_line = mocker.MagicMock(spec=JournalLine)
+    mismatch = PlsMismatch(agreement_id="AGR-1", pls_in_order=True, report_has_enterprise=False)
+    mock_auth_gen.run.return_value = AuthorizationJournalResult(
+        lines=[mock_line], pls_mismatches=[mismatch]
+    )
+    mock_auth_generator_cls.return_value = mock_auth_gen
+    mocker.patch(f"{MODULE}.JournalManager", autospec=True)
+    service = BillingJournalService(mock_context)
+
+    service.run()  # act
+
+    mock_context.notifier.send_warning.assert_called_once_with(
+        title="PLS Mismatch Summary",
+        text=f"1 agreement(s) with PLS mismatch:\n\n• {mismatch.description}",
+    )
 
 
 def test_dry_run_skips_upload_with_empty_report_data(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Fix `BillingJournalService` to evaluate PLS eligibility from the AWS account state rather than ordering parameters alone, preventing incorrect PLS enablement for agreements where the account does not qualify.

## Additional changes

- **Lint fixes**: resolve WPS210 (`run()` had 7 local variables > 5) and WPS214 (`BillingJournalService` had 9 methods > 7) by extracting dry-run logging helpers as module-level functions.
- **Test coverage**: achieve 100 % coverage for `swo_aws_extension/flows/jobs/billing_journal/` — adds `test_journal_result.py` for `PlsMismatch.description`, covers the `pls_mismatches` propagation branch in the authorization generator, and the `send_warning` PLS mismatch summary path in the service.

## Testing

`make check-all` passes — 986 tests, all lint checks and uv lock check clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20916](https://softwareone.atlassian.net/browse/MPT-20916)

- Fix BillingJournalService so PLS eligibility is determined from AWS account state (usage report) instead of ordering parameters, preventing incorrect PLS enablement.
- Add PlsMismatch dataclass and extend AgreementJournalResult with pls_mismatches to record discrepancies between ordered PLS and report enterprise support.
- Propagate pls_mismatches from agreement → authorization → billing service and consolidate/send a single "PLS Mismatch Summary" warning containing all mismatch descriptions.
- Add OrganizationUsageResult.has_enterprise_support() to detect "AWS Support (Enterprise)" in usage data.
- Move dry-run logging helpers to module-level functions and extract journal aggregation/notification into _process_journal_results() to resolve WPS210/WPS214 lint issues.
- Tests: new and updated unit tests to cover PlsMismatch.description, mismatch propagation, send_warning behavior, and has_enterprise_support(); reach 100% coverage for swo_aws_extension/flows/jobs/billing_journal/ and make check-all pass (986 tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20916]: https://softwareone.atlassian.net/browse/MPT-20916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ