### PR TITLE
[BACKPORT] MPT-21023 Block duplicate agreement creation for same licensee

### DIFF
--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -28,6 +28,7 @@ class AgreementStatusEnum(StrEnum):
 
     ACTIVE = "Active"
     UPDATING = "Updating"
+    PROVISIONING = "Provisioning"
 
 
 class SubscriptionStatus(StrEnum):

--- a/swo_aws_extension/flows/fulfillment/pipelines.py
+++ b/swo_aws_extension/flows/fulfillment/pipelines.py
@@ -31,6 +31,7 @@ from swo_aws_extension.flows.steps.onboard_services import OnboardServices
 from swo_aws_extension.flows.steps.setup_context import SetupContext
 from swo_aws_extension.flows.steps.swo_job import SWOJobStep
 from swo_aws_extension.flows.steps.terminate import TerminateResponsibilityTransferStep
+from swo_aws_extension.flows.steps.validate_order import ValidateOrder
 from swo_aws_extension.swo.notifications.teams import (
     notify_one_time_error,
 )
@@ -63,6 +64,7 @@ def pipeline_error_handler(error: Exception, context: Context, next_step):
 
 purchase_new_aws_environment = Pipeline(
     SetupContext(config),
+    ValidateOrder(),
     CRMTicketNewAccount(config),
     CreateNewAWSEnvironment(config),
     CreateBillingTransferInvitation(config),
@@ -84,6 +86,7 @@ purchase_new_aws_environment = Pipeline(
 
 purchase_existing_aws_environment = Pipeline(
     SetupContext(config),
+    ValidateOrder(),
     CreateBillingTransferInvitation(config),
     CheckBillingTransferInvitation(config),
     ConfigureAPNProgram(config),

--- a/swo_aws_extension/flows/order_utils.py
+++ b/swo_aws_extension/flows/order_utils.py
@@ -5,16 +5,18 @@ from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.mpt import (
     complete_order,
     fail_order,
+    get_agreements_by_query,
     get_product_template_or_default,
     query_order,
     update_order,
 )
 from mpt_extension_sdk.mpt_http.wrap_http_error import MPTError, wrap_mpt_http_error
 
-from swo_aws_extension.constants import MptOrderStatus
+from swo_aws_extension.constants import AgreementStatusEnum, MptOrderStatus
 from swo_aws_extension.flows.order import InitialAWSContext
 from swo_aws_extension.flows.steps.errors import OrderStatusChangeError
 from swo_aws_extension.parameters import get_mpa_account_id, set_mpa_account_id
+from swo_aws_extension.swo.rql.query_builder import RQLQuery
 
 logger = logging.getLogger(__name__)
 MPT_ORDER_STATUS_QUERYING = "Querying"
@@ -160,6 +162,29 @@ def update_processing_template(
     }
 
     context.order = update_order(client, context.order_id, **kwargs)
+
+
+def get_previous_order(client: MPTClient, order: dict) -> dict | None:
+    """Return the first active agreement for the same licensee and product, or None."""
+    licensee_id = order.get("licensee", {}).get("id")
+    if not licensee_id:
+        return None
+    product_id = order.get("product", {}).get("id")
+    client_id = order.get("client", {}).get("id")
+    rql_filter = (
+        RQLQuery(licensee__id__eq=licensee_id)
+        & RQLQuery(client__id__eq=client_id)
+        & RQLQuery(
+            status__in=[
+                AgreementStatusEnum.ACTIVE,
+                AgreementStatusEnum.UPDATING,
+                AgreementStatusEnum.PROVISIONING,
+            ]
+        )
+        & RQLQuery(product__id__in=[product_id])
+    )
+    agreements = get_agreements_by_query(client, str(rql_filter))
+    return agreements[0] if agreements else None
 
 
 def set_order_error(order: dict, error: dict) -> dict:

--- a/swo_aws_extension/flows/steps/validate_order.py
+++ b/swo_aws_extension/flows/steps/validate_order.py
@@ -1,0 +1,37 @@
+import logging
+from typing import override
+
+from mpt_extension_sdk.mpt_http.base import MPTClient
+
+from swo_aws_extension.flows.order import InitialAWSContext
+from swo_aws_extension.flows.order_utils import get_previous_order
+from swo_aws_extension.flows.steps.base import BasePhaseStep
+from swo_aws_extension.flows.steps.errors import FailStepError
+
+logger = logging.getLogger(__name__)
+
+
+class ValidateOrder(BasePhaseStep):
+    """Validate purchase order before processing."""
+
+    @override
+    def pre_step(self, context: InitialAWSContext) -> None:
+        logger.debug("%s - ValidateOrder - starting order validation", context.order_id)
+
+    @override
+    def process(self, client: MPTClient, context: InitialAWSContext) -> None:
+        if get_previous_order(client, context.order):
+            logger.warning(
+                "%s - Duplicate agreement found for licensee %s, failing order",
+                context.order_id,
+                context.order.get("licensee", {}).get("id"),
+            )
+            raise FailStepError(
+                "AWS004",
+                "An active agreement already exists for this licensee. "
+                "A new agreement can only be created with a different licensee.",
+            )
+
+    @override
+    def post_step(self, client: MPTClient, context: InitialAWSContext) -> None:
+        logger.info("%s - Next - ValidateOrder completed successfully", context.order_id)

--- a/swo_aws_extension/flows/validation/base.py
+++ b/swo_aws_extension/flows/validation/base.py
@@ -5,8 +5,15 @@ from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.mpt import get_product_items_by_skus
 from mpt_extension_sdk.mpt_http.wrap_http_error import ValidationError
 
-from swo_aws_extension.constants import AWS_ITEMS_SKUS, AccountTypesEnum, OrderParametersEnum
-from swo_aws_extension.flows.order_utils import strip_whitespace_from_mpa_account
+from swo_aws_extension.constants import (
+    AWS_ITEMS_SKUS,
+    AccountTypesEnum,
+    OrderParametersEnum,
+)
+from swo_aws_extension.flows.order_utils import (
+    get_previous_order,
+    strip_whitespace_from_mpa_account,
+)
 from swo_aws_extension.parameters import (
     get_account_type,
     get_ordering_parameter,
@@ -109,6 +116,24 @@ def _is_parameter_visible(order: dict, param_external_id: str) -> bool:
     return not constraints.get("hidden", True)
 
 
+def _validate_duplicate_agreement(client: MPTClient, order: dict) -> dict | None:
+    if order.get("type") != "Purchase":
+        return None
+    if get_previous_order(client, order):
+        return set_ordering_parameter_error(
+            order,
+            OrderParametersEnum.ACCOUNT_TYPE.value,
+            ValidationError(
+                err_id="AWS004",
+                message=(
+                    "An active agreement already exists for this licensee. "
+                    "A new agreement can only be created with a different licensee."
+                ),
+            ).to_dict(),
+        )
+    return None
+
+
 def _validate_new_account_constraints(order: dict) -> dict | None:
     """
     Validate that newAccountInstructions parameter is not visible.
@@ -154,6 +179,9 @@ def validate_order(client: MPTClient, order: dict) -> dict:
     validated_order = copy.deepcopy(order)
     validated_order = reset_ordering_parameters_error(validated_order)
     validated_order = strip_whitespace_from_mpa_account(validated_order)
+    error_order = _validate_duplicate_agreement(client, validated_order)
+    if error_order:
+        return error_order
     error_order = _validate_new_account_constraints(validated_order)
     if error_order:
         return error_order

--- a/tests/flows/fulfillment/test_pipelines.py
+++ b/tests/flows/fulfillment/test_pipelines.py
@@ -8,6 +8,7 @@ from swo_aws_extension.flows.fulfillment import pipelines
 def test_purchase_new_steps():
     expected_step_classes = [
         "SetupContext",
+        "ValidateOrder",
         "CRMTicketNewAccount",
         "CreateNewAWSEnvironment",
         "CreateBillingTransferInvitation",
@@ -35,6 +36,7 @@ def test_purchase_new_steps():
 def test_purchase_existing_steps():
     expected_step_classes = [
         "SetupContext",
+        "ValidateOrder",
         "CreateBillingTransferInvitation",
         "CheckBillingTransferInvitation",
         "ConfigureAPNProgram",

--- a/tests/flows/steps/test_validate_order.py
+++ b/tests/flows/steps/test_validate_order.py
@@ -1,0 +1,41 @@
+from mpt_extension_sdk.flows.pipeline import Step
+from mpt_extension_sdk.mpt_http.base import MPTClient
+
+from swo_aws_extension.flows.order import PurchaseContext
+from swo_aws_extension.flows.steps.validate_order import ValidateOrder
+
+
+def test_validate_order_fails_when_active_agreement_exists(
+    mocker, order_factory, order_parameters_factory
+):
+    mock_client = mocker.MagicMock(spec=MPTClient)
+    next_step_mock = mocker.MagicMock(spec=Step)
+    mock_fail = mocker.patch("swo_aws_extension.flows.steps.base.switch_order_status_to_failed")
+    mocker.patch(
+        "swo_aws_extension.flows.steps.validate_order.get_previous_order",
+        return_value={"id": "AGR-0001"},
+    )
+    context = PurchaseContext.from_order_data(order_factory())
+    step = ValidateOrder()
+
+    step(mock_client, context, next_step_mock)  # act
+
+    assert mock_fail.call_args[0][2]["id"] == "AWS004"
+    next_step_mock.assert_not_called()
+
+
+def test_validate_order_proceeds_when_no_previous_agreement(
+    mocker, order_factory, order_parameters_factory
+):
+    mock_client = mocker.MagicMock(spec=MPTClient)
+    next_step_mock = mocker.MagicMock(spec=Step)
+    mocker.patch(
+        "swo_aws_extension.flows.steps.validate_order.get_previous_order",
+        return_value=None,
+    )
+    context = PurchaseContext.from_order_data(order_factory())
+    step = ValidateOrder()
+
+    step(mock_client, context, next_step_mock)  # act
+
+    next_step_mock.assert_called_once()

--- a/tests/flows/test_order_utils.py
+++ b/tests/flows/test_order_utils.py
@@ -4,6 +4,7 @@ from mpt_extension_sdk.mpt_http.wrap_http_error import MPTError
 from swo_aws_extension.constants import OrderCompletedTemplate, OrderQueryingTemplateEnum
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.order_utils import (
+    get_previous_order,
     set_order_template,
     strip_whitespace_from_mpa_account,
     switch_order_status_to_complete,
@@ -268,3 +269,40 @@ def test_strip_whitespace_from_mpa_account_without_value(order_factory, order_pa
     result = strip_whitespace_from_mpa_account(order)
 
     assert not get_mpa_account_id(result)
+
+
+def test_get_previous_order_returns_agreement_when_found(mocker, order_factory):
+    client = mocker.MagicMock(spec=MPTClient)
+    agreement = {"id": "AGR-0001"}
+    mocker.patch(
+        "swo_aws_extension.flows.order_utils.get_agreements_by_query",
+        return_value=[agreement],
+    )
+    order = order_factory()
+
+    result = get_previous_order(client, order)
+
+    assert result == agreement
+
+
+def test_get_previous_order_returns_none_when_not_found(mocker, order_factory):
+    client = mocker.MagicMock(spec=MPTClient)
+    mocker.patch(
+        "swo_aws_extension.flows.order_utils.get_agreements_by_query",
+        return_value=[],
+    )
+    order = order_factory()
+
+    result = get_previous_order(client, order)
+
+    assert result is None
+
+
+def test_get_previous_order_returns_none_when_no_licensee(mocker):
+    client = mocker.MagicMock(spec=MPTClient)
+    mock_query = mocker.patch("swo_aws_extension.flows.order_utils.get_agreements_by_query")
+
+    result = get_previous_order(client, {})
+
+    assert result is None
+    mock_query.assert_not_called()

--- a/tests/flows/validation/test_base.py
+++ b/tests/flows/validation/test_base.py
@@ -31,6 +31,10 @@ def test_validate_order_orchestrates_all_steps_new_aws_environment(
         }
     ]
     mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value=None,
+    )
+    mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
         return_value=mock_items,
     )
@@ -77,6 +81,10 @@ def test_validate_order_orchestrates_all_steps_existing_aws_environment(
         }
     ]
     mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value=None,
+    )
+    mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
         return_value=mock_items,
     )
@@ -96,7 +104,7 @@ def test_validate_order_orchestrates_all_steps_existing_aws_environment(
 
 
 def test_validate_order_returns_error_when_new_account_instructions_visible(
-    order_factory, order_parameters_factory
+    order_factory, order_parameters_factory, mocker
 ):
     mock_client = MagicMock()
     order = order_factory(
@@ -109,6 +117,10 @@ def test_validate_order_returns_error_when_new_account_instructions_visible(
         order,
         OrderParametersEnum.NEW_ACCOUNT_INSTRUCTIONS.value,
         constraints={"hidden": False, "required": False, "readonly": False},
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value=None,
     )
 
     result = validate_order(mock_client, order)
@@ -126,6 +138,10 @@ def test_validate_order_with_invalid_account_type(order_factory, order_parameter
             account_type="INVALID_TYPE",
         ),
         lines=[],
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value=None,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
@@ -150,6 +166,10 @@ def test_validate_order_when_product_items_not_found(
         lines=[],
     )
     mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value=None,
+    )
+    mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
         return_value=[],
     )
@@ -170,6 +190,10 @@ def test_validate_order_strips_whitespace_from_mpa_account(
             constraints={"hidden": None, "required": None, "readonly": None},
         ),
         lines=[],
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value=None,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",

--- a/tests/flows/validation/test_duplicate_agreement.py
+++ b/tests/flows/validation/test_duplicate_agreement.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+
+from mpt_extension_sdk.mpt_http.base import MPTClient
+
+from swo_aws_extension.constants import (
+    AccountTypesEnum,
+    OrderParametersEnum,
+)
+from swo_aws_extension.flows.validation.base import validate_order
+from swo_aws_extension.parameters import get_ordering_parameter
+
+
+def test_validate_order_blocks_purchase_when_active_agreement_exists_for_licensee(
+    order_factory, order_parameters_factory, mocker
+):
+    mock_client = MagicMock(spec=MPTClient)
+    order = order_factory(
+        order_type="Purchase",
+        order_parameters=order_parameters_factory(
+            account_type=AccountTypesEnum.EXISTING_AWS_ENVIRONMENT.value,
+        ),
+        lines=[],
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value={"id": "AGR-0001"},
+    )
+
+    result = validate_order(mock_client, order)
+
+    account_type_param = get_ordering_parameter(OrderParametersEnum.ACCOUNT_TYPE.value, result)
+    assert account_type_param["error"]["id"] == "AWS004"
+
+
+def test_validate_order_allows_purchase_when_no_existing_agreement_for_licensee(
+    order_factory, order_parameters_factory, mocker
+):
+    mock_client = MagicMock(spec=MPTClient)
+    order = order_factory(
+        order_type="Purchase",
+        order_parameters=order_parameters_factory(
+            account_type=AccountTypesEnum.EXISTING_AWS_ENVIRONMENT.value,
+            constraints={"hidden": None, "required": None, "readonly": None},
+        ),
+        lines=[],
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+        return_value=None,
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
+        return_value=[{"id": "ITM-1", "name": "AWS Usage"}],
+    )
+
+    result = validate_order(mock_client, order)
+
+    account_type_param = get_ordering_parameter(OrderParametersEnum.ACCOUNT_TYPE.value, result)
+    assert account_type_param.get("error") is None
+
+
+def test_validate_order_skips_duplicate_check_for_non_purchase_orders(
+    order_factory, order_parameters_factory, mocker
+):
+    mock_client = MagicMock(spec=MPTClient)
+    order = order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(
+            account_type=AccountTypesEnum.EXISTING_AWS_ENVIRONMENT.value,
+            constraints={"hidden": None, "required": None, "readonly": None},
+        ),
+        lines=[],
+    )
+    mock_get_previous = mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_previous_order",
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
+        return_value=[{"id": "ITM-1", "name": "AWS Usage"}],
+    )
+
+    validate_order(mock_client, order)  # act
+
+    assert not mock_get_previous.called


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Backport of MPT-21023 from `main` to `release/5`.

- Add duplicate agreement validation in both the order validation and fulfillment flows
- Reject Purchase orders with error `AWS004` when an active or updating agreement already exists for the same licensee and product
- Change orders and other non-Purchase order types bypass the check

## Cherry-picked commit

`137cb6e` — fix: MPT-21023 block duplicate agreement creation for same licensee

## Test plan

- [ ] Verify a Purchase order is rejected with `AWS004` when an active agreement already exists for the same licensee and product
- [ ] Confirm a Purchase order for a different licensee or MPA is allowed through
- [ ] Confirm Change orders and other non-Purchase types bypass the duplicate check
- [ ] Run `make test` to confirm all validation and fulfillment tests pass

Closes [MPT-21023](https://softwareone.atlassian.net/browse/MPT-21023)

[MPT-21023]: https://softwareone.atlassian.net/browse/MPT-21023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21023](https://softwareone.atlassian.net/browse/MPT-21023)

**Release Notes:**

- Added duplicate-agreement validation to block Purchase orders when an active or updating agreement already exists for the same licensee and product, returning error code `AWS004`
- Validation checks are skipped for Change orders and other non-Purchase order types
- Integrated `ValidateOrder` step into fulfillment pipelines (`purchase_new_aws_environment` and `purchase_existing_aws_environment`) to perform upfront validation
- Added `get_previous_order` helper function to query existing agreements by licensee and product
- Added `PROVISIONING` status to `AgreementStatusEnum` to include provisioning-state agreements in duplicate detection
- Updated validation flow to check for duplicate agreements before other account constraint validations
- Added comprehensive test coverage for duplicate-agreement validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-aws-extension/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->