### PR TITLE
MPT-21079 Truncate invoice IDs to last 4 digits with overflow indicator for Navision 20-char limit

### DIFF
--- a/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
@@ -12,6 +12,33 @@ from swo_aws_extension.logger import get_logger
 
 logger = get_logger(__name__)
 SPP_DISCOUNT_DESCRIPTION = "Discount (AWS SPP Discount)"
+MAX_INVOICE_ID_LENGTH = 20
+_INVOICE_ID_SUFFIX_LENGTH = 4
+_OVERFLOW_MARKER = ".."
+_SUFFIX_PREFIX = "-"
+
+_SEPARATOR = ","
+
+
+def merge_invoice_ids(existing_id: str, new_id: str) -> str:
+    """Merge invoice IDs keeping only the unique suffix (last 4 chars) of each.
+
+    Each suffix is prefixed with ``-`` to signal truncation.
+    The result must fit within MAX_INVOICE_ID_LENGTH characters.
+    When it overflows, an ellipsis marker replaces the newest suffix.
+    """
+    if not new_id:
+        return existing_id
+    new_suffix = _SUFFIX_PREFIX + new_id[-_INVOICE_ID_SUFFIX_LENGTH:]
+    if _SEPARATOR not in existing_id:
+        existing_id = _SUFFIX_PREFIX + existing_id[-_INVOICE_ID_SUFFIX_LENGTH:]
+    candidate = _SEPARATOR.join((existing_id, new_suffix))
+    if len(candidate) <= MAX_INVOICE_ID_LENGTH:
+        return candidate
+    truncated = _SEPARATOR.join((existing_id, _OVERFLOW_MARKER))
+    if len(truncated) <= MAX_INVOICE_ID_LENGTH:
+        return truncated
+    return existing_id
 
 
 def _belongs_to_mpa(invoice: dict, mpa_account: str) -> bool:
@@ -158,7 +185,7 @@ class InvoiceGenerator:
         billing_entity = entity.get("BillingEntity", "AWS")
         if existing:
             new_id = invoice.get("InvoiceId", "")
-            merged_id = ",".join(filter(None, [existing.invoice_id, new_id]))
+            merged_id = merge_invoice_ids(existing.invoice_id, new_id)
             return InvoiceEntity(
                 invoice_id=merged_id,
                 base_currency_code=existing.base_currency_code,

--- a/tests/flows/jobs/billing_journal/generators/test_invoice.py
+++ b/tests/flows/jobs/billing_journal/generators/test_invoice.py
@@ -4,8 +4,10 @@ import pytest
 
 from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.flows.jobs.billing_journal.generators.invoice import (
+    MAX_INVOICE_ID_LENGTH,
     ExchangeRateResolver,
     InvoiceGenerator,
+    merge_invoice_ids,
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
 from swo_aws_extension.flows.jobs.billing_journal.models.invoice import (
@@ -115,9 +117,9 @@ def test_run_invoice_entity_has_correct_billing_entity(generator, mock_aws_clien
 
 def test_run_merges_entities_and_calculates_totals(generator, mock_aws_client, billing_period):
     invoices = [
-        build_invoice(invoice_id="INV-001", base_total="100.00", payment_total="95.00"),
+        build_invoice(invoice_id="2609293185", base_total="100.00", payment_total="95.00"),
         build_invoice(
-            invoice_id="INV-002",
+            invoice_id="SGIN26-350441",
             base_total="200.00",
             base_total_before_tax="180.00",
             payment_total="190.00",
@@ -129,7 +131,7 @@ def test_run_merges_entities_and_calculates_totals(generator, mock_aws_client, b
     result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
     entity = result.invoice.entities["AWS Inc.:AWS"]
-    assert entity.invoice_id == "INV-001,INV-002"
+    assert entity.invoice_id == "-3185,-0441"
     assert result.invoice.base_total_amount == Decimal("300.00")
     assert result.invoice.base_total_amount_before_tax == Decimal("270.00")
     assert result.invoice.payment_currency_total_amount == Decimal("285.00")
@@ -281,3 +283,36 @@ def test_run_falls_back_to_account_id_when_bill_source_accounts_absent(
 
     assert len(result.raw_data) == 1
     assert result.raw_data[0]["InvoiceId"] == "INV-001"
+
+
+@pytest.mark.parametrize(
+    ("existing_id", "new_id", "expected"),
+    [
+        ("2609293185", "", "2609293185"),
+        ("2609293185", "SGIN26-350441", "-3185,-0441"),
+        ("-3185,-0441", "EUINPL26-355205", "-3185,-0441,-5205"),
+        ("-3185,-0441,-5205", "NEXT26-000002", "-3185,-0441,-5205,.."),
+        ("-3185,-0441,-5205,..", "NEXT26-000003", "-3185,-0441,-5205,.."),
+    ],
+)
+def test_merge_invoice_ids(existing_id, new_id, expected):
+    result = merge_invoice_ids(existing_id, new_id)  # act
+
+    assert result == expected
+
+
+def test_merge_invoice_ids_result_never_exceeds_navision_limit(
+    generator, mock_aws_client, billing_period
+):
+    invoice_count = 10
+    invoice_id_template = "EUINPL26-3{0:05d}"
+    invoices = [
+        build_invoice(invoice_id=invoice_id_template.format(idx)) for idx in range(invoice_count)
+    ]
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")  # act
+
+    entity = result.invoice.entities["AWS Inc.:AWS"]
+    assert len(entity.invoice_id) <= MAX_INVOICE_ID_LENGTH
+    assert entity.invoice_id.endswith(",..")


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Navision rejects invoice ID fields longer than 20 characters. This fix replaces the raw comma-join of full invoice IDs with a new `merge_invoice_ids()` helper in `invoice.py`.

The helper:

- Keeps a single invoice ID as-is (no truncation needed for the single-invoice case).
- Reduces each invoice ID to its last 4 characters prefixed with `-` when multiple IDs are present.
- Joins the shortened IDs with commas.
- Appends `..` when the joined result would still exceed the 20-character Navision limit.

## Why

Parent story: MPT-21020 — AWS extension maps invoice with MPA account using BillSourceAccounts field.

When multiple invoices are consolidated into a single journal line the concatenated IDs routinely exceed 20 characters, causing Navision to reject the record.

## Testing

- Unit tests updated in `tests/flows/jobs/billing_journal/generators/test_invoice.py`.
- New cases cover: merge logic for multiple IDs, overflow truncation with `..`, the 20-char limit guarantee, and the unchanged single-invoice path.
- Run `make test` locally to verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21079](https://softwareone.atlassian.net/browse/MPT-21079)

- Added `merge_invoice_ids()` helper function to intelligently merge multiple invoice IDs while respecting Navision's 20-character field limit
- Implemented truncation strategy: individual invoice IDs reduced to last 4 characters with `-` prefix, joined with commas
- Added overflow indicator (`..`) when merged result exceeds maximum length to signal truncation
- Updated `InvoiceGenerator._build_invoice_entity` to use new merge helper instead of simple comma-concatenation
- Added supporting constants: `MAX_INVOICE_ID_LENGTH` (20), `_INVOICE_ID_SUFFIX_LENGTH` (4), `_OVERFLOW_MARKER`, `_SUFFIX_PREFIX`, `_SEPARATOR`
- Updated test suite to validate merged invoice ID format and enforce 20-character length constraint with parameterized test coverage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-aws-extension/pull/338)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21079]: https://softwareone.atlassian.net/browse/MPT-21079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ