### PR TITLE
[BACKPORT] MPT-21159 billing report with two sheets and linked account breakdown

### DIFF
--- a/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
@@ -101,9 +101,16 @@ class BillingJournalService:
         report_rows = [
             row for auth_result in journal_results for row in auth_result.billing_report_rows
         ]
+        report_rows_by_account = [
+            row
+            for auth_result in journal_results
+            for row in auth_result.billing_report_rows_by_account
+        ]
         if report_rows and not self._context.dry_run:
             report_creator = BillingReportCreator(self._context.config, self._context.notifier)
-            report_creator.create_and_notify_teams(str(self._context.billing_period), report_rows)
+            report_creator.create_and_notify_teams(
+                str(self._context.billing_period), report_rows, report_rows_by_account
+            )
 
     def _process_authorization(self, authorization: dict) -> AuthorizationJournalResult | None:
         authorization_id = authorization.get("id", "")

--- a/swo_aws_extension/flows/jobs/billing_journal/billing_report_creator.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/billing_report_creator.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from swo_aws_extension.config import Config
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import BillingReportRow
 from swo_aws_extension.logger import get_logger
@@ -7,18 +9,45 @@ from swo_aws_extension.swo.notifications.teams import Button, TeamsNotificationM
 
 logger = get_logger(__name__)
 
+
+def _format_spp_discount_pct(discount_pct: Decimal) -> str:
+    rounded = discount_pct.quantize(Decimal("0.0001"))
+    ratio_str = f"{rounded:.4f}".replace(".", ",")
+    pct = discount_pct * 100
+    return f"{ratio_str} ({pct:.2f}%)"
+
+
 BILLING_REPORT_HEADERS = (
     "Authorization ID",
     "PMA",
     "Agreement ID",
     "MPA",
     "Service Name",
-    "Amount",
+    "PP",
+    "SP",
     "Currency",
     "Invoice ID",
     "Invoice Entity",
     "Exchange Rate",
     "SPP Discount",
+    "SPP Discount %",
+)
+
+BILLING_REPORT_BY_ACCOUNT_HEADERS = (
+    "Authorization ID",
+    "PMA",
+    "Agreement ID",
+    "MPA",
+    "Linked Account",
+    "Service Name",
+    "PP",
+    "SP",
+    "Currency",
+    "Invoice ID",
+    "Invoice Entity",
+    "Exchange Rate",
+    "SPP Discount",
+    "SPP Discount %",
 )
 
 
@@ -36,7 +65,10 @@ class BillingReportCreator:
         )
 
     def create_and_notify_teams(
-        self, billing_period_str: str, report_rows: list[BillingReportRow]
+        self,
+        billing_period_str: str,
+        report_rows: list[BillingReportRow],
+        rows_by_account: list[BillingReportRow] | None = None,
     ) -> None:
         """Create the report, upload to Azure, and notify teams."""
         if not report_rows:
@@ -45,7 +77,9 @@ class BillingReportCreator:
 
         logger.info("Creating billing report Excel file...")
         rows_data = self._build_rows_data(report_rows)
-        excel_bytes = self._generate_excel(rows_data)
+        excel_bytes = self._generate_excel(
+            rows_data, self._build_rows_by_account_data(rows_by_account or [])
+        )
         folder = self._config.report_billing_folder
         blob_name = f"{folder}{billing_period_str}.xlsx"
 
@@ -69,8 +103,13 @@ class BillingReportCreator:
         )
         logger.info("Billing report uploaded and Teams notification sent.")
 
-    def _generate_excel(self, rows_data: list[list[str]]) -> bytes:
-        return self._excel_builder.build_from_rows(rows_data)
+    def _generate_excel(
+        self, rows_data: list[list[str]], by_account_data: list[list[str]]
+    ) -> bytes:
+        return self._excel_builder.build_multi_sheet([
+            ("Billing Report", list(BILLING_REPORT_HEADERS), rows_data),
+            ("By Linked Account", list(BILLING_REPORT_BY_ACCOUNT_HEADERS), by_account_data),
+        ])
 
     def _upload(self, excel_bytes: bytes, blob_name: str) -> str:
         return self._blob_uploader.upload_and_get_sas_url(excel_bytes, blob_name)
@@ -83,12 +122,35 @@ class BillingReportCreator:
                 row.agreement_id,
                 row.mpa,
                 row.service_name,
-                str(row.amount),
+                str(row.pp),
+                str(row.sp),
                 row.currency,
                 row.invoice_id,
                 row.invoice_entity,
                 str(row.exchange_rate),
                 str(row.spp_discount),
+                _format_spp_discount_pct(row.spp_discount_pct),
             ]
             for row in report_rows
+        ]
+
+    def _build_rows_by_account_data(self, rows: list[BillingReportRow]) -> list[list[str]]:
+        return [
+            [
+                row.authorization_id,
+                row.pma,
+                row.agreement_id,
+                row.mpa,
+                row.linked_account,
+                row.service_name,
+                str(row.pp),
+                str(row.sp),
+                row.currency,
+                row.invoice_id,
+                row.invoice_entity,
+                str(row.exchange_rate),
+                str(row.spp_discount),
+                _format_spp_discount_pct(row.spp_discount_pct),
+            ]
+            for row in rows
         ]

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
@@ -4,8 +4,8 @@ from mpt_extension_sdk.runtime.tracer import dynamic_trace_span
 
 from swo_aws_extension.constants import ResponsibilityTransferStatus, SupportTypesEnum
 from swo_aws_extension.flows.jobs.billing_journal.generators.billing_report_rows import (
+    BillingReportRowsBuilder,
     ReportContext,
-    generate_billing_report_rows,
 )
 from swo_aws_extension.flows.jobs.billing_journal.generators.discount.extra_discounts import (
     ExtraDiscountsManager,
@@ -149,16 +149,17 @@ class AgreementJournalGenerator:
                 )
             )
 
-        report_rows = generate_billing_report_rows(
-            context=ReportContext.from_contexts(self._auth_context, journal_details),
-            usage_result=usage_result,
-            organization_invoice=organization_invoice,
+        report_builder = BillingReportRowsBuilder(
+            ReportContext.from_contexts(self._auth_context, journal_details),
+            usage_result,
+            organization_invoice,
         )
 
         return AgreementJournalResult(
             lines=all_lines,
             report=usage_result.reports,
-            billing_report_rows=report_rows,
+            billing_report_rows=report_builder.build(),
+            billing_report_rows_by_account=report_builder.build_by_account(),
             pls_mismatches=pls_mismatches,
         )
 

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
@@ -8,8 +8,8 @@ from swo_aws_extension.flows.jobs.billing_journal.generators.agreement import (
     AgreementJournalGenerator,
 )
 from swo_aws_extension.flows.jobs.billing_journal.generators.billing_report_rows import (
+    BillingReportRowsBuilder,
     ReportContext,
-    generate_billing_report_rows,
 )
 from swo_aws_extension.flows.jobs.billing_journal.generators.invoice import InvoiceGenerator
 from swo_aws_extension.flows.jobs.billing_journal.generators.usage import CostExplorerUsageGenerator
@@ -133,6 +133,10 @@ class AuthorizationJournalGenerator:
             result.reports_by_agreement[agreement_id] = agreement_result.report
         if agreement_result.billing_report_rows:
             result.billing_report_rows.extend(agreement_result.billing_report_rows)
+        if agreement_result.billing_report_rows_by_account:
+            result.billing_report_rows_by_account.extend(
+                agreement_result.billing_report_rows_by_account
+            )
         if agreement_result.pls_mismatches:
             result.pls_mismatches.extend(agreement_result.pls_mismatches)
 
@@ -161,12 +165,13 @@ class AuthorizationJournalGenerator:
             mpa=auth_context.pma_account,
             currency=auth_context.currency,
         )
-        pma_report_rows = generate_billing_report_rows(
-            context=pma_report_context,
-            usage_result=pma_usage,
-            organization_invoice=pma_invoice,
+        report_builder = BillingReportRowsBuilder(
+            pma_report_context,
+            pma_usage,
+            pma_invoice,
         )
-        result.billing_report_rows.extend(pma_report_rows)
+        result.billing_report_rows.extend(report_builder.build())
+        result.billing_report_rows_by_account.extend(report_builder.build_by_account())
 
     def _fetch_raw_pma_usage(
         self,

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/billing_report_rows.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/billing_report_rows.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal
+from itertools import starmap
 from typing import TYPE_CHECKING, TypedDict
 
 from swo_aws_extension.constants import DEC_ZERO, AWSRecordTypeEnum
@@ -53,60 +54,95 @@ class ReportContext:
         )
 
 
-type ReportGroupsAlias = dict[tuple[str, str, str], ServiceAmounts]
+class BillingReportRowsBuilder:
+    """Builds billing report rows from usage metrics and invoice data."""
 
+    def __init__(
+        self,
+        context: ReportContext,
+        usage_result: OrganizationUsageResult,
+        organization_invoice: OrganizationInvoice,
+    ):
+        self._context = context
+        self._usage_result = usage_result
+        self._invoice = organization_invoice
 
-def _process_metrics(
-    metrics: list[ServiceMetric],
-    groups: ReportGroupsAlias,
-) -> None:
-    for metric in metrics:
-        key = (metric.service_name, metric.invoice_id or "", metric.invoice_entity or "")
+    def build(self) -> list[BillingReportRow]:
+        """Aggregate usage metrics into distinct billing report rows."""
+        groups: dict[tuple[str, str, str], ServiceAmounts] = {}
+        for account_usage in self._usage_result.usage_by_account.values():
+            for metric in account_usage.metrics:
+                key = (metric.service_name, metric.invoice_id or "", metric.invoice_entity or "")
+                self._accumulate(groups, key, metric)
+        return list(starmap(self._to_row, groups.items()))
+
+    def build_by_account(self) -> list[BillingReportRow]:
+        """Build billing report rows broken down by linked account."""
+        return [
+            self._to_row(
+                (service_name, inv_id, inv_entity),
+                amounts,
+                linked_account=account_id,
+            )
+            for (
+                account_id,
+                service_name,
+                inv_id,
+                inv_entity,
+            ), amounts in self._group_by_account().items()
+        ]
+
+    def _group_by_account(self) -> dict[tuple[str, str, str, str], ServiceAmounts]:
+        groups: dict[tuple[str, str, str, str], ServiceAmounts] = {}
+        for account_id, account_usage in self._usage_result.usage_by_account.items():
+            for metric in account_usage.metrics:
+                key = (
+                    account_id,
+                    metric.service_name,
+                    metric.invoice_id or "",
+                    metric.invoice_entity or "",
+                )
+                self._accumulate(groups, key, metric)
+        return groups
+
+    def _accumulate(self, groups: dict, key: tuple, metric: ServiceMetric) -> None:
         if key not in groups:
             groups[key] = ServiceAmounts(amount=DEC_ZERO, spp_discount=DEC_ZERO)
-
         if metric.record_type == AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT:
             groups[key]["spp_discount"] += metric.amount
         else:
             groups[key]["amount"] += metric.amount
 
-
-def _group_service_metrics(
-    usage_result: OrganizationUsageResult,
-) -> ReportGroupsAlias:
-    groups: ReportGroupsAlias = {}
-    for account_usage in usage_result.usage_by_account.values():
-        _process_metrics(account_usage.metrics, groups)
-    return groups
-
-
-def _resolve_exchange_rate(inv_entity: str, org_invoice: OrganizationInvoice) -> Decimal:
-    if inv_entity and inv_entity in org_invoice.entities:
-        return org_invoice.entities[inv_entity].exchange_rate
-    return Decimal("1.0")
-
-
-def generate_billing_report_rows(
-    context: ReportContext,
-    usage_result: OrganizationUsageResult,
-    organization_invoice: OrganizationInvoice,
-) -> list[BillingReportRow]:
-    """Aggregate usage metrics into distinct billing report rows."""
-    groups = _group_service_metrics(usage_result)
-
-    return [
-        BillingReportRow(
-            authorization_id=context.authorization_id,
-            pma=context.pma,
-            agreement_id=context.agreement_id,
-            mpa=context.mpa,
+    def _to_row(
+        self,
+        metric_key: tuple,
+        amounts: ServiceAmounts,
+        linked_account: str = "",
+    ) -> BillingReportRow:
+        service_name, inv_id, inv_entity = metric_key
+        exchange_rate = self._resolve_exchange_rate(inv_entity)
+        spp_discount_pct = (
+            abs(amounts["spp_discount"]) / amounts["amount"] if amounts["amount"] else DEC_ZERO
+        )
+        return BillingReportRow(
+            authorization_id=self._context.authorization_id,
+            pma=self._context.pma,
+            agreement_id=self._context.agreement_id,
+            mpa=self._context.mpa,
             service_name=service_name,
-            amount=amounts["amount"],
-            currency=context.currency,
+            pp=(amounts["amount"] - abs(amounts["spp_discount"])) * exchange_rate,
+            sp=amounts["amount"] * exchange_rate,
+            currency=self._context.currency,
             invoice_id=inv_id,
             invoice_entity=inv_entity,
-            exchange_rate=_resolve_exchange_rate(inv_entity, organization_invoice),
-            spp_discount=amounts["spp_discount"],
+            exchange_rate=exchange_rate,
+            spp_discount=amounts["spp_discount"] * exchange_rate,
+            spp_discount_pct=spp_discount_pct,
+            linked_account=linked_account,
         )
-        for (service_name, inv_id, inv_entity), amounts in groups.items()
-    ]
+
+    def _resolve_exchange_rate(self, inv_entity: str) -> Decimal:
+        if inv_entity and inv_entity in self._invoice.entities:
+            rate = self._invoice.entities[inv_entity].exchange_rate
+            return rate if rate > DEC_ZERO else Decimal("1.0")
+        return Decimal("1.0")

--- a/swo_aws_extension/flows/jobs/billing_journal/models/journal_result.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/journal_result.py
@@ -14,12 +14,15 @@ class BillingReportRow:
     agreement_id: str
     mpa: str
     service_name: str
-    amount: Decimal
+    pp: Decimal
+    sp: Decimal
     currency: str
     invoice_id: str
     invoice_entity: str
     exchange_rate: Decimal
     spp_discount: Decimal
+    spp_discount_pct: Decimal
+    linked_account: str = ""
 
 
 @dataclass
@@ -48,6 +51,7 @@ class AgreementJournalResult:
     lines: list[JournalLine] = field(default_factory=list)
     report: OrganizationReport | None = None
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
+    billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)
 
 
@@ -58,4 +62,5 @@ class AuthorizationJournalResult:
     lines: list[JournalLine] = field(default_factory=list)
     reports_by_agreement: dict[str, OrganizationReport] = field(default_factory=dict)
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
+    billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)

--- a/swo_aws_extension/swo/excel_report_builder.py
+++ b/swo_aws_extension/swo/excel_report_builder.py
@@ -3,6 +3,11 @@ from pathlib import Path
 
 from openpyxl import Workbook
 from openpyxl.styles import Font
+from openpyxl.worksheet.worksheet import Worksheet
+
+type SheetDefinition = tuple[str, list[str], list[list[str]]]
+
+_HEADER_FONT = Font(bold=True)
 
 
 class ExcelReportBuilder:
@@ -12,28 +17,42 @@ class ExcelReportBuilder:
         self.headers = headers
         self.sheet_name = sheet_name
 
-    def build_from_rows(self, rows: list[list[str]]) -> bytes:  # noqa: WPS210
+    def build_from_rows(self, rows: list[list[str]]) -> bytes:
         """Build an Excel workbook in memory and return its raw bytes."""
         wb = Workbook()
         ws = wb.active
         if ws.title == "Sheet":
             ws.title = self.sheet_name
+        self._populate_sheet(ws, self.headers, rows)
+        return self._save_to_bytes(wb)
 
-        header_font = Font(bold=True)
-        for col, header in enumerate(self.headers, start=1):
-            cell = ws.cell(row=1, column=col, value=header)
-            cell.font = header_font
-
-        for row_idx, row_data in enumerate(rows, start=2):
-            for col_idx, cell_value in enumerate(row_data, start=1):
-                ws.cell(row=row_idx, column=col_idx, value=cell_value)
-
-        ws.auto_filter.ref = ws.dimensions
-
-        buffer = BytesIO()
-        wb.save(buffer)
-        return buffer.getvalue()
+    def build_multi_sheet(self, sheets: list[SheetDefinition]) -> bytes:
+        """Build an Excel workbook with multiple named sheets and return its raw bytes."""
+        wb = Workbook()
+        for idx, sheet_def in enumerate(sheets):
+            ws = wb.active if idx == 0 else wb.create_sheet()
+            ws.title = sheet_def[0]
+            self._populate_sheet(ws, sheet_def[1], sheet_def[2])
+        return self._save_to_bytes(wb)
 
     def save(self, file_path: str, file_content: bytes) -> None:
         """Save the provided bytes to the specified file path."""
         Path(file_path).write_bytes(file_content)
+
+    def _populate_sheet(
+        self,
+        ws: Worksheet,
+        headers: list[str],
+        rows: list[list[str]],
+    ) -> None:
+        ws.append(headers)
+        for cell in ws[1]:
+            cell.font = _HEADER_FONT
+        for row_data in rows:
+            ws.append(row_data)
+        ws.auto_filter.ref = ws.dimensions
+
+    def _save_to_bytes(self, wb: Workbook) -> bytes:
+        buf = BytesIO()
+        wb.save(buf)
+        return buf.getvalue()

--- a/tests/flows/jobs/billing_journal/generators/test_agreement.py
+++ b/tests/flows/jobs/billing_journal/generators/test_agreement.py
@@ -114,7 +114,10 @@ def test_run(
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="PartnerLedSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_discount_line = mocker.MagicMock(spec=JournalLine)
@@ -168,7 +171,10 @@ def test_run_without_pls(
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="DeveloperSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
@@ -315,7 +321,10 @@ def test_run_processes_when_transfer_started_on_billing_start(
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement()
     mock_aws_client.get_responsibility_transfer_details.return_value = {
         "ResponsibilityTransfer": {
@@ -368,7 +377,10 @@ def test_pls_mismatch_param_pls_but_no_enterprise_in_report(
     mock_pls_charge_manager_cls,
 ):
     """When param says PLS but report has no Enterprise Support, record mismatch."""
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="PartnerLedSupport")
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = []
@@ -411,7 +423,10 @@ def test_pls_mismatch_param_resold_but_enterprise_in_report(
     mock_pls_charge_manager_cls,
 ):
     """When param says Resold but report has Enterprise Support, record mismatch and apply PLS."""
-    mocker.patch(f"{MODULE}.generate_billing_report_rows", return_value=[])
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="ResoldSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_pls_line = mocker.MagicMock(spec=JournalLine)

--- a/tests/flows/jobs/billing_journal/generators/test_authorization.py
+++ b/tests/flows/jobs/billing_journal/generators/test_authorization.py
@@ -63,7 +63,11 @@ def mock_aws_client_cls(mocker):
 
 @pytest.fixture
 def mock_generate_billing_report_rows(mocker):
-    return mocker.patch(f"{MODULE}.generate_billing_report_rows", autospec=True)
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
+    return mock_builder
 
 
 def test_no_agreements_returns_empty_list(
@@ -146,9 +150,13 @@ def test_includes_report_in_result(
     mock_get_agreements.return_value = [{"id": "AGR-1"}]
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_row = mocker.MagicMock(spec=BillingReportRow)
+    mock_row_by_account = mocker.MagicMock(spec=BillingReportRow)
     mock_agr_gen = mocker.MagicMock(spec=AgreementJournalGenerator)
     mock_agr_gen.run.return_value = AgreementJournalResult(
-        lines=[mock_journal_line], report=report, billing_report_rows=[mock_row]
+        lines=[mock_journal_line],
+        report=report,
+        billing_report_rows=[mock_row],
+        billing_report_rows_by_account=[mock_row_by_account],
     )
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
@@ -157,6 +165,7 @@ def test_includes_report_in_result(
 
     assert result.reports_by_agreement == {"AGR-1": report}
     assert result.billing_report_rows == [mock_row]
+    assert result.billing_report_rows_by_account == [mock_row_by_account]
 
 
 def test_includes_pls_mismatches_in_result(
@@ -208,7 +217,7 @@ def test_pma_usage_included_in_report_rows(
     mock_invoice_gen.run.return_value = mock_pma_invoice_result
     mock_usage_gen.run_for_pma.return_value = mock_pma_usage_result
     mock_row = mocker.MagicMock(spec=BillingReportRow)
-    mock_generate_billing_report_rows.return_value = [mock_row]
+    mock_generate_billing_report_rows.build.return_value = [mock_row]
     generator = AuthorizationJournalGenerator(mock_context)
 
     result = generator.run(authorization)
@@ -220,7 +229,7 @@ def test_pma_usage_included_in_report_rows(
         organization_invoice=mock_pma_invoice_result.invoice,
         granularity="MONTHLY",
     )
-    mock_generate_billing_report_rows.assert_called_once()
+    mock_generate_billing_report_rows.build.assert_called_once()
     assert mock_row in result.billing_report_rows
 
 

--- a/tests/flows/jobs/billing_journal/generators/test_billing_report_rows.py
+++ b/tests/flows/jobs/billing_journal/generators/test_billing_report_rows.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.constants import AWSRecordTypeEnum
 from swo_aws_extension.flows.jobs.billing_journal.generators.billing_report_rows import (
+    BillingReportRowsBuilder,
     ReportContext,
-    generate_billing_report_rows,
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.context import (
     AuthorizationContext,
@@ -46,8 +46,9 @@ def test_generate_billing_report_rows_aggregates_metrics():
     usage_result = OrganizationUsageResult(
         reports=OrganizationReport(), usage_by_account={"ACC-1": account_usage}
     )
+    exchange_rate = Decimal("1.2")
     org_invoice = OrganizationInvoice(
-        entities={"INV-E1": InvoiceEntity("INV-1", "USD", "USD", Decimal("1.2"))}
+        entities={"INV-E1": InvoiceEntity("INV-1", "USD", "USD", exchange_rate)},
     )
     context = ReportContext("AUTH-1", "PMA-1", "AGR-1", "MPA-1", "USD")
     expected_row = BillingReportRow(
@@ -56,15 +57,17 @@ def test_generate_billing_report_rows_aggregates_metrics():
         agreement_id="AGR-1",
         mpa="MPA-1",
         service_name="EC2",
-        amount=Decimal(AGGREGATED_AMOUNT),
+        pp=(Decimal(AGGREGATED_AMOUNT) - abs(Decimal(TEST_AMOUNT_M5))) * exchange_rate,
+        sp=Decimal(AGGREGATED_AMOUNT) * exchange_rate,
         currency="USD",
         invoice_id="INV-1",
         invoice_entity="INV-E1",
-        exchange_rate=Decimal("1.2"),
-        spp_discount=Decimal(TEST_AMOUNT_M5),
+        exchange_rate=exchange_rate,
+        spp_discount=Decimal(TEST_AMOUNT_M5) * exchange_rate,
+        spp_discount_pct=abs(Decimal(TEST_AMOUNT_M5)) / (Decimal(AGGREGATED_AMOUNT)),
     )
 
-    result = generate_billing_report_rows(context, usage_result, org_invoice)
+    result = BillingReportRowsBuilder(context, usage_result, org_invoice).build()
 
     assert len(result) == 1
     assert result[0] == expected_row
@@ -104,7 +107,31 @@ def test_generate_billing_report_rows_defaults_exchange_rate_for_unknown_entity(
     org_invoice = OrganizationInvoice(entities={})
     context = ReportContext("AUTH-1", "PMA-1", "AGR-1", "MPA-1", "USD")
 
-    result = generate_billing_report_rows(context, usage_result, org_invoice)
+    result = BillingReportRowsBuilder(context, usage_result, org_invoice).build()
 
     assert len(result) == 1
     assert result[0].exchange_rate == Decimal("1.0")
+
+
+def test_build_by_account_groups_by_linked_account():
+    metric1 = ServiceMetric(
+        "EC2", AWSRecordTypeEnum.USAGE, Decimal(MEDIUM_AMOUNT), "INV-E1", "INV-1"
+    )
+    metric2 = ServiceMetric("S3", AWSRecordTypeEnum.USAGE, Decimal(SMALL_AMOUNT), "INV-E1", "INV-1")
+    usage_result = OrganizationUsageResult(
+        reports=OrganizationReport(),
+        usage_by_account={
+            "ACC-1": AccountUsage([metric1]),
+            "ACC-2": AccountUsage([metric2]),
+        },
+    )
+    org_invoice = OrganizationInvoice(
+        entities={"INV-E1": InvoiceEntity("INV-1", "USD", "USD", Decimal("1.0"))},
+    )
+    context = ReportContext("AUTH-1", "PMA-1", "AGR-1", "MPA-1", "USD")
+
+    result = BillingReportRowsBuilder(context, usage_result, org_invoice).build_by_account()
+
+    assert len(result) == 2
+    accounts = {row.linked_account for row in result}
+    assert accounts == {"ACC-1", "ACC-2"}

--- a/tests/flows/jobs/billing_journal/test_billing_journal_service.py
+++ b/tests/flows/jobs/billing_journal/test_billing_journal_service.py
@@ -140,7 +140,7 @@ def test_processes_authorizations_creates_billing_report(
     service.run()  # act
 
     mock_report_creator.create_and_notify_teams.assert_called_once_with(
-        str(mock_context.billing_period), [mock_row]
+        str(mock_context.billing_period), [mock_row], []
     )
 
 

--- a/tests/flows/jobs/billing_journal/test_billing_report_creator.py
+++ b/tests/flows/jobs/billing_journal/test_billing_report_creator.py
@@ -38,12 +38,14 @@ def sample_row():
         agreement_id="AGR-1",
         mpa="MPA-1",
         service_name="EC2",
-        amount=Decimal("10.5"),
+        pp=Decimal("10.5"),
+        sp=Decimal("11.5"),
         currency="USD",
         invoice_id="INV-1",
         invoice_entity="INV-E1",
         exchange_rate=Decimal("1.2"),
         spp_discount=Decimal("-1.0"),
+        spp_discount_pct=Decimal("1.0") / Decimal("11.5"),
     )
 
 
@@ -54,7 +56,7 @@ def test_create_and_notify_teams_skips_empty(
 
     creator.create_and_notify_teams("2024-01", [])  # act
 
-    mock_excel_builder_cls.return_value.build_from_rows.assert_not_called()
+    mock_excel_builder_cls.return_value.build_multi_sheet.assert_not_called()
     mock_notifier.send_success.assert_not_called()
 
 
@@ -62,14 +64,14 @@ def test_create_and_notify_teams_success(
     mock_config, mock_notifier, mock_blob_uploader_cls, mock_excel_builder_cls, sample_row
 ):
     mock_excel_builder = mock_excel_builder_cls.return_value
-    mock_excel_builder.build_from_rows.return_value = b"excel_bytes"
+    mock_excel_builder.build_multi_sheet.return_value = b"excel_bytes"
     mock_blob_uploader = mock_blob_uploader_cls.return_value
     mock_blob_uploader.upload_and_get_sas_url.return_value = "https://azure.blob/report.xlsx"
     creator = BillingReportCreator(mock_config, mock_notifier)
 
     creator.create_and_notify_teams("2024-01", [sample_row])  # act
 
-    mock_excel_builder.build_from_rows.assert_called_once()
+    mock_excel_builder.build_multi_sheet.assert_called_once()
     mock_blob_uploader.upload_and_get_sas_url.assert_called_once()
     mock_notifier.send_success.assert_called_once()
 
@@ -77,7 +79,7 @@ def test_create_and_notify_teams_success(
 def test_create_and_notify_teams_upload_failure(
     mock_config, mock_notifier, mock_blob_uploader_cls, mock_excel_builder_cls, sample_row
 ):
-    mock_excel_builder_cls.return_value.build_from_rows.return_value = b"excel_bytes"
+    mock_excel_builder_cls.return_value.build_multi_sheet.return_value = b"excel_bytes"
     mock_blob_uploader_cls.return_value.upload_and_get_sas_url.side_effect = Exception(
         "Upload failed"
     )
@@ -93,13 +95,61 @@ def test_create_and_notify_teams_converts_decimals_to_string(
     mock_config, mock_notifier, mock_blob_uploader_cls, mock_excel_builder_cls, sample_row
 ):
     mock_excel_builder = mock_excel_builder_cls.return_value
-    mock_excel_builder.build_from_rows.return_value = b"excel_bytes"
+    mock_excel_builder.build_multi_sheet.return_value = b"excel_bytes"
     mock_blob_uploader_cls.return_value.upload_and_get_sas_url.return_value = "https://url"
     creator = BillingReportCreator(mock_config, mock_notifier)
 
     creator.create_and_notify_teams("2024-01", [sample_row])  # act
 
-    rows_data = mock_excel_builder.build_from_rows.call_args[0][0]
-    assert rows_data[0][5] == "10.5"
-    assert rows_data[0][9] == "1.2"
-    assert rows_data[0][10] == "-1.0"
+    call_args = mock_excel_builder.build_multi_sheet.call_args[0][0]
+    sheet1_name, _, sheet1_rows = call_args[0]
+    assert sheet1_name == "Billing Report"
+    expected_row = [
+        "AUTH-1",
+        "PMA-1",
+        "AGR-1",
+        "MPA-1",
+        "EC2",
+        "10.5",
+        "11.5",
+        "USD",
+        "INV-1",
+        "INV-E1",
+        "1.2",
+        "-1.0",
+        "0,0870 (8.70%)",
+    ]
+    assert sheet1_rows == [expected_row]
+
+
+def test_create_and_notify_teams_builds_by_account_sheet(
+    mock_config, mock_notifier, mock_blob_uploader_cls, mock_excel_builder_cls, sample_row
+):
+    mock_excel_builder = mock_excel_builder_cls.return_value
+    mock_excel_builder.build_multi_sheet.return_value = b"excel_bytes"
+    mock_blob_uploader_cls.return_value.upload_and_get_sas_url.return_value = "https://url"
+    by_account_row = BillingReportRow(
+        authorization_id="AUTH-1",
+        pma="PMA-1",
+        agreement_id="AGR-1",
+        mpa="MPA-1",
+        service_name="EC2",
+        pp=Decimal("10.5"),
+        sp=Decimal("11.5"),
+        currency="USD",
+        invoice_id="INV-1",
+        invoice_entity="INV-E1",
+        exchange_rate=Decimal("1.2"),
+        spp_discount=Decimal("-1.0"),
+        spp_discount_pct=Decimal("1.0") / Decimal("11.5"),
+        linked_account="ACC-001",
+    )
+    creator = BillingReportCreator(mock_config, mock_notifier)
+
+    creator.create_and_notify_teams("2024-01", [sample_row], [by_account_row])  # act
+
+    call_args = mock_excel_builder.build_multi_sheet.call_args[0][0]
+    sheet2_name, sheet2_headers, sheet2_rows = call_args[1]
+    assert sheet2_name == "By Linked Account"
+    assert "Linked Account" in sheet2_headers
+    assert sheet2_rows[0][4] == "ACC-001"

--- a/tests/swo/test_excel_report_builder.py
+++ b/tests/swo/test_excel_report_builder.py
@@ -35,3 +35,36 @@ def test_save_writes_bytes_to_file(tmp_path):
     builder.save(str(output_file), file_content)  # act
 
     assert output_file.read_bytes() == file_content
+
+
+def test_build_multi_sheet_creates_multiple_sheets():
+    builder = ExcelReportBuilder([], "Unused")
+    sheets = [
+        ("Sales", ["Region", "Amount"], [["EU", "100"], ["US", "200"]]),
+        ("Returns", ["Item", "Qty"], [["Widget", "5"]]),
+    ]
+
+    result = builder.build_multi_sheet(sheets)
+
+    wb = load_workbook(filename=BytesIO(result))
+    assert wb.sheetnames == ["Sales", "Returns"]
+    sales_ws = wb["Sales"]
+    assert sales_ws.cell(row=1, column=1).value == "Region"
+    assert sales_ws.cell(row=2, column=2).value == "100"
+    returns_ws = wb["Returns"]
+    assert returns_ws.cell(row=1, column=1).value == "Item"
+    assert returns_ws.cell(row=2, column=1).value == "Widget"
+
+
+def test_build_from_rows_keeps_existing_sheet_title(mocker):
+    builder = ExcelReportBuilder(["H1"], "Custom")
+    mock_wb = mocker.patch(
+        "swo_aws_extension.swo.excel_report_builder.Workbook",
+    ).return_value
+    mock_ws = mock_wb.active
+    mock_ws.title = "AlreadyNamed"
+    mock_ws.dimensions = "A1:A1"
+
+    builder.build_from_rows([])  # act
+
+    assert mock_ws.title == "AlreadyNamed"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Backport of [MPT-21159](https://softwareone.atlassian.net/browse/MPT-21159) — implements the billing report generation logic with two sheets and a linked account breakdown.

Cherry-picked commit `3a5866e` from `main` onto `release/5` with no conflicts.

## Changes

- Extended `billing_report_creator.py` to produce a two-sheet Excel report
- Updated `agreement.py`, `authorization.py`, and `billing_report_rows.py` generators to include linked account breakdown data
- Refined `excel_report_builder.py` to support multi-sheet output
- Updated `journal_result.py` model and `billing_journal_service.py` accordingly
- Added and extended tests for all affected modules

## Related

- Original PR: #340
- Epic: [MPT-20925](https://softwareone.atlassian.net/browse/MPT-20925)
- Subtask: [MPT-21159](https://softwareone.atlassian.net/browse/MPT-21159)

[MPT-21159]: https://softwareone.atlassian.net/browse/MPT-21159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-20925]: https://softwareone.atlassian.net/browse/MPT-20925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-21159]: https://softwareone.atlassian.net/browse/MPT-21159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21159](https://softwareone.atlassian.net/browse/MPT-21159)

- **Two-sheet Excel billing report**: Added generation of monthly billing reports with two sheets — "Billing Report" (aggregated by service/invoice) and "By Linked Account" (per-account breakdown)
- **Enhanced BillingReportRow**: Extended data model with `pp`, `sp`, `spp_discount_pct`, and `linked_account` fields to support detailed billing and discount information
- **BillingReportRowsBuilder**: Refactored billing report row generation into a builder class with `build()` for aggregated rows and `build_by_account()` for per-account grouped rows
- **ExcelReportBuilder enhancements**: Added `build_multi_sheet()` method to generate workbooks with multiple named sheets, with shared header styling logic
- **BillingReportCreator refactoring**: Updated to accept and process both aggregated and per-account billing rows, generating multi-sheet Excel output with formatted discount percentages (using comma decimal separator and percentage in parentheses)
- **Updated service and generator modules**: Refactored `BillingJournalService`, `AgreementJournalGenerator`, and `AuthorizationJournalGenerator` to use the new builder pattern and support account-level billing breakdown
- **Comprehensive test updates**: Added/updated tests for multi-sheet generation, per-account grouping, and new billing field calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-aws-extension/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->