### PR TITLE
MPT-20106 add external integrations documentation

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -22,6 +22,17 @@ This file documents repository-specific documentation rules only.
 - [`contributing.md`](contributing.md): repository-specific development workflow
 - [`testing.md`](testing.md): testing strategy and command mapping
 - [`migrations.md`](migrations.md): migration workflow and migration-specific constraints
+- [`external-integrations.md`](external-integrations.md): index of all external services and APIs
+- [`external/cloud-orchestrator.md`](external/cloud-orchestrator.md): Cloud Orchestrator API
+- [`external/ccp.md`](external/ccp.md): CCP Platform (OpenID secret rotation)
+- [`external/service-now.md`](external/service-now.md): Service-Now CRM ticketing
+- [`external/finops.md`](external/finops.md): FinOps FFC Operations API
+- [`external/cco.md`](external/cco.md): CCO API (Contract Creation Online)
+- [`external/service-provisioning.md`](external/service-provisioning.md): Services Provisioning API
+- [`external/azure-blob-storage.md`](external/azure-blob-storage.md): Azure Blob Storage
+- [`external/confluence.md`](external/confluence.md): Confluence API
+- [`external/ms-teams.md`](external/ms-teams.md): MS Teams notifications
+- [`external/aws-ses.md`](external/aws-ses.md): AWS SES email
 
 ## Documentation Change Rule
 

--- a/docs/external-integrations.md
+++ b/docs/external-integrations.md
@@ -1,0 +1,24 @@
+# External Integrations
+
+This document is the index of all external services and APIs integrated with the AWS extension.
+
+Each integration document covers: purpose, authentication mechanism, required environment variables, and available operations.
+
+## Integrations
+
+| Service | Purpose | Auth Mechanism | Document |
+| --- | --- | --- | --- |
+| [Cloud Orchestrator](external/cloud-orchestrator.md) | AWS customer onboarding, bootstrap role validation, deployment status | OAuth 2.0 (OpenID Bearer) | [cloud-orchestrator.md](external/cloud-orchestrator.md) |
+| [CCP Platform](external/ccp.md) | Monthly OpenID client secret rotation via Azure AD | OAuth 2.0 Client Credentials | [ccp.md](external/ccp.md) |
+| [Service-Now (CRM)](external/service-now.md) | Customer service request creation and tracking | OAuth 2.0 Client Credentials | [service-now.md](external/service-now.md) |
+| [FinOps (FFC)](external/finops.md) | Billing entitlement and datasource management | Self-signed JWT (HS256) | [finops.md](external/finops.md) |
+| [CCO API](external/cco.md) | Contract registration in Navision | OAuth 2.0 Client Credentials | [cco.md](external/cco.md) |
+| [Service Provisioning](external/service-provisioning.md) | Customer service onboarding from CCO contracts | OAuth 2.0 Client Credentials | [service-provisioning.md](external/service-provisioning.md) |
+| [Azure Blob Storage](external/azure-blob-storage.md) | Report upload and SAS URL generation | Azure Storage Connection String | [azure-blob-storage.md](external/azure-blob-storage.md) |
+| [Confluence](external/confluence.md) | Billing report attachment to Confluence pages | Basic Auth (username + API token) | [confluence.md](external/confluence.md) |
+| [MS Teams](external/ms-teams.md) | Internal operational notifications | Incoming Webhook (no auth) | [ms-teams.md](external/ms-teams.md) |
+| [AWS SES](external/aws-ses.md) | Customer-facing email delivery | AWS Access Key + Secret Key | [aws-ses.md](external/aws-ses.md) |
+
+## Code Location
+
+All integration clients live under [`swo_aws_extension/swo/`](../swo_aws_extension/swo), grouped by service name. The [`swo_aws_extension/swo/base_client.py`](../swo_aws_extension/swo/base_client.py) `OAuthSessionClient` is the shared base for OAuth 2.0 integrations.

--- a/docs/external/aws-ses.md
+++ b/docs/external/aws-ses.md
@@ -1,0 +1,31 @@
+# AWS SES
+
+Delivers customer-facing emails from a verified SoftwareOne sender address. Used for order-related notifications and feature deployment alerts where direct email delivery is required.
+
+## Authentication
+
+AWS access key credentials passed directly to the `boto3` SES client. No OAuth flow is involved.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_AWS_SES_CREDENTIALS` | Credentials in `AccessKey:SecretKey` format |
+| `EXT_AWS_SES_REGION` | AWS region where SES is configured (e.g., `eu-west-1`) |
+| `EXT_EMAIL_NOTIFICATIONS_ENABLED` | Feature toggle: `1` enables sending, `0` skips silently |
+| `EXT_EMAIL_NOTIFICATIONS_SENDER` | Verified sender address shown in the `From` field |
+| `EXT_DEPLOY_SERVICES_FEATURE_RECIPIENTS` | Comma-separated recipient list for deploy-services notifications |
+
+The `EXT_AWS_SES_CREDENTIALS` value is split on `:` at runtime: the first segment becomes `aws_access_key_id` and the second `aws_secret_access_key`.
+
+## Operations
+
+| Operation | boto3 Call | Description |
+| --- | --- | --- |
+| Send Email | `ses.send_email(Source, Destination, Message)` | Sends an HTML email to one or more recipients; returns `False` on any boto3 error |
+
+`EmailNotificationManager.send_email()` returns `True` on success and `False` on failure. When `EXT_EMAIL_NOTIFICATIONS_ENABLED` is `0`, it returns `False` immediately without making any API call.
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/notifications/email.py`](../../swo_aws_extension/swo/notifications/email.py)

--- a/docs/external/azure-blob-storage.md
+++ b/docs/external/azure-blob-storage.md
@@ -1,0 +1,30 @@
+# Azure Blob Storage
+
+Stores generated binary reports (billing Excel files, invitation reports) in Azure object storage and produces time-limited SAS URLs for secure external delivery to customers.
+
+## Authentication
+
+Authenticated via the Azure Python SDK using a full Storage Account Connection String. No bearer token flow is involved; the SDK derives credentials directly from `EXT_AZURE_STORAGE_CONNECTION_STRING`.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_AZURE_STORAGE_CONNECTION_STRING` | Full Azure Storage Account connection string |
+| `EXT_AZURE_STORAGE_CONTAINER` | Root container name for uploaded blobs |
+| `EXT_AZURE_STORAGE_SAS_EXPIRY_DAYS` | Expiry period in days for generated SAS tokens |
+| `EXT_REPORT_INVITATIONS_FOLDER` | Blob folder path for invitation reports |
+| `EXT_REPORT_BILLING_FOLDER` | Blob folder path for billing reports |
+
+## Operations
+
+| Operation | SDK Method | Description |
+| --- | --- | --- |
+| Upload Blob | `BlobClient.upload_blob(data, overwrite=True)` | Uploads binary data to the specified blob name, overwriting any existing blob |
+| Generate SAS URL | `generate_blob_sas(...)` | Generates a read-only SAS URL valid for `EXT_AZURE_STORAGE_SAS_EXPIRY_DAYS` days |
+
+The `AzureBlobUploader.upload_and_get_sas_url()` method combines both operations: it uploads the file and immediately returns the SAS URL.
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/azure_blob_uploader.py`](../../swo_aws_extension/swo/azure_blob_uploader.py)

--- a/docs/external/cco.md
+++ b/docs/external/cco.md
@@ -1,0 +1,58 @@
+# CCO API (Contract Creation Online)
+
+Registers and retrieves commercial contracts within Navision (SoftwareOne's internal ERP). The extension creates a CCO contract when a new AWS customer subscription is confirmed, and queries existing contracts when processing Master Payer Account (MPA) related orders.
+
+## Authentication
+
+OAuth 2.0 Client Credentials. The `OAuthSessionClient` base class refreshes the bearer token transparently before each request.
+
+```http
+POST <EXT_CCO_OAUTH_URL>
+Content-Type: application/x-www-form-urlencoded
+
+client_id=<EXT_CCO_CLIENT_ID>
+client_secret=<EXT_CCO_CLIENT_SECRET>
+grant_type=client_credentials
+audience=<EXT_CCO_AUDIENCE>
+```
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_CCO_API_BASE_URL` | Base URL for the CCO API |
+| `EXT_CCO_OAUTH_URL` | OAuth token endpoint |
+| `EXT_CCO_CLIENT_ID` | OAuth client ID |
+| `EXT_CCO_CLIENT_SECRET` | OAuth client secret |
+| `EXT_CCO_AUDIENCE` | Token audience parameter |
+| `EXT_CCO_MANUFACTURER_CODE` | Manufacturer code injected into every contract creation request |
+
+## Operations
+
+| Operation | Method | Endpoint | Description |
+| --- | --- | --- | --- |
+| Create CCO Contract | `POST` | `v1/contracts` | Creates a new contract; returns `{"contractInsert": {"contractNumber": "CCO-12345"}}` |
+| Get All MPA Contracts | `GET` | `v1/contracts/all/{mpa_id}` | Returns all contracts for a Master Payer Account |
+| Get Contract by ID | `GET` | `v1/contracts/{cco_id}` | Returns a single contract, or `null` if not found (`404`) |
+
+Example create payload:
+
+```json
+{
+  "softwareOneLegalEntity": "SWO_CH_01",
+  "contractNumberReference": "123456789012",
+  "customerNumber": "CUST-123",
+  "customerReference": "CUST-REF-999",
+  "enrollmentNumber": "ENR-456",
+  "manufacturerCode": "SWOTS",
+  "startDate": "2024-01-01T00:00:00",
+  "currencyCode": "USD",
+  "licenseModel": "CAW-0046",
+  "contractCategory": "CLOUD-BASI"
+}
+```
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/cco/client.py`](../../swo_aws_extension/swo/cco/client.py)
+Models: [`swo_aws_extension/swo/cco/models.py`](../../swo_aws_extension/swo/cco/models.py)

--- a/docs/external/ccp.md
+++ b/docs/external/ccp.md
@@ -1,0 +1,49 @@
+# CCP Platform
+
+The CCP Platform is used exclusively to rotate the OpenID client secret that expires on a monthly basis. The extension calls the CCP API to retrieve a fresh `clientSecret`, then stores it in Azure Key Vault for use by the `OpenIDClient`.
+
+## Authentication
+
+OAuth 2.0 Client Credentials. The extension authenticates against the CCP OAuth endpoint using `EXT_CCP_OAUTH_CREDENTIALS_SCOPE` (a different scope than the one used for Cloud Orchestrator).
+
+```http
+POST <EXT_CCP_OAUTH_URL>
+Content-Type: application/x-www-form-urlencoded
+
+client_id=<EXT_CCP_CLIENT_ID>
+client_secret=<CCP_KEY_VAULT_SECRET>
+grant_type=client_credentials
+scope=<EXT_CCP_OAUTH_CREDENTIALS_SCOPE>
+```
+
+The `client_secret` is retrieved from Azure Key Vault using `EXT_CCP_KEY_VAULT_SECRET_NAME` before each token request.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_CCP_API_BASE_URL` | Base URL of the CCP platform API |
+| `EXT_CCP_OAUTH_URL` | OAuth token endpoint (Azure AD) |
+| `EXT_CCP_CLIENT_ID` | OAuth client ID |
+| `EXT_CCP_KEY_VAULT_SECRET_NAME` | Azure Key Vault secret name holding the client secret |
+| `EXT_CCP_OAUTH_CREDENTIALS_SCOPE` | OAuth scope used for CCP secret retrieval |
+
+## Operations
+
+| Operation | Method | Endpoint | Description |
+| --- | --- | --- | --- |
+| Retrieve AD Secret | `GET` | `/process/lighthouse/ad/retrieve/secret/{client_id}?api-version=v1` | Returns `{"clientSecret": "..."}` for the given client ID |
+
+## Secret Rotation Flow
+
+1. `OpenIDClient` detects the current secret is expired or missing.
+2. `CCPClient.refresh_secret()` acquires a temporary token using `EXT_CCP_OAUTH_CREDENTIALS_SCOPE`.
+3. It calls the CCP secret endpoint to get the new `clientSecret`.
+4. `KeyVaultManager.save_secret()` stores the new secret under `EXT_CCP_KEY_VAULT_SECRET_NAME`.
+5. Subsequent OAuth token requests use the refreshed secret from Key Vault.
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/ccp/client.py`](../../swo_aws_extension/swo/ccp/client.py)
+OpenID client: [`swo_aws_extension/swo/openid/client.py`](../../swo_aws_extension/swo/openid/client.py)
+Key Vault manager: [`swo_aws_extension/swo/key_vault.py`](../../swo_aws_extension/swo/key_vault.py)

--- a/docs/external/cloud-orchestrator.md
+++ b/docs/external/cloud-orchestrator.md
@@ -1,0 +1,41 @@
+# Cloud Orchestrator
+
+Manages AWS customer onboarding processes and bootstrap role deployments. The extension uses this API to trigger customer onboarding, verify bootstrap role readiness, and poll deployment execution status.
+
+## Authentication
+
+OAuth 2.0 Client Credentials using an OpenID Bearer token. The client fetches a token from the CCP OAuth endpoint using the `EXT_AWS_OPENID_SCOPE` scope, then attaches it to every request.
+
+```http
+POST <EXT_CCP_OAUTH_URL>
+Content-Type: application/x-www-form-urlencoded
+
+client_id=<EXT_CCP_CLIENT_ID>
+client_secret=<CCP_KEY_VAULT_SECRET>
+grant_type=client_credentials
+scope=<EXT_AWS_OPENID_SCOPE>
+```
+
+The `client_secret` is not stored in environment variables — it is retrieved at runtime from Azure Key Vault using `EXT_CCP_KEY_VAULT_SECRET_NAME`. The `OpenIDClient` in [`swo_aws_extension/swo/openid/client.py`](../../swo_aws_extension/swo/openid/client.py) handles token refresh automatically.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_CLOUD_ORCHESTRATOR_API_BASE_URL` | Base URL for the Cloud Orchestrator API |
+| `EXT_CCP_OAUTH_URL` | OAuth token endpoint (Azure AD) |
+| `EXT_CCP_CLIENT_ID` | OAuth client ID |
+| `EXT_CCP_KEY_VAULT_SECRET_NAME` | Azure Key Vault secret name holding the client secret |
+| `EXT_AWS_OPENID_SCOPE` | OAuth scope for Cloud Orchestrator requests |
+
+## Operations
+
+| Operation | Method | Endpoint | Description |
+| --- | --- | --- | --- |
+| Check Bootstrap Role | `GET` | `/api/v1/bootstrap-role/check?target_account_id={id}` | Returns `{"deployed": true/false, ...}` for the target AWS account |
+| Onboard Customer | `POST` | `/api/v1/marketplace/onboard` | Triggers onboarding and returns `{"execution_arn": "..."}` |
+| Get Deployment Status | `GET` | `/api/v1/deployments/execution-arn/{execution_arn}` | Returns `{"status": "succeeded/failed/running"}` |
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/cloud_orchestrator/client.py`](../../swo_aws_extension/swo/cloud_orchestrator/client.py)

--- a/docs/external/confluence.md
+++ b/docs/external/confluence.md
@@ -1,0 +1,28 @@
+# Confluence
+
+Attaches generated billing journals and reports to internal Confluence workspace pages. Used by the pending-orders reporting job to upload Excel files directly to a target Confluence page.
+
+## Authentication
+
+Basic Authentication using a service account username and a Personal Access Token (PAT). The Atlassian Python SDK handles the `Authorization: Basic <base64(user:token)>` header automatically when `cloud=True` is set.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_CONFLUENCE_BASE_URL` | Base URL of the Confluence instance |
+| `EXT_CONFLUENCE_USER` | Service account email address |
+| `EXT_CONFLUENCE_TOKEN` | Atlassian Personal Access Token |
+| `EXT_PENDING_ORDERS_INFORMATION_REPORT_PAGE_ID` | Confluence page ID where pending-orders reports are attached |
+
+## Operations
+
+| Operation | SDK Method | Endpoint | Description |
+| --- | --- | --- | --- |
+| Attach Document | `Confluence.attach_content(...)` | `POST /rest/api/content/{page_id}/child/attachment` | Uploads binary content as a `multipart/form-data` attachment to the specified page |
+
+The `ConfluenceClient.attach_content()` method returns `True` on success and `False` on any HTTP or connection error, logging the exception without re-raising.
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/confluence_client.py`](../../swo_aws_extension/swo/confluence_client.py)

--- a/docs/external/finops.md
+++ b/docs/external/finops.md
@@ -1,0 +1,55 @@
+# FinOps (FFC Operations)
+
+Manages billing entitlements that map AWS datasources to external affiliates. The extension creates an entitlement when a new customer subscription is activated, and terminates or deletes it when the subscription ends.
+
+## Authentication
+
+Self-signed JSON Web Tokens (JWT). No external token authority is involved. The `FinOpsClient` generates and signs a short-lived JWT (5-minute expiry) using the shared secret before each request.
+
+```json
+{
+  "sub": "<EXT_FFC_SUB>",
+  "exp": <now + 5 minutes>,
+  "nbf": <now>,
+  "iat": <now>
+}
+```
+
+Token is signed with `HS256` using `EXT_FFC_OPERATIONS_SECRET` and attached via:
+
+```http
+Authorization: Bearer <generated_jwt>
+```
+
+The client checks token expiry before each request and re-generates when expired.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_FFC_OPERATIONS_API_BASE_URL` | FFC Operations API base URL |
+| `EXT_FFC_SUB` | Subject identifier used in the JWT `sub` claim |
+| `EXT_FFC_OPERATIONS_SECRET` | Secret used to sign the JWT (HS256) |
+
+## Operations
+
+| Operation | Method | Endpoint | Description |
+| --- | --- | --- | --- |
+| Create Entitlement | `POST` | `/entitlements` | Creates an entitlement for a datasource/affiliate pair |
+| Get Entitlement by Datasource | `GET` | `/entitlements?datasource_id={id}&limit=1` | Returns the entitlement linked to a datasource, or `null` |
+| Terminate Entitlement | `POST` | `/entitlements/{id}/terminate` | Marks the entitlement as terminated |
+| Delete Entitlement | `DELETE` | `/entitlements/{id}` | Permanently removes the entitlement (`204 No Content`) |
+
+### Create Entitlement Payload
+
+```json
+{
+  "name": "AWS",
+  "affiliate_external_id": "<affiliate_id>",
+  "datasource_id": "<datasource_id>"
+}
+```
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/finops/client.py`](../../swo_aws_extension/swo/finops/client.py)

--- a/docs/external/ms-teams.md
+++ b/docs/external/ms-teams.md
@@ -1,0 +1,30 @@
+# MS Teams
+
+Sends operational notifications to internal engineering channels. Used throughout the extension to report errors, warnings, and successes during order processing, secret rotation, and integration failures.
+
+## Authentication
+
+No authentication. Uses an Incoming Webhook URL that posts directly to a specific Teams channel. The webhook URL itself acts as the secret.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_MSTEAMS_WEBHOOK_URL` | Incoming Webhook URL for the target Teams channel |
+
+## Operations
+
+The `TeamsNotificationManager` sends Connector Card messages via `pymsteams`. All methods accept `title`, `text`, an optional `Button`, and an optional `FactsSection`.
+
+| Method | Color | Prefix | Use Case |
+| --- | --- | --- | --- |
+| `send_warning(...)` | Orange | ☢ | Non-critical issues that need attention |
+| `send_success(...)` | Green | ✅ | Successful completions |
+| `send_error(...)` | Red | 💣 | Recoverable errors |
+| `send_exception(...)` | Dark Red | 🔥 | Unhandled exceptions |
+
+The `notify_one_time_error()` helper ensures a given `(title, message)` pair is sent at most once per process lifetime.
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/notifications/teams.py`](../../swo_aws_extension/swo/notifications/teams.py)

--- a/docs/external/service-now.md
+++ b/docs/external/service-now.md
@@ -1,0 +1,43 @@
+# Service-Now (CRM)
+
+Automates the creation and lifecycle management of Customer Service Requests linked to AWS orders. The extension creates a ticket when an order enters a specific phase, adds comments as the order progresses, and reads the ticket status to decide the next step.
+
+## Authentication
+
+OAuth 2.0 Client Credentials. Every request carries a `Bearer` token, an `x-api-version` header, and an `x-correlation-id` header set to the MPT order ID.
+
+```http
+POST <EXT_CRM_OAUTH_URL>
+Content-Type: application/x-www-form-urlencoded
+
+client_id=<EXT_CRM_CLIENT_ID>
+client_secret=<EXT_CRM_CLIENT_SECRET>
+grant_type=client_credentials
+audience=<EXT_CRM_AUDIENCE>
+```
+
+The `OAuthSessionClient` base class in [`swo_aws_extension/swo/base_client.py`](../../swo_aws_extension/swo/base_client.py) refreshes the token transparently. The CRM client additionally injects `x-api-version: 3.0.0` on every request.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_CRM_API_BASE_URL` | Base URL for the Service-Now API |
+| `EXT_CRM_OAUTH_URL` | OAuth token endpoint |
+| `EXT_CRM_CLIENT_ID` | OAuth client ID |
+| `EXT_CRM_CLIENT_SECRET` | OAuth client secret |
+| `EXT_CRM_AUDIENCE` | Token audience parameter |
+
+## Operations
+
+| Operation | Method | Endpoint | Description |
+| --- | --- | --- | --- |
+| Create Service Request | `POST` | `/ticketing/ServiceRequests` | Creates a new ticket; returns `{"id": "CS0004728"}` |
+| Get Service Request | `GET` | `/ticketing/ServiceRequests/{id}` | Returns service request details |
+| Add Comment | `POST` | `/ticketing/ServiceRequests/{id}/comments` | Appends a comment with `{"value": "..."}` |
+
+All operations send `Authorization: Bearer <token>`, `x-api-version: 3.0.0`, and `x-correlation-id: <mpt_order_id>`.
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/crm_service/client.py`](../../swo_aws_extension/swo/crm_service/client.py)

--- a/docs/external/service-provisioning.md
+++ b/docs/external/service-provisioning.md
@@ -1,0 +1,59 @@
+# Services Provisioning API
+
+Provisions customer service allocations in SoftwareOne's internal service management platform based on CCO contract enrollments. The extension calls this API after a CCO contract is created to onboard the customer's service contacts and return an ERP project number.
+
+## Authentication
+
+OAuth 2.0 Client Credentials. The `OAuthSessionClient` base class refreshes the bearer token transparently before each request. Every request also carries an `x-api-version: 1.0` header.
+
+```http
+POST <EXT_SVC_PROVISIONING_OAUTH_URL>
+Content-Type: application/x-www-form-urlencoded
+
+client_id=<EXT_SVC_PROVISIONING_CLIENT_ID>
+client_secret=<EXT_SVC_PROVISIONING_CLIENT_SECRET>
+grant_type=client_credentials
+audience=<EXT_SVC_PROVISIONING_AUDIENCE>
+```
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_SVC_PROVISIONING_API_BASE_URL` | Base URL for the Service Provisioning API |
+| `EXT_SVC_PROVISIONING_OAUTH_URL` | OAuth token endpoint |
+| `EXT_SVC_PROVISIONING_CLIENT_ID` | OAuth client ID |
+| `EXT_SVC_PROVISIONING_CLIENT_SECRET` | OAuth client secret |
+| `EXT_SVC_PROVISIONING_AUDIENCE` | Token audience parameter |
+
+## Operations
+
+| Operation | Method | Endpoint | Description |
+| --- | --- | --- | --- |
+| Onboard Service | `POST` | `service-provisioning/api/serviceonboarding` | Onboards a CCO contract and returns `{"erpProjectNo": "PRJ-9999"}` |
+
+Example onboard payload:
+
+```json
+{
+  "erpClientId": "SWO_CH_01",
+  "contractNo": "CCO-12345",
+  "serviceDescription": "AWS Cloud",
+  "contacts": [
+    {
+      "firstName": "John",
+      "lastName": "Doe",
+      "email": "jdoe@example.com",
+      "phoneNumber": "+1234567890",
+      "languageCode": "en"
+    }
+  ]
+}
+```
+
+All operations send `Authorization: Bearer <token>` and `x-api-version: 1.0`.
+
+## Code Reference
+
+Client: [`swo_aws_extension/swo/service_provisioning/client.py`](../../swo_aws_extension/swo/service_provisioning/client.py)
+Models: [`swo_aws_extension/swo/service_provisioning/models.py`](../../swo_aws_extension/swo/service_provisioning/models.py)


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add documentation for all external services and APIs integrated with the AWS extension.

- `docs/external-integrations.md` — index table linking to all 10 service docs
- `docs/external/cloud-orchestrator.md` — AWS onboarding/bootstrap, OpenID Bearer auth via Key Vault
- `docs/external/ccp.md` — monthly OpenID secret rotation via CCP API and Key Vault
- `docs/external/service-now.md` — CRM ticketing (create/get/comment), OAuth 2.0 + correlation headers
- `docs/external/finops.md` — billing entitlements, self-signed HS256 JWT auth
- `docs/external/cco.md` — Navision contract registration, OAuth 2.0
- `docs/external/service-provisioning.md` — service onboarding after CCO, OAuth 2.0 + x-api-version
- `docs/external/azure-blob-storage.md` — blob upload + SAS URL generation
- `docs/external/confluence.md` — report attachment via Atlassian SDK, Basic Auth
- `docs/external/ms-teams.md` — Incoming Webhook notifications, 4 severity levels
- `docs/external/aws-ses.md` — email delivery via boto3, feature toggle

Each document covers: purpose, authentication mechanism, required environment variables, and available operations with endpoint and payload details. `docs/documentation.md` map updated to include all new entries.

## Why

Developers and operators had no single reference for how the extension authenticates and communicates with each external service. This closes that gap without duplicating what is already in `docs/deployment.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20106](https://softwareone.atlassian.net/browse/MPT-20106)

### Release Notes

- Added comprehensive external integrations documentation index (docs/external-integrations.md) with overview, links to per-service docs, and code location references.
- Added ten new integration docs under docs/external/:
  - Cloud Orchestrator — AWS onboarding/bootstrap, OpenID Bearer auth with OAuth 2.0 and Azure Key Vault secret retrieval
  - CCP — Monthly OpenID client-secret rotation via CCP API and Azure Key Vault
  - Service-Now — CRM ticketing (create/get/comment) using OAuth 2.0 and correlation headers
  - FinOps — Billing entitlements lifecycle with self-signed HS256 JWT auth
  - CCO API — Navision contract registration via OAuth 2.0 client-credentials
  - Service Provisioning — Service onboarding API with OAuth 2.0 and x-api-version header
  - Azure Blob Storage — Report blob upload and SAS URL generation via Azure SDK
  - Confluence — Report attachment using Atlassian SDK with Basic Auth (PAT)
  - MS Teams — Incoming Webhook notifications (4 severity levels)
  - AWS SES — Email delivery via boto3 with runtime credential parsing and feature toggle
- Updated docs/documentation.md "Current Documentation Map" to reference the new external integrations index and per-service pages.
- Each integration doc specifies purpose, authentication mechanism, required environment variables, supported operations (endpoints/payloads), and code references.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-aws-extension/pull/332)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20106]: https://softwareone.atlassian.net/browse/MPT-20106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ