### PR TITLE
MPT-21067 Change subService value to Customer Activation in ServiceNow ticket payload

### DIFF
--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -13,7 +13,7 @@ CRM_EXTERNAL_USERNAME = "mpt@marketplace.com"
 CRM_SERVICE_TYPE = "MarketPlaceServiceActivation"
 CRM_GLOBAL_EXT_USER_ID = "globalacademicExtUserId"
 CRM_REQUESTER = "Supplier.Portal"
-CRM_SUB_SERVICE = "Service Activation"
+CRM_SUB_SERVICE = "Customer Activation"
 
 BASIC_PRICING_PLAN_ARN = "arn:aws:billingconductor::aws:pricingplan/BasicPricingPlan"
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Changed the `CRM_SUB_SERVICE` constant value in `swo_aws_extension/constants.py` from `"Service Activation"` to `"Customer Activation"` so that ServiceNow tickets are routed to the correct destination group.

## Why

The ServiceNow ticket payload was using the wrong sub-service value, causing tickets to be routed to an incorrect destination group. This fix aligns the value with the expected `"Customer Activation"` label required by the target group.

## Related

- Jira: [MPT-21067](https://softwareone.atlassian.net/browse/MPT-21067)
- Parent story: [MPT-20840](https://softwareone.atlassian.net/browse/MPT-20840)

[MPT-21067]: https://softwareone.atlassian.net/browse/MPT-21067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-20840]: https://softwareone.atlassian.net/browse/MPT-20840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21067](https://softwareone.atlassian.net/browse/MPT-21067)

## Release Notes

- Update `CRM_SUB_SERVICE` in swo_aws_extension/constants.py from "Service Activation" → "Customer Activation" to ensure ServiceNow tickets are routed to the correct destination group.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-aws-extension/pull/336)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->