### PR TITLE
[BACKPORT] MPT-21020 AWS extension maps invoice with MPA account using BillSourceAccounts field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = { text = "Apache-2.0 license" }
 dependencies = [
   "atlassian-python-api==4.0.*",
   "azure-storage-blob==12.28.*",
-  "boto3==1.42.*",
+  "boto3==1.43.*",
   "django==4.2.*",
   "jinja2==3.1.*",
   "markdown-it-py==4.0.*",

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
@@ -76,6 +76,7 @@ class AgreementJournalGenerator:
 
         logger.info("Generating billing journal for MPA account %s", mpa_account)
         invoice_result = self._invoice_generator.run(
+            self._auth_context.pma_account,
             mpa_account,
             self._billing_period,
             self._auth_context.currency,
@@ -87,6 +88,7 @@ class AgreementJournalGenerator:
             self._billing_period,
             organization_invoice=invoice_result.invoice,
         )
+        usage_result.reports.organization_data["INVOICES"] = invoice_result.raw_data
         logger.info("Usage generation completed for MPA account %s", mpa_account)
 
         journal_details = JournalDetails(

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
@@ -177,6 +177,7 @@ class AuthorizationJournalGenerator:
         logger.info("Generating raw usage for PMA account to include in billing report")
         pma_invoice_result = invoice_generator.run(
             auth_context.pma_account,
+            auth_context.pma_account,
             self._billing_period,
             auth_context.currency,
         )

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
@@ -12,6 +12,33 @@ from swo_aws_extension.logger import get_logger
 
 logger = get_logger(__name__)
 SPP_DISCOUNT_DESCRIPTION = "Discount (AWS SPP Discount)"
+MAX_INVOICE_ID_LENGTH = 20
+_INVOICE_ID_SUFFIX_LENGTH = 4
+_OVERFLOW_MARKER = ".."
+_SUFFIX_PREFIX = "-"
+
+_SEPARATOR = ","
+
+
+def merge_invoice_ids(existing_id: str, new_id: str) -> str:
+    """Merge invoice IDs keeping only the unique suffix (last 4 chars) of each.
+
+    Each suffix is prefixed with ``-`` to signal truncation.
+    The result must fit within MAX_INVOICE_ID_LENGTH characters.
+    When it overflows, an ellipsis marker replaces the newest suffix.
+    """
+    if not new_id:
+        return existing_id
+    new_suffix = _SUFFIX_PREFIX + new_id[-_INVOICE_ID_SUFFIX_LENGTH:]
+    if _SEPARATOR not in existing_id:
+        existing_id = _SUFFIX_PREFIX + existing_id[-_INVOICE_ID_SUFFIX_LENGTH:]
+    candidate = _SEPARATOR.join((existing_id, new_suffix))
+    if len(candidate) <= MAX_INVOICE_ID_LENGTH:
+        return candidate
+    truncated = _SEPARATOR.join((existing_id, _OVERFLOW_MARKER))
+    if len(truncated) <= MAX_INVOICE_ID_LENGTH:
+        return truncated
+    return existing_id
 
 
 def _belongs_to_mpa(invoice: dict, mpa_account: str) -> bool:
@@ -158,7 +185,7 @@ class InvoiceGenerator:
         billing_entity = entity.get("BillingEntity", "AWS")
         if existing:
             new_id = invoice.get("InvoiceId", "")
-            merged_id = ",".join(filter(None, [existing.invoice_id, new_id]))
+            merged_id = merge_invoice_ids(existing.invoice_id, new_id)
             return InvoiceEntity(
                 invoice_id=merged_id,
                 base_currency_code=existing.base_currency_code,

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/invoice.py
@@ -14,6 +14,24 @@ logger = get_logger(__name__)
 SPP_DISCOUNT_DESCRIPTION = "Discount (AWS SPP Discount)"
 
 
+def _belongs_to_mpa(invoice: dict, mpa_account: str) -> bool:
+    bill_source_accounts = invoice.get("BillSourceAccounts")
+    if bill_source_accounts is not None:
+        return mpa_account in bill_source_accounts
+    return invoice.get("AccountId") == mpa_account
+
+
+def _is_primary_invoice(invoice: dict) -> bool:
+    breakdowns = (
+        invoice
+        .get("BaseCurrencyAmount", {})
+        .get("AmountBreakdown", {})
+        .get("Discounts", {})
+        .get("Breakdown", [])
+    )
+    return any(breakdown.get("Description") == SPP_DISCOUNT_DESCRIPTION for breakdown in breakdowns)
+
+
 class ExchangeRateResolver:
     """Resolves exchange rates and payment currencies from invoices."""
 
@@ -62,6 +80,7 @@ class InvoiceGenerator:
 
     def run(
         self,
+        pma_account: str,
         mpa_account: str,
         billing_period: BillingPeriod,
         authorization_currency: str,
@@ -69,7 +88,8 @@ class InvoiceGenerator:
         """Fetch and process invoices for the given account and billing period.
 
         Args:
-            mpa_account: The MPA account ID.
+            pma_account: The PMA account ID used to call the AWS API.
+            mpa_account: The MPA account ID used to filter invoices from the map.
             billing_period: The billing period to fetch invoices for.
             authorization_currency: The currency for the authorization.
 
@@ -77,10 +97,9 @@ class InvoiceGenerator:
             OrganizationInvoiceResult containing raw data and processed invoice.
         """
         invoice_summaries = self._aws_client.list_invoice_summaries_by_account_id(
-            mpa_account, billing_period.year, billing_period.month
+            pma_account, billing_period.year, billing_period.month
         )
-        raw_invoices = [inv for inv in invoice_summaries if inv.get("AccountId") == mpa_account]
-
+        raw_invoices = [inv for inv in invoice_summaries if _belongs_to_mpa(inv, mpa_account)]
         invoice = self._build_organization_invoice(raw_invoices, authorization_currency)
 
         for entity_name, entity in invoice.entities.items():
@@ -120,37 +139,47 @@ class InvoiceGenerator:
         self, raw_invoices: list[dict], currency: str, resolver: ExchangeRateResolver
     ) -> dict[str, InvoiceEntity]:
         entities: dict[str, InvoiceEntity] = {}
-
         for invoice in raw_invoices:
-            entity_name = invoice.get("Entity", {}).get("InvoicingEntity")
-            existing = entities.get(entity_name)
-            if existing:
-                entities[entity_name] = InvoiceEntity(
-                    invoice_id=f"{existing.invoice_id},{invoice.get('InvoiceId', '')}",
-                    base_currency_code=existing.base_currency_code,
-                    payment_currency_code=existing.payment_currency_code,
-                    exchange_rate=existing.exchange_rate,
-                    primary=self._is_primary_invoice(invoice) or existing.primary,
-                )
-            else:
-                entity_name = invoice.get("Entity", {}).get("InvoicingEntity")
-                exchange_rate = resolver.get_rate(entity_name, currency)
-
-                entities[entity_name] = InvoiceEntity(
-                    invoice_id=invoice.get("InvoiceId", ""),
-                    base_currency_code=invoice.get("BaseCurrencyAmount", {}).get(
-                        "CurrencyCode", ""
-                    ),
-                    payment_currency_code=resolver.get_payment_currency(exchange_rate),
-                    exchange_rate=exchange_rate,
-                    primary=self._is_primary_invoice(invoice),
-                )
-
+            entity = invoice.get("Entity", {})
+            entity_key = f"{entity.get('InvoicingEntity', '')}:{entity.get('BillingEntity', 'AWS')}"
+            entities[entity_key] = self._build_invoice_entity(
+                invoice, entity, entities.get(entity_key), currency, resolver
+            )
         return entities
+
+    def _build_invoice_entity(
+        self,
+        invoice: dict,
+        entity: dict,
+        existing: InvoiceEntity | None,
+        currency: str,
+        resolver: ExchangeRateResolver,
+    ) -> InvoiceEntity:
+        billing_entity = entity.get("BillingEntity", "AWS")
+        if existing:
+            new_id = invoice.get("InvoiceId", "")
+            merged_id = ",".join(filter(None, [existing.invoice_id, new_id]))
+            return InvoiceEntity(
+                invoice_id=merged_id,
+                base_currency_code=existing.base_currency_code,
+                payment_currency_code=existing.payment_currency_code,
+                exchange_rate=existing.exchange_rate,
+                billing_entity=billing_entity,
+                primary=_is_primary_invoice(invoice) or existing.primary,
+            )
+        exchange_rate = resolver.get_rate(entity.get("InvoicingEntity", ""), currency)
+        return InvoiceEntity(
+            invoice_id=invoice.get("InvoiceId", ""),
+            base_currency_code=invoice.get("BaseCurrencyAmount", {}).get("CurrencyCode", ""),
+            payment_currency_code=resolver.get_payment_currency(exchange_rate),
+            exchange_rate=exchange_rate,
+            billing_entity=billing_entity,
+            primary=_is_primary_invoice(invoice),
+        )
 
     def _get_principal_amount(self, raw_invoices: list[dict]) -> Decimal | None:
         for invoice in raw_invoices:
-            if self._is_primary_invoice(invoice):
+            if _is_primary_invoice(invoice):
                 return Decimal(invoice.get("BaseCurrencyAmount", {}).get("TotalAmount", 0))
         return None
 
@@ -158,16 +187,4 @@ class InvoiceGenerator:
         return sum(
             (Decimal(inv.get(currency_key, {}).get(amount_key, 0)) for inv in invoices),
             DEC_ZERO,
-        )
-
-    def _is_primary_invoice(self, invoice: dict) -> bool:
-        breakdowns = (
-            invoice
-            .get("BaseCurrencyAmount", {})
-            .get("AmountBreakdown", {})
-            .get("Discounts", {})
-            .get("Breakdown", [])
-        )
-        return any(
-            breakdown.get("Description") == SPP_DISCOUNT_DESCRIPTION for breakdown in breakdowns
         )

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
@@ -306,14 +306,18 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
         record_type: str,
         entities: dict[str, str],
     ) -> ServiceMetric:
-
-        entity_name = entities.get(metric_data.service_name)
-        invoice_entity = self._organization_invoice.entities.get(entity_name, None)
+        invoicing_entity = entities.get(metric_data.service_name)
+        if invoicing_entity:
+            billing_entity = "AWS_MARKETPLACE" if record_type == "MARKETPLACE" else "AWS"
+            entity_key = f"{invoicing_entity}:{billing_entity}"
+        else:
+            entity_key = None
+        invoice_entity = self._organization_invoice.entities.get(entity_key or "", None)
         return ServiceMetric(
             service_name=metric_data.service_name,
             record_type=record_type,
             amount=metric_data.amount,
-            invoice_entity=entity_name,
+            invoice_entity=entity_key,
             invoice_id=invoice_entity.invoice_id if invoice_entity else "",
             start_date=metric_data.start_date,
             end_date=metric_data.end_date,

--- a/swo_aws_extension/flows/jobs/billing_journal/journal_manager.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/journal_manager.py
@@ -1,4 +1,5 @@
 import calendar
+import datetime as dt
 import json
 from io import BytesIO
 from urllib.parse import urljoin
@@ -15,6 +16,13 @@ from swo_aws_extension.swo.notifications.teams import Button
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
 
 logger = get_logger(__name__)
+
+
+def serialize_default(unserializable):
+    """JSON serializer for objects not serializable by default."""
+    if isinstance(unserializable, dt.datetime):
+        return unserializable.isoformat()
+    return str(unserializable)
 
 
 class JournalManager:  # noqa: WPS214
@@ -109,7 +117,13 @@ class JournalManager:  # noqa: WPS214
         filename = f"{agreement_id}.json"
 
         report_data = report.to_dict()
-        json_bytes = BytesIO(json.dumps(report_data, indent=2).encode("utf-8"))
+        json_bytes = BytesIO(
+            json.dumps(
+                report_data,
+                indent=2,
+                default=serialize_default,
+            ).encode("utf-8")
+        )
 
         attachment = JournalAttachment(
             name=filename,

--- a/swo_aws_extension/flows/jobs/billing_journal/models/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/invoice.py
@@ -12,6 +12,7 @@ class InvoiceEntity:
     base_currency_code: str = ""
     payment_currency_code: str = ""
     exchange_rate: Decimal = field(default_factory=lambda: Decimal(0))
+    billing_entity: str = "AWS"
     primary: bool = field(default=False)
 
 

--- a/tests/flows/jobs/billing_journal/generators/test_authorization.py
+++ b/tests/flows/jobs/billing_journal/generators/test_authorization.py
@@ -213,7 +213,7 @@ def test_pma_usage_included_in_report_rows(
 
     result = generator.run(authorization)
 
-    mock_invoice_gen.run.assert_any_call("MPA-123", mock_context.billing_period, "USD")
+    mock_invoice_gen.run.assert_any_call("MPA-123", "MPA-123", mock_context.billing_period, "USD")
     mock_usage_gen.run_for_pma.assert_called_once_with(
         "MPA-123",
         mock_context.billing_period,

--- a/tests/flows/jobs/billing_journal/generators/test_invoice.py
+++ b/tests/flows/jobs/billing_journal/generators/test_invoice.py
@@ -25,6 +25,7 @@ def build_invoice(
     payment_total_before_tax="85.00",
     exchange_rate="0.95",
     discounts=None,
+    bill_source_accounts=None,
 ):
     """Factory function to create invoice dictionaries for testing."""
     invoice = {
@@ -45,6 +46,8 @@ def build_invoice(
     }
     if discounts:
         invoice["BaseCurrencyAmount"]["AmountBreakdown"] = {"Discounts": {"Breakdown": discounts}}
+    if bill_source_accounts is not None:
+        invoice["BillSourceAccounts"] = bill_source_accounts
     return invoice
 
 
@@ -67,7 +70,7 @@ def test_run_returns_organization_invoice_result(generator, mock_aws_client, bil
     invoice = build_invoice(base_total="100.50")
     mock_aws_client.list_invoice_summaries_by_account_id.return_value = [invoice]
 
-    result = generator.run("MPA-123", billing_period, "EUR")
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
     assert isinstance(result, OrganizationInvoiceResult)
     assert len(result.raw_data) == 1
@@ -80,7 +83,7 @@ def test_run_filters_invoices_by_account_id(generator, mock_aws_client, billing_
     ]
     mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
 
-    result = generator.run("MPA-123", billing_period, "EUR")
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
     assert len(result.raw_data) == 1
     assert result.raw_data[0]["InvoiceId"] == "INV-001"
@@ -90,14 +93,24 @@ def test_run_builds_invoice_entities(generator, mock_aws_client, billing_period)
     invoice = build_invoice()
     mock_aws_client.list_invoice_summaries_by_account_id.return_value = [invoice]
 
-    result = generator.run("MPA-123", billing_period, "EUR")
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
-    assert "AWS Inc." in result.invoice.entities
-    entity = result.invoice.entities["AWS Inc."]
+    assert "AWS Inc.:AWS" in result.invoice.entities
+    entity = result.invoice.entities["AWS Inc.:AWS"]
     assert entity.invoice_id == "INV-001"
     assert entity.base_currency_code == "USD"
     assert entity.payment_currency_code == "EUR"
     assert entity.exchange_rate == Decimal("0.95")
+
+
+def test_run_invoice_entity_has_correct_billing_entity(generator, mock_aws_client, billing_period):
+    invoice = build_invoice()
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = [invoice]
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")  # act
+
+    entity = result.invoice.entities["AWS Inc.:AWS"]
+    assert entity.billing_entity == "AWS"
 
 
 def test_run_merges_entities_and_calculates_totals(generator, mock_aws_client, billing_period):
@@ -113,9 +126,9 @@ def test_run_merges_entities_and_calculates_totals(generator, mock_aws_client, b
     ]
     mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
 
-    result = generator.run("MPA-123", billing_period, "EUR")
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
-    entity = result.invoice.entities["AWS Inc."]
+    entity = result.invoice.entities["AWS Inc.:AWS"]
     assert entity.invoice_id == "INV-001,INV-002"
     assert result.invoice.base_total_amount == Decimal("300.00")
     assert result.invoice.base_total_amount_before_tax == Decimal("270.00")
@@ -135,7 +148,7 @@ def test_run_handles_principal_invoice_amount_with_spp_discount(
     )
     mock_aws_client.list_invoice_summaries_by_account_id.return_value = [invoice]
 
-    result = generator.run("MPA-123", billing_period, "EUR")
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
     assert result.invoice.principal_invoice_amount == Decimal("-50.00")
 
@@ -146,7 +159,7 @@ def test_run_handles_principal_invoice_amount_without_spp_discount(
     invoice = build_invoice()
     mock_aws_client.list_invoice_summaries_by_account_id.return_value = [invoice]
 
-    result = generator.run("MPA-123", billing_period, "EUR")
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
     assert result.invoice.principal_invoice_amount is None
 
@@ -154,7 +167,7 @@ def test_run_handles_principal_invoice_amount_without_spp_discount(
 def test_run_handles_empty_invoices(generator, mock_aws_client, billing_period):
     mock_aws_client.list_invoice_summaries_by_account_id.return_value = []
 
-    result = generator.run("MPA-123", billing_period, "EUR")
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
     assert result.raw_data == []
     assert result.invoice.entities == {}
@@ -200,3 +213,71 @@ def test_exchange_rate_resolver_get_payment_currency(rate, expected_currency):
     result = resolver.get_payment_currency(rate)
 
     assert result == expected_currency
+
+
+def test_run_filters_invoices_by_bill_source_accounts(generator, mock_aws_client, billing_period):
+    invoices = [
+        build_invoice(
+            account_id="BUYER-001", invoice_id="INV-001", bill_source_accounts=["MPA-123"]
+        ),
+        build_invoice(
+            account_id="BUYER-002", invoice_id="INV-002", bill_source_accounts=["OTHER-456"]
+        ),
+    ]
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
+
+    assert len(result.raw_data) == 1
+    assert result.raw_data[0]["InvoiceId"] == "INV-001"
+
+
+def test_run_filters_invoices_with_multiple_bill_source_accounts(
+    generator, mock_aws_client, billing_period
+):
+    invoices = [
+        build_invoice(
+            account_id="BUYER-001",
+            invoice_id="INV-001",
+            bill_source_accounts=["MPA-123", "MPA-789"],
+        ),
+        build_invoice(
+            account_id="BUYER-002",
+            invoice_id="INV-002",
+            bill_source_accounts=["OTHER-456"],
+        ),
+    ]
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
+
+    assert len(result.raw_data) == 1
+    assert result.raw_data[0]["InvoiceId"] == "INV-001"
+
+
+def test_run_excludes_invoices_with_empty_bill_source_accounts(
+    generator, mock_aws_client, billing_period
+):
+    invoices = [
+        build_invoice(account_id="MPA-123", invoice_id="INV-001", bill_source_accounts=[]),
+    ]
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
+
+    assert result.raw_data == []
+
+
+def test_run_falls_back_to_account_id_when_bill_source_accounts_absent(
+    generator, mock_aws_client, billing_period
+):
+    invoices = [
+        build_invoice(account_id="MPA-123", invoice_id="INV-001"),
+        build_invoice(account_id="OTHER-456", invoice_id="INV-002"),
+    ]
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
+
+    assert len(result.raw_data) == 1
+    assert result.raw_data[0]["InvoiceId"] == "INV-001"

--- a/tests/flows/jobs/billing_journal/generators/test_invoice.py
+++ b/tests/flows/jobs/billing_journal/generators/test_invoice.py
@@ -4,8 +4,10 @@ import pytest
 
 from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.flows.jobs.billing_journal.generators.invoice import (
+    MAX_INVOICE_ID_LENGTH,
     ExchangeRateResolver,
     InvoiceGenerator,
+    merge_invoice_ids,
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
 from swo_aws_extension.flows.jobs.billing_journal.models.invoice import (
@@ -115,9 +117,9 @@ def test_run_invoice_entity_has_correct_billing_entity(generator, mock_aws_clien
 
 def test_run_merges_entities_and_calculates_totals(generator, mock_aws_client, billing_period):
     invoices = [
-        build_invoice(invoice_id="INV-001", base_total="100.00", payment_total="95.00"),
+        build_invoice(invoice_id="2609293185", base_total="100.00", payment_total="95.00"),
         build_invoice(
-            invoice_id="INV-002",
+            invoice_id="SGIN26-350441",
             base_total="200.00",
             base_total_before_tax="180.00",
             payment_total="190.00",
@@ -129,7 +131,7 @@ def test_run_merges_entities_and_calculates_totals(generator, mock_aws_client, b
     result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
 
     entity = result.invoice.entities["AWS Inc.:AWS"]
-    assert entity.invoice_id == "INV-001,INV-002"
+    assert entity.invoice_id == "-3185,-0441"
     assert result.invoice.base_total_amount == Decimal("300.00")
     assert result.invoice.base_total_amount_before_tax == Decimal("270.00")
     assert result.invoice.payment_currency_total_amount == Decimal("285.00")
@@ -281,3 +283,36 @@ def test_run_falls_back_to_account_id_when_bill_source_accounts_absent(
 
     assert len(result.raw_data) == 1
     assert result.raw_data[0]["InvoiceId"] == "INV-001"
+
+
+@pytest.mark.parametrize(
+    ("existing_id", "new_id", "expected"),
+    [
+        ("2609293185", "", "2609293185"),
+        ("2609293185", "SGIN26-350441", "-3185,-0441"),
+        ("-3185,-0441", "EUINPL26-355205", "-3185,-0441,-5205"),
+        ("-3185,-0441,-5205", "NEXT26-000002", "-3185,-0441,-5205,.."),
+        ("-3185,-0441,-5205,..", "NEXT26-000003", "-3185,-0441,-5205,.."),
+    ],
+)
+def test_merge_invoice_ids(existing_id, new_id, expected):
+    result = merge_invoice_ids(existing_id, new_id)  # act
+
+    assert result == expected
+
+
+def test_merge_invoice_ids_result_never_exceeds_navision_limit(
+    generator, mock_aws_client, billing_period
+):
+    invoice_count = 10
+    invoice_id_template = "EUINPL26-3{0:05d}"
+    invoices = [
+        build_invoice(invoice_id=invoice_id_template.format(idx)) for idx in range(invoice_count)
+    ]
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")  # act
+
+    entity = result.invoice.entities["AWS Inc.:AWS"]
+    assert len(entity.invoice_id) <= MAX_INVOICE_ID_LENGTH
+    assert entity.invoice_id.endswith(",..")

--- a/tests/flows/jobs/billing_journal/generators/test_usage.py
+++ b/tests/flows/jobs/billing_journal/generators/test_usage.py
@@ -176,7 +176,7 @@ def test_generate_returns_correct_invoice_entity(
 
     account_usage = result.usage_by_account["ACT-1"]
     metrics = [metric for metric in account_usage.metrics if metric.service_name == "AmazonEC2"]
-    assert metrics[0].invoice_entity == "Amazon Web Services, Inc."
+    assert metrics[0].invoice_entity == "Amazon Web Services, Inc.:AWS"
 
 
 def test_generate_handles_multiple_billing_views(
@@ -257,7 +257,7 @@ def test_generate_sets_invoice_id_from_organization_invoice(
     mock_aws_client.get_cost_and_usage.side_effect = single_account_usage
     organization_invoice = OrganizationInvoice(
         entities={
-            "Amazon Web Services, Inc.": InvoiceEntity(invoice_id="INV-001,INV-002"),
+            "Amazon Web Services, Inc.:AWS": InvoiceEntity(invoice_id="INV-001,INV-002"),
         },
     )
 
@@ -269,7 +269,11 @@ def test_generate_sets_invoice_id_from_organization_invoice(
     )
 
     account_usage = result.usage_by_account["ACT-1"]
-    metrics = [metric for metric in account_usage.metrics if metric.service_name == "AmazonEC2"]
+    metrics = [
+        metric
+        for metric in account_usage.metrics
+        if metric.service_name == "AmazonEC2" and metric.record_type != "MARKETPLACE"
+    ]
     assert metrics[0].invoice_id == "INV-001,INV-002"
 
 
@@ -292,3 +296,50 @@ def test_run_for_pma_fetches_correct_usage(
     assert mock_aws_client.get_cost_and_usage.call_count == 3
     first_call_kwargs = mock_aws_client.get_cost_and_usage.call_args_list[0].kwargs
     assert "view_arn" not in first_call_kwargs or first_call_kwargs["view_arn"] in {None, ""}
+
+
+def test_create_metric_without_invoicing_entity(
+    generator,
+    mock_aws_client,
+    billing_period,
+    single_billing_view,
+):
+    account_usage_data = [
+        [{"Groups": [{"Keys": ["ACT-1"]}]}],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [
+                    {
+                        "Keys": ["ACT-1", "AmazonEC2"],
+                        "Metrics": {"UnblendedCost": {"Amount": "10.00"}},
+                    },
+                ],
+            },
+        ],
+        [{"Groups": [{"Keys": ["UnknownService", "SomeEntity"]}]}],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [
+                    {
+                        "Keys": [AWSRecordTypeEnum.USAGE, "AmazonEC2"],
+                        "Metrics": {"UnblendedCost": {"Amount": "50.00"}},
+                    },
+                ],
+            },
+        ],
+    ]
+    mock_aws_client.get_billing_views_by_account_id.return_value = single_billing_view
+    mock_aws_client.get_cost_and_usage.side_effect = account_usage_data
+
+    result = generator.run("USD", "MPA-1", billing_period, OrganizationInvoice())
+
+    account_usage = result.usage_by_account["ACT-1"]
+    usage_metrics = [
+        metric
+        for metric in account_usage.metrics
+        if metric.service_name == "AmazonEC2" and metric.record_type != "MARKETPLACE"
+    ]
+    assert usage_metrics[0].invoice_entity is None
+    assert not usage_metrics[0].invoice_id

--- a/tests/flows/jobs/billing_journal/test_journal_manager.py
+++ b/tests/flows/jobs/billing_journal/test_journal_manager.py
@@ -1,8 +1,11 @@
+import datetime as dt
+from decimal import Decimal
 from io import BytesIO
 
 from requests import HTTPError
 
 from swo_aws_extension.constants import BILLING_JOURNAL_SUCCESS_TITLE
+from swo_aws_extension.flows.jobs.billing_journal.journal_manager import serialize_default
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import JournalLine
 from swo_aws_extension.flows.jobs.billing_journal.models.usage import OrganizationReport
 from swo_aws_extension.swo.notifications.teams import Button
@@ -130,3 +133,19 @@ def test_upload_attachments_logs_error_on_failure(manager, mock_billing_client):
     manager.upload_attachments("JRN-001", {"AGR-1": report})  # act
 
     mock_billing_client.journal.attachments("JRN-001").upload.assert_called_once()
+
+
+def test_serialize_default_with_datetime():
+    datetime_value = dt.datetime.fromisoformat("2025-10-15T12:30:00+00:00")
+
+    result = serialize_default(datetime_value)  # act
+
+    assert result == "2025-10-15T12:30:00+00:00"
+
+
+def test_serialize_default_with_non_datetime():
+    decimal_value = Decimal("123.45")
+
+    result = serialize_default(decimal_value)  # act
+
+    assert result == "123.45"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -168,43 +172,43 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.73"
+version = "1.43.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8b/d00575be514744ca4839e7d85bf4a8a3c7b6b4574433291e58d14c68ae09/boto3-1.42.73.tar.gz", hash = "sha256:d37b58d6cd452ca808dd6823ae19ca65b6244096c5125ef9052988b337298bae", size = 112775, upload-time = "2026-03-20T19:39:52.814Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/37/78c630d1308964aa9abf44951d9c4df776546ff37251ec2434944e205c4e/boto3-1.43.6.tar.gz", hash = "sha256:e6315effaf12b890b99956e6f8e2c3000a3f64e4ee91943cec3895ce9a836afb", size = 113153, upload-time = "2026-05-07T20:49:59.694Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/05/1fcf03d90abaa3d0b42a6bfd10231dd709493ecbacf794aa2eea5eae6841/boto3-1.42.73-py3-none-any.whl", hash = "sha256:1f81b79b873f130eeab14bb556417a7c66d38f3396b7f2fe3b958b3f9094f455", size = 140556, upload-time = "2026-03-20T19:39:50.298Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e2/3c2eef44f55eafab256836d1d9479bd6a74f70c26cbfdc0639a0e23e4327/boto3-1.43.6-py3-none-any.whl", hash = "sha256:179601ec2992726a718053bf41e43c223ceba397d31ceab11f64d9c910d9fc3a", size = 140502, upload-time = "2026-05-07T20:49:57.8Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.42.73"
+version = "1.42.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/c3/fcc47102c63278af25ad57c93d97dc393f4dbc54c0117a29c78f2b96ec1e/boto3_stubs-1.42.73.tar.gz", hash = "sha256:36f625769b5505c4bc627f16244b98de9e10dae3ac36f1aa0f0ebe2f201dc138", size = 101373, upload-time = "2026-03-20T19:59:51.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/86/65f45f84621cccc2471871088bab8fe515b4346ba9e48d9001484ec440d6/boto3_stubs-1.42.96.tar.gz", hash = "sha256:1e7819c34d1eae8e5e3cfaf9d144fdcad65aad184b380488871de1d0b2851879", size = 102691, upload-time = "2026-04-24T20:25:13.984Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/57/d570ba61a2a0c7fe0c8667e41269a0480293cb53e1786d6661a2bd827fc5/boto3_stubs-1.42.73-py3-none-any.whl", hash = "sha256:bd658429069d8215247fc3abc003220cd875c24ab6eda7b3405090408afaacdf", size = 70009, upload-time = "2026-03-20T19:59:43.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/bdac1ff9fd4321091183776c5adffce5fc7b4d0fec7e38af9064e24a2497/boto3_stubs-1.42.96-py3-none-any.whl", hash = "sha256:2c112e257f40006147a53f6f62075804689154271973b2807f5656feaa804216", size = 70668, upload-time = "2026-04-24T20:25:09.736Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.73"
+version = "1.43.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/23/0c88ca116ef63b1ae77c901cd5d2095d22a8dbde9e80df74545db4a061b4/botocore-1.42.73.tar.gz", hash = "sha256:575858641e4949aaf2af1ced145b8524529edf006d075877af6b82ff96ad854c", size = 15008008, upload-time = "2026-03-20T19:39:40.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/a7/23d0f5028011455096a1eeac0ddf3cbe147b3e855e127342f8202552194d/botocore-1.43.6.tar.gz", hash = "sha256:b1e395b347356860398da42e61c808cf1e34b6fa7180cf2b9d87d986e1a06ba0", size = 15336070, upload-time = "2026-05-07T20:49:48.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/65/971f3d55015f4d133a6ff3ad74cd39f4b8dd8f53f7775a3c2ad378ea5145/botocore-1.42.73-py3-none-any.whl", hash = "sha256:7b62e2a12f7a1b08eb7360eecd23bb16fe3b7ab7f5617cf91b25476c6f86a0fe", size = 14681861, upload-time = "2026-03-20T19:39:35.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c8/6f47223840e8d8cfa8c9f7c0ec1b77970417f257fc885169ff4f6326ce09/botocore-1.43.6-py3-none-any.whl", hash = "sha256:b6d1fdbc6f65a5fe0b7e947823aa37535d3f39f3ba4d21110fab1f55bbbcc04b", size = 15017094, upload-time = "2026-05-07T20:49:44.964Z" },
 ]
 
 [[package]]
@@ -785,7 +789,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.11.0"
+version = "9.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -795,13 +799,14 @@ dependencies = [
     { name = "matplotlib-inline" },
     { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "prompt-toolkit" },
+    { name = "psutil" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/90/45c72becc57158facc6a6404f663b77bbcea2519ca57f760e2879ae1315d/ipython-9.11.0-py3-none-any.whl", hash = "sha256:6922d5bcf944c6e525a76a0a304451b60a2b6f875e86656d8bc2dfda5d710e19", size = 624222, upload-time = "2026-03-05T08:57:28.94Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
 ]
 
 [[package]]
@@ -1025,15 +1030,14 @@ wheels = [
 
 [[package]]
 name = "mpt-api-client"
-version = "5.2.0"
+version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "python-box" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/07/86a4d59c4e44f49299449012da69bbeb4d2d6736db838ee9da4f34a6c4fe/mpt_api_client-5.2.0.tar.gz", hash = "sha256:c145d391b1339861d64b2235668c520ed070a26f86f91405c8299939b751c9e7", size = 41343, upload-time = "2026-02-24T11:33:03.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/41/d5ec7ee9e6d626c0bcff192eb481ff8f1b77a8cd0583a188d3833ff72c79/mpt_api_client-5.4.0.tar.gz", hash = "sha256:abd7a60e00cbb0a7e8d66e14dec9f415a4d5a020dec5f7b2534a60d62cde0a74", size = 49617, upload-time = "2026-03-25T10:43:29.538Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/6d/27136754f367ba0044c994adb093781d28f587d04898a6db7154ca42f77a/mpt_api_client-5.2.0-py3-none-any.whl", hash = "sha256:1b0348d8f06481b21ce0385473ddf43d864afdef08ec98b0be407bfbb7e78acc", size = 92135, upload-time = "2026-02-24T11:33:01.576Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/99/1ae0a342ee580e44017c6775a882c1a318f7eac7a79eab6255c906a4edb2/mpt_api_client-5.4.0-py3-none-any.whl", hash = "sha256:f2b8798a57a5a5737094a70c19eae0e32d12a2c83c25d7582b3252f64a80f835", size = 110983, upload-time = "2026-03-25T10:43:28.625Z" },
 ]
 
 [[package]]
@@ -1069,16 +1073,16 @@ wheels = [
 
 [[package]]
 name = "mpt-tool"
-version = "5.6.0"
+version = "5.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mpt-api-client" },
     { name = "pyairtable" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/ab/32a104b6f1605e139eff1feecf134c8bd0d03400db277e1be6da09720178/mpt_tool-5.6.0.tar.gz", hash = "sha256:6a4513562646b2e7ea1545b5429e9b224bbdc9a3d97c9ac5b6e8bfc2a548f8cc", size = 24570, upload-time = "2026-02-26T10:10:09.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/a3/c25376ca33cde3e9cb3752af93a4fcb9a1c3328372960464f31d759432ba/mpt_tool-5.6.1.tar.gz", hash = "sha256:c15df28a430f83a2f729633a00cee928d761440d22a4336fba6901b2d310beb1", size = 20738, upload-time = "2026-04-21T15:27:03.417Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/07/fb96878306df97bbaf5006c68fb039b4fcf7296112373875ef1bdf042a73/mpt_tool-5.6.0-py3-none-any.whl", hash = "sha256:1d100b6339988363a21b97322c4fe4c3981ddd89be634b8ac872244b8cc17a64", size = 38058, upload-time = "2026-02-26T10:10:08.846Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/26/bdf134fafa80f56856925c4e3975f187d81704bcf12eed4ebcf0a3e3c47c/mpt_tool-5.6.1-py3-none-any.whl", hash = "sha256:6a6f95119ea3b8c579df2812191e45345e596bb9c865855eca8de97477994f05", size = 34100, upload-time = "2026-04-21T15:27:02.457Z" },
 ]
 
 [[package]]
@@ -1651,7 +1655,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1660,9 +1664,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1738,23 +1742,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
-]
-
-[[package]]
-name = "python-box"
-version = "7.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/0f/34e7ee0a72f1464b4c7a2e8bafb389f230477256af586bc82bcfad85295a/python_box-7.4.1.tar.gz", hash = "sha256:e412e36c25fca8223560516d53ef6c7993591c3b0ec8bb4ec582bf7defdd79f0", size = 49859, upload-time = "2026-02-21T16:21:16.008Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/d9/d05f317b38b42253422d8483f5d7dc16d382c99ddc253e426639a0f2f235/python_box-7.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dfb91effff00d9e23486c4f0db3b19e03d602ebb7c9e20fc6a287c704fad2552", size = 1849441, upload-time = "2026-02-21T16:21:37.314Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/a3/383eb3d658f36c6e531c8cf1e348ccb4b5031231df4aeb7742bb159a3166/python_box-7.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7f977f00e715b030cee6ffef2322ff8ce100ffbf1dbcc4ef91099c75752d5f8", size = 4485153, upload-time = "2026-02-21T16:26:04.507Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f9/5de3c18415dd6f5286f00e6539c0ae3cceb1c6aaf28d1d5f17b0b568c97f/python_box-7.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:2ca9a18fd15326bc267e9cc7e0e6e3a0cb78d11507940f43f687adf7e156d882", size = 1295520, upload-time = "2026-02-21T16:22:26.192Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e9/48d1b1eb21efc3f82a31b037b6903c9139018f686d96d251faa4cb0d593a/python_box-7.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:85db37b43094bf6c4884b931fb149a7850db5ce331f6e191edf98b453e6cf2d6", size = 1845195, upload-time = "2026-02-21T16:21:46.235Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/48d38c855f277223caf3aa79518476f95abc07f04386940855b7bd3d95f6/python_box-7.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb204822c7638bd2dbed5c55d6ab264c6903c37d18dee5c45bdbda58b2e1e17a", size = 4468245, upload-time = "2026-02-21T16:26:05.701Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1d/7a1e04f37674399e0f3076cfe1fa358f6a51540ae98299a06f2c0424c471/python_box-7.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:615da3fafd41572aec1b905832555c0ea08b6fbc27cc917356e257a9a5721af7", size = 1295564, upload-time = "2026-02-21T16:22:36.547Z" },
-    { url = "https://files.pythonhosted.org/packages/94/a2/771b5e526bba2214ac2d30e321209a66680c40788616a45cf01005e95204/python_box-7.4.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:33c6701faa51fd87f0dcc538873c0fad2b3a1cc3750eab85835cd071cadf1948", size = 1875508, upload-time = "2026-02-21T16:21:37.432Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/5f/0e7ea7640ba60ff459ce37e340d816ac5e91b7a9a7c3c161f9dabe622be6/python_box-7.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:ae8c540a0457f52350211d24690211251912018e1e0c1857f50792729d6f562c", size = 1314304, upload-time = "2026-02-21T16:22:22.173Z" },
-    { url = "https://files.pythonhosted.org/packages/06/a6/5d3f3abf46b37aa44b1f6788d287c8b4f2319b55013191dddf25b9e6d62c/python_box-7.4.1-py3-none-any.whl", hash = "sha256:a3b0d84d003882fb6abe505b1b883b3a5dcbf226b0fe168d24bc5ff75d9826e5", size = 30402, upload-time = "2026-02-21T16:21:14.78Z" },
 ]
 
 [[package]]
@@ -1884,39 +1871,39 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.7"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/22/9e4f66ee588588dc6c9af6a994e12d26e19efbe874d1a909d09a6dac7a59/ruff-0.15.7.tar.gz", hash = "sha256:04f1ae61fc20fe0b148617c324d9d009b5f63412c0b16474f3d5f1a1a665f7ac", size = 4601277, upload-time = "2026-03-19T16:26:22.605Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/2f/0b08ced94412af091807b6119ca03755d651d3d93a242682bf020189db94/ruff-0.15.7-py3-none-linux_armv6l.whl", hash = "sha256:a81cc5b6910fb7dfc7c32d20652e50fa05963f6e13ead3c5915c41ac5d16668e", size = 10489037, upload-time = "2026-03-19T16:26:32.47Z" },
-    { url = "https://files.pythonhosted.org/packages/91/4a/82e0fa632e5c8b1eba5ee86ecd929e8ff327bbdbfb3c6ac5d81631bef605/ruff-0.15.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:722d165bd52403f3bdabc0ce9e41fc47070ac56d7a91b4e0d097b516a53a3477", size = 10955433, upload-time = "2026-03-19T16:27:00.205Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/10/12586735d0ff42526ad78c049bf51d7428618c8b5c467e72508c694119df/ruff-0.15.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7fbc2448094262552146cbe1b9643a92f66559d3761f1ad0656d4991491af49e", size = 10269302, upload-time = "2026-03-19T16:26:26.183Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/5d/32b5c44ccf149a26623671df49cbfbd0a0ae511ff3df9d9d2426966a8d57/ruff-0.15.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b39329b60eba44156d138275323cc726bbfbddcec3063da57caa8a8b1d50adf", size = 10607625, upload-time = "2026-03-19T16:27:03.263Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/f1/f0001cabe86173aaacb6eb9bb734aa0605f9a6aa6fa7d43cb49cbc4af9c9/ruff-0.15.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87768c151808505f2bfc93ae44e5f9e7c8518943e5074f76ac21558ef5627c85", size = 10324743, upload-time = "2026-03-19T16:27:09.791Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/87/b8a8f3d56b8d848008559e7c9d8bf367934d5367f6d932ba779456e2f73b/ruff-0.15.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb0511670002c6c529ec66c0e30641c976c8963de26a113f3a30456b702468b0", size = 11138536, upload-time = "2026-03-19T16:27:06.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f2/4fd0d05aab0c5934b2e1464784f85ba2eab9d54bffc53fb5430d1ed8b829/ruff-0.15.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0d19644f801849229db8345180a71bee5407b429dd217f853ec515e968a6912", size = 11994292, upload-time = "2026-03-19T16:26:48.718Z" },
-    { url = "https://files.pythonhosted.org/packages/64/22/fc4483871e767e5e95d1622ad83dad5ebb830f762ed0420fde7dfa9d9b08/ruff-0.15.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4806d8e09ef5e84eb19ba833d0442f7e300b23fe3f0981cae159a248a10f0036", size = 11398981, upload-time = "2026-03-19T16:26:54.513Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/99/66f0343176d5eab02c3f7fcd2de7a8e0dd7a41f0d982bee56cd1c24db62b/ruff-0.15.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dce0896488562f09a27b9c91b1f58a097457143931f3c4d519690dea54e624c5", size = 11242422, upload-time = "2026-03-19T16:26:29.277Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/3a/a7060f145bfdcce4c987ea27788b30c60e2c81d6e9a65157ca8afe646328/ruff-0.15.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1852ce241d2bc89e5dc823e03cff4ce73d816b5c6cdadd27dbfe7b03217d2a12", size = 11232158, upload-time = "2026-03-19T16:26:42.321Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/53/90fbb9e08b29c048c403558d3cdd0adf2668b02ce9d50602452e187cd4af/ruff-0.15.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5f3e4b221fb4bd293f79912fc5e93a9063ebd6d0dcbd528f91b89172a9b8436c", size = 10577861, upload-time = "2026-03-19T16:26:57.459Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/aa/5f486226538fe4d0f0439e2da1716e1acf895e2a232b26f2459c55f8ddad/ruff-0.15.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b15e48602c9c1d9bdc504b472e90b90c97dc7d46c7028011ae67f3861ceba7b4", size = 10327310, upload-time = "2026-03-19T16:26:35.909Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/271afdffb81fe7bfc8c43ba079e9d96238f674380099457a74ccb3863857/ruff-0.15.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b4705e0e85cedc74b0a23cf6a179dbb3df184cb227761979cc76c0440b5ab0d", size = 10840752, upload-time = "2026-03-19T16:26:45.723Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/29/a4ae78394f76c7759953c47884eb44de271b03a66634148d9f7d11e721bd/ruff-0.15.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:112c1fa316a558bb34319282c1200a8bf0495f1b735aeb78bfcb2991e6087580", size = 11336961, upload-time = "2026-03-19T16:26:39.076Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]
@@ -2020,7 +2007,7 @@ dev = [
 requires-dist = [
     { name = "atlassian-python-api", specifier = "==4.0.*" },
     { name = "azure-storage-blob", specifier = "==12.28.*" },
-    { name = "boto3", specifier = "==1.42.*" },
+    { name = "boto3", specifier = "==1.43.*" },
     { name = "django", specifier = "==4.2.*" },
     { name = "jinja2", specifier = "==3.1.*" },
     { name = "markdown-it-py", specifier = "==4.0.*" },
@@ -2095,23 +2082,23 @@ wheels = [
 
 [[package]]
 name = "types-openpyxl"
-version = "3.1.5.20260322"
+version = "3.1.5.20260408"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/bf/15240de4d68192d2a1f385ef2f6f1ecb29b85d2f3791dd2e2d5b980be30f/types_openpyxl-3.1.5.20260322.tar.gz", hash = "sha256:a61d66ebe1e49697853c6db8e0929e1cda2c96755e71fb676ed7fc48dfdcf697", size = 101325, upload-time = "2026-03-22T04:08:40.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/c9/24f03f9d9fedd164de699c1418869bef9b819f59f75e7f647f5788c02d98/types_openpyxl-3.1.5.20260408.tar.gz", hash = "sha256:b49274d086fbb6e6bcd2a67d161dd1161d4d380488e4cce546d647d45eadcac2", size = 101361, upload-time = "2026-04-08T04:30:37.809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/b4/c14191b30bcb266365b124b2bb4e67ecd68425a78ba77ee026f33667daa9/types_openpyxl-3.1.5.20260322-py3-none-any.whl", hash = "sha256:2f515f0b0bbfb04bfb587de34f7522d90b5151a8da7bbbd11ecec4ca40f64238", size = 166102, upload-time = "2026-03-22T04:08:39.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/64db0c32c6fda4b198aff84329ceeea00a93d16c28f05e9fe0404ddb8b8c/types_openpyxl-3.1.5.20260408-py3-none-any.whl", hash = "sha256:7ab7586796aed017cde50b81bd67ba024120c39b99c102320b57dd91390c317f", size = 166044, upload-time = "2026-04-08T04:30:36.449Z" },
 ]
 
 [[package]]
 name = "types-requests"
-version = "2.32.4.20260107"
+version = "2.32.4.20260324"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/b1/66bafdc85965e5aa3db42e1b9128bf8abe252edd7556d00a07ef437a3e0e/types_requests-2.32.4.20260324.tar.gz", hash = "sha256:33a2a9ccb1de7d4e4da36e347622c35418f6761269014cc32857acabd5df739e", size = 23765, upload-time = "2026-03-24T04:06:35.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/ce5999f9bd72c7fac681d26cd0a5782b379053bfc2214e2a3fbe30852c9e/types_requests-2.32.4.20260324-py3-none-any.whl", hash = "sha256:f83ef2deb284fe99a249b8b0b0a3e4b9809e01ff456063c4df0aac7670c07ab9", size = 20735, upload-time = "2026-03-24T04:06:33.9Z" },
 ]
 
 [[package]]
@@ -2283,16 +2270,16 @@ wheels = [
 
 [[package]]
 name = "wemake-python-styleguide"
-version = "1.6.1"
+version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "flake8" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/b3/3ade9b1595052bf15b94bedd458768b596de02d701075ba87e95b5d6b392/wemake_python_styleguide-1.6.1.tar.gz", hash = "sha256:72eb81dc421dde9f32ce1f67b25d1a13060c264bac12857897b582f83e6bbdbf", size = 158266, upload-time = "2026-02-28T18:55:54.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/eb/c0ed67f144c6b5426cd444ccd22a22da4971e50a345c84bae187d1bfce27/wemake_python_styleguide-1.6.2.tar.gz", hash = "sha256:59c7d52b0677519aeb49714fca558eb93f278d8a7e18eadead455db8620ceb2f", size = 158636, upload-time = "2026-04-27T05:51:41.03Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/75/fb15010739383946c532f157836bb3ca826f0252333a07f60743999a7799/wemake_python_styleguide-1.6.1-py3-none-any.whl", hash = "sha256:799690b3654e9eb6db4bf021053c64f907eff9845646a634e22f89a34c3b6ef0", size = 221563, upload-time = "2026-02-28T18:55:56.336Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0c/c77f5bbb2e018d80916442022609cfbbfaa88a9579724f5332cf4a66e57c/wemake_python_styleguide-1.6.2-py3-none-any.whl", hash = "sha256:857690cb0e36132e7b3b5d339a11714014d539634ed27cf04cf08107f1c347cb", size = 221687, upload-time = "2026-04-27T05:51:42.481Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Backport of MPT-21020 and its subtask MPT-21079 from `main` to `release/5`.

**MPT-21020** — Maps invoice with MPA account using BillSourceAccounts field:
- Read `BillSourceAccounts` from each invoice summary returned by the AWS `list_invoice_summaries` API
- Use it to map each invoice to the correct MPA account
- Bump `boto3` dependency from `1.42.*` to `1.43.*` to support the updated API response shape

**MPT-21079** — Truncate invoice IDs to last 4 digits with overflow indicator for Navision 20-char limit:
- Replace raw comma-join of full invoice IDs with `merge_invoice_ids`, which keeps only the last 4 characters of each ID (prefixed with `-`) and appends `..` when further IDs would exceed the 20-character Navision limit

## Cherry-picked commits

1. `8730b1a` — MPT-21020 Maps invoice with the MPA IDs
2. `1cf7db1` — fix: MPT-21079 truncate invoice IDs to last 4 chars to respect Navision 20-char limit

## Test plan

- [ ] Verify invoices are correctly mapped to the MPA account using `BillSourceAccounts`
- [ ] Confirm edge cases are handled: empty `BillSourceAccounts` list, multiple accounts
- [ ] Confirm invoice ID fields do not exceed 20 characters in Navision payloads
- [ ] Confirm the `..` overflow indicator appears when the limit is exceeded
- [ ] Run `make test` to confirm all billing journal and invoice tests pass

Closes [MPT-21020](https://softwareone.atlassian.net/browse/MPT-21020) / [MPT-21079](https://softwareone.atlassian.net/browse/MPT-21079)

[MPT-21020]: https://softwareone.atlassian.net/browse/MPT-21020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21020](https://softwareone.atlassian.net/browse/MPT-21020) / [MPT-21079](https://softwareone.atlassian.net/browse/MPT-21079)

- **Dependencies**: Updated `boto3` from `1.42.*` to `1.43.*` to support BillSourceAccounts field in invoice summary API responses
- **Invoice-to-MPA mapping**: Implemented logic to map invoices to correct MPA accounts using `BillSourceAccounts` field from AWS API, with fallback to `AccountId` equality when field is absent
- **Invoice ID truncation**: Added `merge_invoice_ids()` function to compress invoice IDs by keeping only the last 4 characters (prefixed with "-") and appending overflow marker ("..") to respect Navision's 20-character field limit
- **InvoiceEntity model**: Added `billing_entity` field (default: "AWS") to track billing source alongside invoicing entity
- **Invoice entity keying**: Changed entity identification from single invoicing entity to composite "InvoicingEntity:BillingEntity" format for proper handling of multiple billing sources
- **Generator signature**: Updated `InvoiceGenerator.run()` to accept `pma_account` parameter alongside existing `mpa_account` for API calls
- **JSON serialization**: Added `serialize_default()` helper to handle datetime serialization when creating journal attachments
- **Test coverage**: Extended test suite to validate BillSourceAccounts filtering, invoice ID merging behavior, and new entity keying format

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-aws-extension/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->