### PR TITLE
MPT-21777 Fix issue checking if there is a previous order for the sam…

### DIFF
--- a/swo_aws_extension/flows/order_utils.py
+++ b/swo_aws_extension/flows/order_utils.py
@@ -164,11 +164,11 @@ def update_processing_template(
     context.order = update_order(client, context.order_id, **kwargs)
 
 
-def get_previous_order(client: MPTClient, order: dict) -> dict | None:
-    """Return the first active agreement for the same licensee and product, or None."""
+def has_previous_order(client: MPTClient, order: dict, agreement_id: str) -> bool:
+    """Check if there is an active agreement for the same licensee, client and product."""
     licensee_id = order.get("licensee", {}).get("id")
     if not licensee_id:
-        return None
+        return False
     product_id = order.get("product", {}).get("id")
     client_id = order.get("client", {}).get("id")
     rql_filter = (
@@ -182,9 +182,10 @@ def get_previous_order(client: MPTClient, order: dict) -> dict | None:
             ]
         )
         & RQLQuery(product__id__in=[product_id])
+        & RQLQuery(id__ne=agreement_id)
     )
     agreements = get_agreements_by_query(client, str(rql_filter))
-    return agreements[0] if agreements else None
+    return bool(agreements)
 
 
 def set_order_error(order: dict, error: dict) -> dict:

--- a/swo_aws_extension/flows/steps/validate_order.py
+++ b/swo_aws_extension/flows/steps/validate_order.py
@@ -3,10 +3,12 @@ from typing import override
 
 from mpt_extension_sdk.mpt_http.base import MPTClient
 
+from swo_aws_extension.constants import PhasesEnum
 from swo_aws_extension.flows.order import InitialAWSContext
-from swo_aws_extension.flows.order_utils import get_previous_order
+from swo_aws_extension.flows.order_utils import has_previous_order
 from swo_aws_extension.flows.steps.base import BasePhaseStep
-from swo_aws_extension.flows.steps.errors import FailStepError
+from swo_aws_extension.flows.steps.errors import FailStepError, SkipStepError
+from swo_aws_extension.parameters import get_phase
 
 logger = logging.getLogger(__name__)
 
@@ -17,10 +19,15 @@ class ValidateOrder(BasePhaseStep):
     @override
     def pre_step(self, context: InitialAWSContext) -> None:
         logger.debug("%s - ValidateOrder - starting order validation", context.order_id)
+        phase = get_phase(context.order)
+        if phase != PhasesEnum.CREATE_BILLING_TRANSFER_INVITATION:
+            raise SkipStepError(
+                f"{context.order_id} - Next - Skip order validation",
+            )
 
     @override
     def process(self, client: MPTClient, context: InitialAWSContext) -> None:
-        if get_previous_order(client, context.order):
+        if has_previous_order(client, context.order, context.agreement.get("id")):
             logger.warning(
                 "%s - Duplicate agreement found for licensee %s, failing order",
                 context.order_id,

--- a/swo_aws_extension/flows/validation/base.py
+++ b/swo_aws_extension/flows/validation/base.py
@@ -11,7 +11,7 @@ from swo_aws_extension.constants import (
     OrderParametersEnum,
 )
 from swo_aws_extension.flows.order_utils import (
-    get_previous_order,
+    has_previous_order,
     strip_whitespace_from_mpa_account,
 )
 from swo_aws_extension.parameters import (
@@ -119,7 +119,7 @@ def _is_parameter_visible(order: dict, param_external_id: str) -> bool:
 def _validate_duplicate_agreement(client: MPTClient, order: dict) -> dict | None:
     if order.get("type") != "Purchase":
         return None
-    if get_previous_order(client, order):
+    if has_previous_order(client, order, order.get("agreement", {}).get("id", "")):
         return set_ordering_parameter_error(
             order,
             OrderParametersEnum.ACCOUNT_TYPE.value,

--- a/tests/flows/steps/test_validate_order.py
+++ b/tests/flows/steps/test_validate_order.py
@@ -1,6 +1,7 @@
 from mpt_extension_sdk.flows.pipeline import Step
 from mpt_extension_sdk.mpt_http.base import MPTClient
 
+from swo_aws_extension.constants import PhasesEnum
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.validate_order import ValidateOrder
 
@@ -12,8 +13,12 @@ def test_validate_order_fails_when_active_agreement_exists(
     next_step_mock = mocker.MagicMock(spec=Step)
     mock_fail = mocker.patch("swo_aws_extension.flows.steps.base.switch_order_status_to_failed")
     mocker.patch(
-        "swo_aws_extension.flows.steps.validate_order.get_previous_order",
-        return_value={"id": "AGR-0001"},
+        "swo_aws_extension.flows.steps.validate_order.has_previous_order",
+        return_value=True,
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.steps.validate_order.get_phase",
+        return_value=PhasesEnum.CREATE_BILLING_TRANSFER_INVITATION,
     )
     context = PurchaseContext.from_order_data(order_factory())
     step = ValidateOrder()
@@ -30,8 +35,27 @@ def test_validate_order_proceeds_when_no_previous_agreement(
     mock_client = mocker.MagicMock(spec=MPTClient)
     next_step_mock = mocker.MagicMock(spec=Step)
     mocker.patch(
-        "swo_aws_extension.flows.steps.validate_order.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.steps.validate_order.has_previous_order",
+        return_value=False,
+    )
+    mocker.patch(
+        "swo_aws_extension.flows.steps.validate_order.get_phase",
+        return_value=PhasesEnum.CREATE_BILLING_TRANSFER_INVITATION,
+    )
+    context = PurchaseContext.from_order_data(order_factory())
+    step = ValidateOrder()
+
+    step(mock_client, context, next_step_mock)  # act
+
+    next_step_mock.assert_called_once()
+
+
+def test_validate_order_skips_when_phase_does_not_match(mocker, order_factory):
+    mock_client = mocker.MagicMock(spec=MPTClient)
+    next_step_mock = mocker.MagicMock(spec=Step)
+    mocker.patch(
+        "swo_aws_extension.flows.steps.validate_order.get_phase",
+        return_value="some_other_phase",
     )
     context = PurchaseContext.from_order_data(order_factory())
     step = ValidateOrder()

--- a/tests/flows/test_order_utils.py
+++ b/tests/flows/test_order_utils.py
@@ -4,7 +4,7 @@ from mpt_extension_sdk.mpt_http.wrap_http_error import MPTError
 from swo_aws_extension.constants import OrderCompletedTemplate, OrderQueryingTemplateEnum
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.order_utils import (
-    get_previous_order,
+    has_previous_order,
     set_order_template,
     strip_whitespace_from_mpa_account,
     switch_order_status_to_complete,
@@ -271,21 +271,20 @@ def test_strip_whitespace_from_mpa_account_without_value(order_factory, order_pa
     assert not get_mpa_account_id(result)
 
 
-def test_get_previous_order_returns_agreement_when_found(mocker, order_factory):
+def test_has_previous_order_returns_true_when_found(mocker, order_factory):
     client = mocker.MagicMock(spec=MPTClient)
-    agreement = {"id": "AGR-0001"}
     mocker.patch(
         "swo_aws_extension.flows.order_utils.get_agreements_by_query",
-        return_value=[agreement],
+        return_value=[{"id": "AGR-0001"}],
     )
     order = order_factory()
 
-    result = get_previous_order(client, order)
+    result = has_previous_order(client, order, "AGR-9999")
 
-    assert result == agreement
+    assert result is True
 
 
-def test_get_previous_order_returns_none_when_not_found(mocker, order_factory):
+def test_has_previous_order_returns_false_when_not_found(mocker, order_factory):
     client = mocker.MagicMock(spec=MPTClient)
     mocker.patch(
         "swo_aws_extension.flows.order_utils.get_agreements_by_query",
@@ -293,16 +292,16 @@ def test_get_previous_order_returns_none_when_not_found(mocker, order_factory):
     )
     order = order_factory()
 
-    result = get_previous_order(client, order)
+    result = has_previous_order(client, order, "AGR-9999")
 
-    assert result is None
+    assert result is False
 
 
-def test_get_previous_order_returns_none_when_no_licensee(mocker):
+def test_has_previous_order_returns_false_when_no_licensee(mocker):
     client = mocker.MagicMock(spec=MPTClient)
     mock_query = mocker.patch("swo_aws_extension.flows.order_utils.get_agreements_by_query")
 
-    result = get_previous_order(client, {})
+    result = has_previous_order(client, {}, "AGR-9999")
 
-    assert result is None
+    assert result is False
     mock_query.assert_not_called()

--- a/tests/flows/validation/test_base.py
+++ b/tests/flows/validation/test_base.py
@@ -31,8 +31,8 @@ def test_validate_order_orchestrates_all_steps_new_aws_environment(
         }
     ]
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=False,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
@@ -81,8 +81,8 @@ def test_validate_order_orchestrates_all_steps_existing_aws_environment(
         }
     ]
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=False,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
@@ -119,8 +119,8 @@ def test_validate_order_returns_error_when_new_account_instructions_visible(
         constraints={"hidden": False, "required": False, "readonly": False},
     )
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=False,
     )
 
     result = validate_order(mock_client, order)
@@ -140,8 +140,8 @@ def test_validate_order_with_invalid_account_type(order_factory, order_parameter
         lines=[],
     )
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=False,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
@@ -166,8 +166,8 @@ def test_validate_order_when_product_items_not_found(
         lines=[],
     )
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=False,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
@@ -192,8 +192,8 @@ def test_validate_order_strips_whitespace_from_mpa_account(
         lines=[],
     )
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=False,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",

--- a/tests/flows/validation/test_duplicate_agreement.py
+++ b/tests/flows/validation/test_duplicate_agreement.py
@@ -22,8 +22,8 @@ def test_validate_order_blocks_purchase_when_active_agreement_exists_for_license
         lines=[],
     )
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value={"id": "AGR-0001"},
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=True,
     )
 
     result = validate_order(mock_client, order)
@@ -45,8 +45,8 @@ def test_validate_order_allows_purchase_when_no_existing_agreement_for_licensee(
         lines=[],
     )
     mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
-        return_value=None,
+        "swo_aws_extension.flows.validation.base.has_previous_order",
+        return_value=False,
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",
@@ -72,7 +72,7 @@ def test_validate_order_skips_duplicate_check_for_non_purchase_orders(
         lines=[],
     )
     mock_get_previous = mocker.patch(
-        "swo_aws_extension.flows.validation.base.get_previous_order",
+        "swo_aws_extension.flows.validation.base.has_previous_order",
     )
     mocker.patch(
         "swo_aws_extension.flows.validation.base.get_product_items_by_skus",


### PR DESCRIPTION
…e licensee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21777](https://softwareone.atlassian.net/browse/MPT-21777)

**Release Notes:**

- Replaced `get_previous_order()` utility function with `has_previous_order()` that returns a boolean indicating whether an active agreement exists for the same licensee
- Updated `has_previous_order()` to accept an `agreement_id` parameter and exclude the specified agreement from validation queries
- Enhanced `ValidateOrder` step to compute order phase and skip validation when phase is not `CREATE_BILLING_TRANSFER_INVITATION`
- Updated duplicate-agreement validation across order processing workflow to use the new `has_previous_order()` function signature
- Updated all unit tests to mock and verify the new boolean-returning agreement check behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21777]: https://softwareone.atlassian.net/browse/MPT-21777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ