### PR TITLE
[BACKPORT] MPT-21067 Change subService value to Customer Activation in ServiceNow ticket payload

### DIFF
--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -13,7 +13,7 @@ CRM_EXTERNAL_USERNAME = "mpt@marketplace.com"
 CRM_SERVICE_TYPE = "MarketPlaceServiceActivation"
 CRM_GLOBAL_EXT_USER_ID = "globalacademicExtUserId"
 CRM_REQUESTER = "Supplier.Portal"
-CRM_SUB_SERVICE = "Service Activation"
+CRM_SUB_SERVICE = "Customer Activation"
 
 BASIC_PRICING_PLAN_ARN = "arn:aws:billingconductor::aws:pricingplan/BasicPricingPlan"
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Backport of MPT-21067 from `main` to `release/5`.

- Update `CRM_SUB_SERVICE` constant from `"Service Activation"` to `"Customer Activation"` so that ServiceNow tickets are routed to the correct destination group for customer activation flows

## Cherry-picked commit

`aadf786` — fix: MPT-21067 change CRM sub-service value to Customer Activation

## Test plan

- [ ] Verify ServiceNow tickets created by the extension include `subService: "Customer Activation"` in the payload
- [ ] Confirm tickets are routed to the correct destination group

Closes [MPT-21067](https://softwareone.atlassian.net/browse/MPT-21067)

[MPT-21067]: https://softwareone.atlassian.net/browse/MPT-21067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21067](https://softwareone.atlassian.net/browse/MPT-21067)

- Updated `CRM_SUB_SERVICE` constant from "Service Activation" to "Customer Activation" in `swo_aws_extension/constants.py`
- ServiceNow tickets created by the extension will include `subService: "Customer Activation"` in the payload, ensuring they are routed to the correct destination group for customer activation flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-aws-extension/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->