### PR TITLE
MPT-22050 swo-aws-extension documentation fixes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,9 @@ The runtime is organised as a pipeline-driven fulfilment flow:
 | `swo_aws_extension/management/` | Django management commands run by the worker |
 | `swo_aws_extension/utils/`, `file_builder/` | Shared helpers and ZIP/report file building |
 
-The repository also vendors several standalone client packages used by the
-extension and reusable across repos: `swo_mpt_api`, `swo_ccp_client`,
-`swo_crm_service_client`, `swo_finops_client`, and `swo_rql`.
+The per-service API clients live under `swo_aws_extension/swo/`, grouped by
+service (`mpt/`, `ccp/`, `cco/`, `crm_service/`, `finops/`, `cloud_orchestrator/`,
+`rql/`, `notifications/`, …) on top of the shared `base_client.py`.
 
 ## External integrations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,100 @@
+# Architecture
+
+This document describes the structure, major components, boundaries, and layer
+responsibilities of `swo-aws-extension`. For workflow, testing, deployment,
+migrations, and integration details, see the dedicated documents linked below.
+
+## Purpose
+
+`swo-aws-extension` is a SoftwareOne Marketplace Platform (MPT) extension that
+fulfils and validates AWS Marketplace orders: it provisions AWS accounts,
+configures billing transfers and the APN program, raises CRM/CCP tickets, syncs
+FinOps entitlements, and generates billing journals and reports.
+
+It is built on the MPT Extension SDK and runs as the registered `swo.mpt.ext`
+extension (`pyproject.toml` `[project.entry-points."swo.mpt.ext"]` ->
+`swo_aws_extension.apps:ExtensionConfig`).
+
+## Entry points
+
+- `swo_aws_extension/apps.py` — Django `ExtensionConfig`; validates webhook
+  secrets and the single AWS product ID on startup.
+- `swo_aws_extension/extension.py` — registers the SDK extension hooks:
+  - order fulfilment event listener (`orders`) -> `process_order_fulfillment`
+  - order validation endpoint (`POST /v1/orders/validate`) ->
+    `process_order_validation`
+- `swo_aws_extension/management/commands/` — Django management commands used by
+  the worker for background jobs (billing journals, reports, agreement and
+  FinOps sync).
+
+## Layers
+
+The runtime is organised as a pipeline-driven fulfilment flow:
+
+1. **Entry layer** (`extension.py`) — receives order fulfilment events and
+   validation requests from the platform.
+2. **Orchestration** (`flows/fulfillment/base.py`) — `fulfill_order()` selects a
+   pipeline by order type: purchase a new AWS environment, purchase an existing
+   one, or terminate.
+3. **Pipelines and steps** (`flows/fulfillment/pipelines.py`, `flows/steps/`) —
+   each pipeline is an ordered sequence of `BasePhaseStep` steps that create
+   resources, poll status, raise tickets, and advance the order phase. Order
+   data flows through the steps as an `InitialAWSContext` / `PurchaseContext`
+   (`flows/order.py`).
+4. **Validation** (`flows/validation/base.py`) — pre-fulfilment validation and
+   parameter visibility/requirement rules driven by account type.
+5. **Integration clients** (`aws/`, `swo/`, `airtable/`) — typed clients that
+   wrap each external system behind a single boundary.
+6. **Background jobs** (`flows/jobs/`) — reporting and sync work invoked by
+   management commands, including billing journal generation.
+
+## Major components
+
+| Package | Responsibility |
+|---|---|
+| `swo_aws_extension/` | Extension config, runtime `config.py`, order `parameters.py`, `constants.py` |
+| `swo_aws_extension/flows/` | Fulfilment orchestration, pipelines, steps, validation, order context |
+| `swo_aws_extension/flows/jobs/` | Background jobs: billing journal, reports, FinOps entitlement sync |
+| `swo_aws_extension/processors/` | Chain-of-responsibility processors for querying AWS roles, handshakes, transfers |
+| `swo_aws_extension/aws/` | `AWSClient` (boto3 AssumeRole, account/billing/CUR operations) |
+| `swo_aws_extension/swo/` | External-service clients (CCP, CRM, FinOps, CCO, Cloud Orchestrator, MPT, Key Vault, Blob, notifications, OpenID) |
+| `swo_aws_extension/airtable/` | FinOps entitlements Airtable sync |
+| `swo_aws_extension/management/` | Django management commands run by the worker |
+| `swo_aws_extension/utils/`, `file_builder/` | Shared helpers and ZIP/report file building |
+
+The repository also vendors several standalone client packages used by the
+extension and reusable across repos: `swo_mpt_api`, `swo_ccp_client`,
+`swo_crm_service_client`, `swo_finops_client`, and `swo_rql`.
+
+## External integrations
+
+AWS (`aws/`), CCP, CRM service, FinOps, CCO, and Cloud Orchestrator (`swo/`),
+the MPT API (`swo/mpt/`), Airtable (`airtable/`), Azure Key Vault and Blob
+Storage, Confluence, and MS Teams / email notifications. See
+[external-integrations.md](external-integrations.md) for endpoints, auth, and
+setup expectations.
+
+## Boundaries
+
+- External systems are reached only through their client package; business flows
+  and steps depend on those clients, not on raw HTTP or SDK calls.
+- Order state is carried by the context objects in `flows/order.py`; steps read
+  and update the context rather than passing ad-hoc arguments.
+- Configuration is read through `config.py` / Django settings, not from the
+  environment directly inside business logic.
+
+## Deployment shape
+
+Two workloads are deployed from `helm/swo-extension-aws`: an **api** workload
+(webhooks and the validation endpoint) and a **worker** workload (background
+jobs and CronJobs). The container image is built from the multi-stage
+`Dockerfile` and started via the SDK entrypoint. See
+[deployment.md](deployment.md) for configuration and runtime parameters.
+
+## Related documentation
+
+- [contributing.md](contributing.md) — development workflow and commands
+- [testing.md](testing.md) — test strategy and execution
+- [deployment.md](deployment.md) — deployment model and configuration
+- [migrations.md](migrations.md) — migration workflow
+- [external-integrations.md](external-integrations.md) — external systems and setup

--- a/docs/external-integrations.md
+++ b/docs/external-integrations.md
@@ -18,6 +18,7 @@ Each integration document covers: purpose, authentication mechanism, required en
 | [Confluence](external/confluence.md) | Billing report attachment to Confluence pages | Basic Auth (username + API token) | [confluence.md](external/confluence.md) |
 | [MS Teams](external/ms-teams.md) | Internal operational notifications | Incoming Webhook (no auth) | [ms-teams.md](external/ms-teams.md) |
 | [AWS SES](external/aws-ses.md) | Customer-facing email delivery | AWS Access Key + Secret Key | [aws-ses.md](external/aws-ses.md) |
+| [Airtable](external/airtable.md) | FinOps entitlements table (per-agreement records) | Personal Access Token | [airtable.md](external/airtable.md) |
 
 ## Code Location
 

--- a/docs/external/airtable.md
+++ b/docs/external/airtable.md
@@ -24,7 +24,7 @@ The table name is `FinOps Entitlements`.
 | Operation | Description |
 | --- | --- |
 | Get by agreement | `get_by_agreement_id(agreement_id)` — returns the entitlement records for an agreement |
-| Save | `save(record)` — creates a new entitlement record |
+| Save | `save(record)` — creates or updates an entitlement record (depending on whether it is new) |
 | Update status and usage date | `update_status_and_usage_date(...)` — updates an existing record |
 
 Operations are performed through the `pyairtable` table API rather than direct

--- a/docs/external/airtable.md
+++ b/docs/external/airtable.md
@@ -1,0 +1,37 @@
+# Airtable
+
+Stores the **FinOps Entitlements** table that tracks per-agreement FinOps
+entitlement records (status and usage date). The extension reads and writes
+these records while synchronising FinOps entitlements during fulfilment and
+background jobs.
+
+## Authentication
+
+Airtable Personal Access Token (PAT). The `FinOpsEntitlementsTable` builds a
+`pyairtable` `Api` client with the token and opens the configured base/table.
+
+## Configuration
+
+| Environment Variable | Description |
+| --- | --- |
+| `EXT_AIRTABLE_API_TOKEN` | Airtable Personal Access Token used by repository-specific flows |
+| `EXT_AIRTABLE_BASES` | Per-product Airtable base mapping (`{"PRD-...":"app..."}`); the base is resolved per AWS product id |
+
+The table name is `FinOps Entitlements`.
+
+## Operations
+
+| Operation | Description |
+| --- | --- |
+| Get by agreement | `get_by_agreement_id(agreement_id)` — returns the entitlement records for an agreement |
+| Save | `save(record)` — creates a new entitlement record |
+| Update status and usage date | `update_status_and_usage_date(...)` — updates an existing record |
+
+Operations are performed through the `pyairtable` table API rather than direct
+HTTP calls.
+
+## Code Reference
+
+- Table client: [`swo_aws_extension/airtable/finops_table.py`](../../swo_aws_extension/airtable/finops_table.py)
+- Records/fields: [`swo_aws_extension/airtable/models.py`](../../swo_aws_extension/airtable/models.py)
+- Used by: [`swo_aws_extension/flows/steps/finops_entitlement.py`](../../swo_aws_extension/flows/steps/finops_entitlement.py) and [`swo_aws_extension/flows/jobs/finops_entitlements_processor.py`](../../swo_aws_extension/flows/jobs/finops_entitlements_processor.py)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,8 +16,8 @@ The repository currently has stable coverage in these areas:
 - extension registration and startup checks in [`tests/test_extension.py`](../tests/test_extension.py), [`tests/test_initializer.py`](../tests/test_initializer.py), and Django settings under [`tests/django/`](../tests/django)
 - AWS client and configuration behavior in [`tests/aws/`](../tests/aws)
 - fulfillment, jobs, steps, and validation flows in [`tests/flows/`](../tests/flows)
-- management commands and helpers in [`tests/management/`](../tests/management) and [`tests/commands/`](../tests/commands)
-- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), [`tests/swo_mpt_api/`](../tests/swo_mpt_api), [`tests/swo_ccp_client/`](../tests/swo_ccp_client), [`tests/swo_crm_service_client/`](../tests/swo_crm_service_client), [`tests/swo_finops_client/`](../tests/swo_finops_client), and [`tests/swo_rql/`](../tests/swo_rql)
+- management commands and helpers in [`tests/management/`](../tests/management)
+- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), with per-service subdirectories such as [`tests/swo/mpt/`](../tests/swo/mpt), [`tests/swo/ccp/`](../tests/swo/ccp), [`tests/swo/crm_service/`](../tests/swo/crm_service), [`tests/swo/finops/`](../tests/swo/finops), [`tests/swo/rql/`](../tests/swo/rql), and [`tests/swo/notifications/`](../tests/swo/notifications)
 - Airtable, file-builder, processor, and utility behavior in [`tests/airtable/`](../tests/airtable), [`tests/file_builder/`](../tests/file_builder), [`tests/processor/`](../tests/processor), and [`tests/utils/`](../tests/utils)
 
 ## Commands

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ The repository currently has stable coverage in these areas:
 - AWS client and configuration behavior in [`tests/aws/`](../tests/aws)
 - fulfillment, jobs, steps, and validation flows in [`tests/flows/`](../tests/flows)
 - management commands and helpers in [`tests/management/`](../tests/management)
-- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), with per-service subdirectories such as [`tests/swo/mpt/`](../tests/swo/mpt), [`tests/swo/ccp/`](../tests/swo/ccp), [`tests/swo/crm_service/`](../tests/swo/crm_service), [`tests/swo/finops/`](../tests/swo/finops), [`tests/swo/rql/`](../tests/swo/rql), and [`tests/swo/notifications/`](../tests/swo/notifications)
+- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), with per-service subdirectories such as [`tests/swo/mpt/`](../tests/swo/mpt), [`tests/swo/ccp/`](../tests/swo/ccp), [`tests/swo/cco/`](../tests/swo/cco), [`tests/swo/crm_service/`](../tests/swo/crm_service), [`tests/swo/finops/`](../tests/swo/finops), [`tests/swo/rql/`](../tests/swo/rql), and [`tests/swo/notifications/`](../tests/swo/notifications)
 - Airtable, file-builder, processor, and utility behavior in [`tests/airtable/`](../tests/airtable), [`tests/file_builder/`](../tests/file_builder), [`tests/processor/`](../tests/processor), and [`tests/utils/`](../tests/utils)
 
 ## Commands


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Documentation fixes for swo-aws-extension (MPT-22050, under MPT-22048).

- **docs/architecture.md** added (was the missing required doc): structure, entry points, the pipeline-driven fulfilment layers, component table, external integrations, boundaries, and the helm api/worker deployment shape.
- **docs/external/airtable.md** added + an index row in `external-integrations.md`. Airtable backs the FinOps Entitlements table (used by `flows/steps/finops_entitlement.py` and `flows/jobs/finops_entitlements_processor.py`); its env vars (`EXT_AIRTABLE_API_TOKEN`, `EXT_AIRTABLE_BASES`) were already in deployment.md.
- **docs/testing.md**: fixed stale references to empty test directories — dropped `tests/commands/` and replaced the empty `tests/swo_mpt_api`, `tests/swo_ccp_client`, `tests/swo_crm_service_client`, `tests/swo_finops_client`, `tests/swo_rql` with the real per-service subdirectories under `tests/swo/`.

## Note on EXT_ONBOARD_CUSTOMER_ROLE
Left in `deployment.md`: it is **not** read by the Python code, but it IS wired into the helm config maps (`helm/swo-extension-aws/charts/{api,worker}/templates/configmap.yaml`) from `Values.global.OnboardCustomerRole`, so the deployment doc is accurate. The "set in helm but unused in code" looks like dead config — flagging as a possible follow-up cleanup (out of scope for a docs change).

## Testing
- `audit_docs.py`: no missing required docs.
- pre-commit file-hygiene hooks pass on the changed docs.

Subtask: MPT-22050 (parent MPT-22048).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22050](https://softwareone.atlassian.net/browse/MPT-22050)

- Added docs/architecture.md: documents swo-aws-extension purpose, project structure, entry points, pipeline-driven fulfillment/validation layers, major components, external integration touchpoints, system boundaries, and API/worker deployment topology.
- Added docs/external/airtable.md and index entry in docs/external-integrations.md: documents Airtable integration for the FinOps Entitlements table (auth via EXT_AIRTABLE_API_TOKEN, base resolution via EXT_AIRTABLE_BASES), supported operations (get by agreement, save as create-or-update, update status/usage date), and references to relevant code locations.
- Updated docs/testing.md: removed stale references to tests/commands/ and placeholder tests/swo_* directories; documents actual test layout under tests/swo/ (adds tests/swo/cco to documented subdirectories).
- Notes and housekeeping:
  - EXT_ONBOARD_CUSTOMER_ROLE remains in deployment.md and helm config maps (Values.global.OnboardCustomerRole); not read by Python code — flagged as possible follow-up cleanup (out of scope).
  - audit_docs.py reports no missing required docs; pre-commit file-hygiene hooks pass on changed docs.
- Commit clarifications: per-service API clients live under swo_aws_extension/swo/ (no vendored top-level swo_mpt_api/swo_ccp_client/... packages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22050]: https://softwareone.atlassian.net/browse/MPT-22050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ