### PR TITLE
MPT-21850 use shared CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 remote_config:
-  url: "https://raw.githubusercontent.com/softwareone-platform/swo-extension-playground/refs/heads/main/.coderabbit.yaml"
+  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Updated `.coderabbit.yaml` to point directly to the shared `mpt-extension-skills/coderabbit-shared.yaml` configuration.
- Removed the indirect dependency on `swo-extension-playground` for CodeRabbit configuration inheritance.

## Testing
- Verified the shared remote config URL downloads successfully and parses as YAML.
- `git diff --check -- .coderabbit.yaml`
- `make check-all`

Closes [MPT-21850](https://softwareone.atlassian.net/browse/MPT-21850)

[MPT-21850]: https://softwareone.atlassian.net/browse/MPT-21850