### PR TITLE
MPT-21986 Adopt manual release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,12 @@ jobs:
         run: |
           set -euo pipefail
           if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
-            echo "Tag '${VERSION}' already exists; skipping creation."
+            TAG_SHA="$(git rev-list -n1 "${VERSION}")"
+            if [ "${TAG_SHA}" != "${GITHUB_SHA}" ]; then
+              echo "::error::Tag '${VERSION}' already exists at '${TAG_SHA}', expected '${GITHUB_SHA}'."
+              exit 1
+            fi
+            echo "Tag '${VERSION}' already exists at current commit; skipping creation."
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,132 @@
 name: Release
 
+# Manually-triggered release pipeline. Runs against the branch selected at
+# dispatch time (main -> pre-release, release/* -> latest). No branch input is
+# needed: the dispatch ref is the single source of truth.
+#
+# This pipeline only creates the tag and the GitHub release. The container
+# image is built and published by a separate external system, so this workflow
+# does not need to trigger any downstream GitHub workflow and the default
+# GITHUB_TOKEN is sufficient.
+
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version in X.Y.Z format (no 'v' prefix)"
+        required: true
+        type: string
 
 permissions:
-  contents: read
+  contents: write # push the annotated tag and create the release
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build:
-
+  release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
-    - name: "Checkout"
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
+      - name: "Checkout"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-    - name: "Get the version"
-      id: get_version
-      run: echo  "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
+      - name: "Validate version and branch"
+        id: validate
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
 
-    - name: "Build and push image"
-      uses: azure/docker-login@v2
-      with:
-        login-server: ${{ vars.EXTENSION_REGISTRY_LOGIN_SERVER }}
-        username: ${{ vars.EXTENSION_REGISTRY_USERNAME }}
-        password: ${{ secrets.EXTENSION_REGISTRY_PASSWORD }}
-    - run: |
-        docker build --target prod -t ${{ vars.EXTENSION_REGISTRY_LOGIN_SERVER }}/swo-extensions-aws:${{ steps.get_version.outputs.VERSION }} .
-        docker push ${{ vars.EXTENSION_REGISTRY_LOGIN_SERVER }}/swo-extensions-aws:${{ steps.get_version.outputs.VERSION }}
+          # 1. Format must be strict semver X.Y.Z without a 'v' prefix.
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '${VERSION}' must be in X.Y.Z format (no 'v' prefix)."
+            exit 1
+          fi
+
+          # 2. Releases are only allowed from main or release/*.
+          BRANCH="${GITHUB_REF_NAME}"
+          case "${BRANCH}" in
+            main)       PRERELEASE=true ;;
+            release/*)  PRERELEASE=false ;;
+            *)
+              echo "::error::Releases are only allowed from 'main' or 'release/*' (got '${BRANCH}')."
+              exit 1
+              ;;
+          esac
+
+          git fetch --tags --force origin
+
+          # 3. A published release for this version must not already exist. A bare
+          #    tag without a release is treated as an interrupted previous run and
+          #    is allowed to resume, keeping the pipeline idempotent.
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            echo "::error::A GitHub release for '${VERSION}' already exists."
+            exit 1
+          fi
+
+          # 4. The version must be strictly greater than the highest tag reachable
+          #    from the dispatched ref (monotonic increase per branch). The version
+          #    itself is excluded so a leftover tag from an interrupted run does not
+          #    block its own completion.
+          LATEST="$(git tag --merged HEAD --sort=-v:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -vx "${VERSION}" | head -n1 || true)"
+          if [ -n "${LATEST}" ]; then
+            HIGHEST="$(printf '%s\n%s\n' "${LATEST}" "${VERSION}" | sort -V | tail -n1)"
+            if [ "${HIGHEST}" != "${VERSION}" ]; then
+              echo "::error::Version '${VERSION}' must be greater than the latest reachable tag '${LATEST}'."
+              exit 1
+            fi
+          fi
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "prerelease=${PRERELEASE}" >> "${GITHUB_OUTPUT}"
+          echo "Validated version '${VERSION}' on branch '${BRANCH}' (prerelease=${PRERELEASE})."
+
+      - name: "Create annotated tag"
+        env:
+          VERSION: ${{ steps.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "Tag '${VERSION}' already exists; skipping creation."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "${VERSION}" -m "Release ${VERSION}"
+            git push origin "refs/tags/${VERSION}"
+          fi
+
+      - name: "Create GitHub release"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.validate.outputs.version }}
+          PRERELEASE: ${{ steps.validate.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            echo "Release '${VERSION}' already exists; skipping creation."
+            exit 0
+          fi
+          if [ "${PRERELEASE}" = "true" ]; then
+            RELEASE_FLAG="--prerelease"
+          else
+            RELEASE_FLAG="--latest"
+          fi
+          gh release create "${VERSION}" \
+            --title "v${VERSION}" \
+            --target "${GITHUB_SHA}" \
+            --generate-notes \
+            --verify-tag \
+            ${RELEASE_FLAG}
 
   dtrack:
+    needs: release
     uses: softwareone-platform/ops-template/.github/workflows/dependency-track-python-uv.yml@v2
     with:
       projectName: 'swo-extension-aws'


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Adopts the new manually-triggered release pipeline (from swo-extension-playground) in this repo, replacing the old `release: published` Docker-build workflow. The file keeps the `release.yml` name.

### New `release.yml`
- `workflow_dispatch` with a `version` input (`X.Y.Z`, no `v` prefix).
- Validates: semver format; branch is `main` or `release/*`; no published GitHub release already exists for the version; version is strictly greater than the highest tag reachable from the dispatched branch (monotonic per branch).
- Creates an annotated tag and a GitHub release (title `vX.Y.Z`, generated notes). `main` → pre-release, `release/*` → latest.
- Runs Dependency-Track (project name `swo-extension-aws` preserved).
- Idempotent (skip-if-exists on tag/release) so a run can resume after a partial failure.

### Removed
- The Docker build-and-push step. The container image is now built and published by an external system, so no in-repo build and no `RELEASE_TOKEN` is needed.

## Testing
- `pre-commit` (check-yaml + file-hygiene) passes.
- Not yet exercised end-to-end on GitHub Actions (requires a real dispatch).

Subtask: MPT-21986 (parent MPT-21981).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21986](https://softwareone.atlassian.net/browse/MPT-21986)

## Release Notes

- **Manual release workflow**: Converted from automated Docker-build pipeline to `workflow_dispatch`-triggered release pipeline with version input (format X.Y.Z)
- **Version validation**: Enforces semantic versioning format, monotonic per-branch versioning, and checks for existing releases
- **Branch restrictions**: Releases limited to `main` (marked pre-release) and `release/*` branches (marked latest)
- **Git tag and release management**: Creates annotated Git tags and GitHub releases with generated release notes; skips steps if they already exist (idempotent)
- **Dependency-Track preservation**: Runs SBOM scan with existing project name `swo-extension-aws`
- **Removed Docker operations**: Container image building and pushing now handled externally; `RELEASE_TOKEN` no longer required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21986]: https://softwareone.atlassian.net/browse/MPT-21986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ