### PR TITLE
MPT-21790 add terminationDate subscription parameter

### DIFF
--- a/migrations/20260610073112_split_billing.py
+++ b/migrations/20260610073112_split_billing.py
@@ -1,0 +1,96 @@
+import logging
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from mpt_api_client.rql.query_builder import RQLQuery
+from mpt_tool.migration import SchemaBaseMigration
+from mpt_tool.migration.mixins import MPTAPIClientMixin
+
+logger = logging.getLogger(__name__)
+
+_termination_date_parameter = {
+    "name": "Termination Date",
+    "scope": "Subscription",
+    "phase": "Fulfillment",
+    "context": "None",
+    "description": "Termination Date",
+    "multiple": False,
+    "externalId": "terminationDate",
+    "displayOrder": 130,
+    "constraints": {"required": False},
+    "options": {
+        "placeholderText": "Termination Date",
+        "hintText": "Termination Date",
+    },
+    "type": "Date",
+    "status": "Active",
+}
+
+
+class Migration(SchemaBaseMigration, MPTAPIClientMixin):
+    """Migration to add terminationDate subscription parameter for split billing."""
+
+    def run(self) -> None:
+        """Run the migration."""
+        raw_ids = os.environ["MPT_PRODUCTS_IDS"].replace(" ", "").split(",")
+        product_ids = list(filter(None, raw_ids))
+        logger.info(
+            "Starting migration 20260610073112_split_billing_per_linked_account for %s product(s)",
+            len(product_ids),
+        )
+
+        if not product_ids:
+            logger.info("No product IDs found in MPT_PRODUCTS_IDS; nothing to migrate")
+
+        for product_id in product_ids:
+            self._migrate_product(product_id)
+
+        logger.info("Migration 20260610073112_split_billing_per_linked_account finished")
+
+    def _migrate_product(self, product_id: str) -> None:
+        logger.info("Migrating product '%s'", product_id)
+        existing = self._get_product_parameter(product_id, "terminationDate")
+        self._ensure_parameter(product_id, existing, _termination_date_parameter)
+
+    def _ensure_parameter(
+        self,
+        product_id: str,
+        existing_parameter: Any | None,
+        parameter_data: Mapping[str, Any],
+    ) -> None:
+        external_id = parameter_data["externalId"]
+        if existing_parameter:
+            logger.info(
+                "Parameter '%s' already exists for product '%s'; skipping",
+                external_id,
+                product_id,
+            )
+            return
+
+        logger.info("Creating parameter '%s' for product '%s'", external_id, product_id)
+        self._create_product_parameter(product_id, parameter_data)
+
+    def _get_product_parameter(self, product_id: str, external_id: str) -> Any | None:
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        parameter_query = RQLQuery(externalId=external_id)
+        status_query = RQLQuery(status="Active")
+        product_parameters = list(
+            product_parameters_service
+            .filter(parameter_query)
+            .filter(status_query)
+            .select()
+            .iterate()
+        )
+        if product_parameters:
+            return product_parameters[0]
+        return None
+
+    def _create_product_parameter(self, product_id: str, parameter_data: Mapping[str, Any]) -> None:
+        logger.info(
+            "Creating product parameter '%s' for product '%s'",
+            parameter_data.get("externalId"),
+            product_id,
+        )
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        product_parameters_service.create(parameter_data)

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -129,6 +129,7 @@ class FulfillmentParametersEnum(StrEnum):
     FEATURE_VERSION_DEPLOYMENT_ERROR_NOTIFIED = "featureVersionDeploymentErrorNotified"
     CCO_CONTRACT_NUMBER = "ccoContractNumber"
     ERP_PROJECT_NO = "erpProjectNo"
+    TERMINATION_DATE = "terminationDate"
 
 
 class OrderProcessingTemplateEnum(StrEnum):

--- a/swo_aws_extension/parameters.py
+++ b/swo_aws_extension/parameters.py
@@ -580,3 +580,23 @@ def set_erp_project_no(order: dict, erp_project_no: str) -> dict[str, Any]:
     )
     fulfillment_param["value"] = erp_project_no
     return updated_order
+
+
+def get_termination_date(source: dict[str, Any]) -> str | None:
+    """Get the termination date from the fulfillment parameter or None if it is not set."""
+    fulfillment_param = get_fulfillment_parameter(
+        FulfillmentParametersEnum.TERMINATION_DATE.value,
+        source,
+    )
+    return fulfillment_param.get("value", None)
+
+
+def set_termination_date(order: dict, termination_date: str) -> dict[str, Any]:
+    """Set the termination date on the fulfillment parameters."""
+    updated_order = copy.deepcopy(order)
+    fulfillment_param = get_fulfillment_parameter(
+        FulfillmentParametersEnum.TERMINATION_DATE.value,
+        updated_order,
+    )
+    fulfillment_param["value"] = termination_date
+    return updated_order

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,6 +374,7 @@ def fulfillment_parameters_factory():
         execution_arn="",
         cco_contract_number="",
         erp_project_no="",
+        termination_date="",
     ):
         return [
             {
@@ -448,6 +449,10 @@ def fulfillment_parameters_factory():
             {
                 "externalId": FulfillmentParametersEnum.ERP_PROJECT_NO.value,
                 "value": erp_project_no,
+            },
+            {
+                "externalId": FulfillmentParametersEnum.TERMINATION_DATE.value,
+                "value": termination_date,
             },
         ]
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,7 +1,37 @@
 from swo_aws_extension.constants import AccountTypesEnum
 from swo_aws_extension.parameters import (
+    get_termination_date,
     reset_ordering_parameters_error,
+    set_termination_date,
 )
+
+
+def test_get_termination_date(order_factory, fulfillment_parameters_factory):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(termination_date="2026-12-31")
+    )
+
+    result = get_termination_date(order)
+
+    assert result == "2026-12-31"
+
+
+def test_get_termination_date_not_set():
+    source = {"parameters": {"fulfillment": []}}
+
+    result = get_termination_date(source)
+
+    assert result is None
+
+
+def test_set_termination_date(order_factory, fulfillment_parameters_factory):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(termination_date="")
+    )
+
+    result = set_termination_date(order, "2026-12-31")
+
+    assert get_termination_date(result) == "2026-12-31"
 
 
 def test_reset_ordering_parameters_error(order_factory, order_parameters_factory):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add the `terminationDate` subscription parameter as part of the AWS split billing per linked account feature (MPT-21790).

## Changes

- **`migrations/20260610073112_split_billing.py`**: Schema migration to create the `terminationDate` fulfillment parameter scoped to `Subscription`. Idempotent — skips if the parameter already exists for the product.
- **`swo_aws_extension/constants.py`**: Add `TERMINATION_DATE = "terminationDate"` to `FulfillmentParametersEnum`.
- **`swo_aws_extension/parameters.py`**: Add `get_termination_date` and `set_termination_date` helpers following the existing getter/setter pattern.
- **`tests/conftest.py`**: Add `termination_date` argument to `fulfillment_parameters_factory`.
- **`tests/test_parameters.py`**: Add tests for `get_termination_date` (value set, parameter absent) and `set_termination_date`.

## Testing

`make check-all` passes: 1017 tests (1016 passed, 1 xpassed), 99% coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21790](https://softwareone.atlassian.net/browse/MPT-21790)

## Release Notes

- Add `terminationDate` fulfillment parameter (externalId "terminationDate") scoped to Subscription for AWS split billing per linked account
- Add idempotent migration (migrations/20260610073112_split_billing.py) to create the `terminationDate` parameter (skips if already exists)
- Add `TERMINATION_DATE = "terminationDate"` constant in swo_aws_extension/constants.py
- Add parameter helpers: `get_termination_date()` and `set_termination_date()` in swo_aws_extension/parameters.py
- Update tests (fixtures and new tests) to cover getting/setting the termination date; full test suite passes locally
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21790]: https://softwareone.atlassian.net/browse/MPT-21790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ