### PR TITLE
MPT-22019 AWS billing support for bundled discount and other services

### DIFF
--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -251,6 +251,9 @@ class AWSRecordTypeEnum(StrEnum):
     SAVING_PLAN_RECURRING_FEE = "SavingsPlanRecurringFee"
     RECURRING = "Recurring"
     CREDIT = "Credit"
+    BUNDLE_DISCOUNT = "Bundled Discount"
+    OTHER = "Other"
+    FLAT_RATE_SUBSCRIPTION = "FlatRateSubscription"
 
 
 class DeploymentStatusEnum(StrEnum):

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/journal_line.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/journal_line.py
@@ -2,6 +2,9 @@ from swo_aws_extension.constants import AWSRecordTypeEnum
 from swo_aws_extension.flows.jobs.billing_journal.generators.line_processors.base import (
     JournalLineProcessor,
 )
+from swo_aws_extension.flows.jobs.billing_journal.generators.line_processors.bundle_discount import (  # noqa: E501
+    BundleDiscountJournalLineProcessor,
+)
 from swo_aws_extension.flows.jobs.billing_journal.generators.line_processors.credit import (
     CreditJournalLineProcessor,
 )
@@ -28,6 +31,7 @@ def _build_processor_registry() -> dict[str, JournalLineProcessor]:
     support = SupportJournalLineProcessor()
     credit = CreditJournalLineProcessor()
     marketplace = MarketplaceJournalLineProcessor()
+    bundle_discount = BundleDiscountJournalLineProcessor()
 
     return {
         AWSRecordTypeEnum.USAGE: default,
@@ -36,6 +40,9 @@ def _build_processor_registry() -> dict[str, JournalLineProcessor]:
         AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE: default,
         AWSRecordTypeEnum.CREDIT: credit,
         "MARKETPLACE": marketplace,
+        AWSRecordTypeEnum.BUNDLE_DISCOUNT: bundle_discount,
+        AWSRecordTypeEnum.OTHER: default,
+        AWSRecordTypeEnum.FLAT_RATE_SUBSCRIPTION: default,
     }
 
 

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/bundle_discount.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/bundle_discount.py
@@ -1,0 +1,28 @@
+from typing import override
+
+from swo_aws_extension.flows.jobs.billing_journal.generators.line_processors.base import (
+    JournalLineProcessor,
+)
+from swo_aws_extension.flows.jobs.billing_journal.models.context import LineProcessorContext
+from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import JournalLine
+from swo_aws_extension.flows.jobs.billing_journal.models.usage import ServiceMetric
+
+BUNDLE_DISCOUNT_PREFIX = "Bundled_Discount_"
+
+
+class BundleDiscountJournalLineProcessor(JournalLineProcessor):
+    """Generates journal lines for Bundle Discount metrics.
+
+    Always generates a line with the Bundled_Discount_ prefix.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(prefix_name=BUNDLE_DISCOUNT_PREFIX)
+
+    @override
+    def process(
+        self,
+        metric: ServiceMetric,
+        context: LineProcessorContext,
+    ) -> list[JournalLine]:
+        return super().process(metric, context)

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/usage.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from abc import ABC, abstractmethod
 
 from swo_aws_extension.aws.client import AWSClient
@@ -320,5 +321,7 @@ class CostExplorerUsageGenerator(BaseOrganizationUsageGenerator):
             invoice_entity=entity_key,
             invoice_id=invoice_entity.invoice_id if invoice_entity else "",
             start_date=metric_data.start_date,
-            end_date=metric_data.end_date,
+            end_date=(
+                dt.date.fromisoformat(metric_data.end_date) - dt.timedelta(days=1)
+            ).isoformat(),
         )

--- a/tests/flows/jobs/billing_journal/generators/line_processors/test_bundle_discount.py
+++ b/tests/flows/jobs/billing_journal/generators/line_processors/test_bundle_discount.py
@@ -1,0 +1,112 @@
+from decimal import Decimal
+
+import pytest
+
+from swo_aws_extension.constants import AWSRecordTypeEnum
+from swo_aws_extension.flows.jobs.billing_journal.generators.journal_line import (
+    JournalLineGenerator,
+)
+from swo_aws_extension.flows.jobs.billing_journal.generators.line_processors.bundle_discount import (  # noqa: E501
+    BUNDLE_DISCOUNT_PREFIX,
+)
+from swo_aws_extension.flows.jobs.billing_journal.models.invoice import OrganizationInvoice
+from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import JournalDetails
+from swo_aws_extension.flows.jobs.billing_journal.models.usage import AccountUsage, ServiceMetric
+
+
+@pytest.fixture
+def journal_details():
+    return JournalDetails(
+        agreement_id="AGR-123",
+        mpa_id="MPA-456",
+        start_date="2026-01-01",
+        end_date="2026-01-31",
+    )
+
+
+@pytest.fixture
+def generator():
+    return JournalLineGenerator()
+
+
+@pytest.fixture
+def organization_invoice():
+    return OrganizationInvoice()
+
+
+def test_bundle_discount_metric_has_prefix(journal_details, generator, organization_invoice):
+    metric = ServiceMetric(
+        service_name="Amazon S3",
+        record_type=AWSRecordTypeEnum.BUNDLE_DISCOUNT,
+        amount=Decimal("-25.00"),
+    )
+    account_usage = AccountUsage(metrics=[metric])
+
+    result = generator.generate("ACC-001", account_usage, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    assert result[0].description.value1 == f"{BUNDLE_DISCOUNT_PREFIX}Amazon S3"
+
+
+def test_bundle_discount_skips_zero_amount(journal_details, generator, organization_invoice):
+    metric = ServiceMetric(
+        service_name="Amazon S3",
+        record_type=AWSRecordTypeEnum.BUNDLE_DISCOUNT,
+        amount=Decimal(0),
+    )
+    account_usage = AccountUsage(metrics=[metric])
+
+    result = generator.generate("ACC-001", account_usage, journal_details, organization_invoice)
+
+    assert len(result) == 0
+
+
+def test_bundle_discount_preserves_amount(journal_details, generator, organization_invoice):
+    metric = ServiceMetric(
+        service_name="Amazon EC2",
+        record_type=AWSRecordTypeEnum.BUNDLE_DISCOUNT,
+        amount=Decimal("-15.75"),
+    )
+    account_usage = AccountUsage(metrics=[metric])
+
+    result = generator.generate("ACC-001", account_usage, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    assert result[0].price.pp_x1 == Decimal("-15.75")
+
+
+def test_bundle_discount_multiple_services(journal_details, generator, organization_invoice):
+    metrics = [
+        ServiceMetric(
+            service_name="Amazon S3",
+            record_type=AWSRecordTypeEnum.BUNDLE_DISCOUNT,
+            amount=Decimal("-10.00"),
+        ),
+        ServiceMetric(
+            service_name="Amazon EC2",
+            record_type=AWSRecordTypeEnum.BUNDLE_DISCOUNT,
+            amount=Decimal("-20.00"),
+        ),
+    ]
+    account_usage = AccountUsage(metrics=metrics)
+
+    result = generator.generate("ACC-001", account_usage, journal_details, organization_invoice)
+
+    assert len(result) == 2
+    assert result[0].description.value1 == f"{BUNDLE_DISCOUNT_PREFIX}Amazon S3"
+    assert result[1].description.value1 == f"{BUNDLE_DISCOUNT_PREFIX}Amazon EC2"
+
+
+def test_bundle_discount_includes_invoice_entity(journal_details, generator, organization_invoice):
+    metric = ServiceMetric(
+        service_name="Amazon S3",
+        record_type=AWSRecordTypeEnum.BUNDLE_DISCOUNT,
+        amount=Decimal("-25.00"),
+        invoice_entity="AWS Inc.",
+    )
+    account_usage = AccountUsage(metrics=[metric])
+
+    result = generator.generate("ACC-001", account_usage, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    assert "AWS Inc." in result[0].description.value2

--- a/tests/flows/jobs/billing_journal/generators/test_usage.py
+++ b/tests/flows/jobs/billing_journal/generators/test_usage.py
@@ -94,26 +94,38 @@ def duplicate_billing_views():
 @pytest.fixture
 def duplicate_account_usage():
     view_data = [
-        [{"Groups": [{"Keys": ["ACT-1"]}]}],
         [
             {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [{"Keys": ["ACT-1"]}],
+            }
+        ],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
                 "Groups": [
                     {
                         "Keys": ["ACT-1", "AmazonRDS"],
                         "Metrics": {"UnblendedCost": {"Amount": "100.0"}},
                     }
-                ]
+                ],
             }
         ],
-        [{"Groups": [{"Keys": ["AmazonRDS", "Amazon Web Services, Inc."]}]}],
         [
             {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [{"Keys": ["AmazonRDS", "Amazon Web Services, Inc."]}],
+            }
+        ],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
                 "Groups": [
                     {
                         "Keys": [AWSRecordTypeEnum.USAGE, "AmazonRDS"],
                         "Metrics": {"UnblendedCost": {"Amount": "50.0"}},
                     }
-                ]
+                ],
             }
         ],
     ]
@@ -144,7 +156,7 @@ def test_generate_processes_single_account(
     assert (metric.amount, metric.start_date, metric.end_date) == (
         Decimal("10.25"),
         "2025-10-01",
-        "2025-10-02",
+        "2025-10-01",
     )
 
 
@@ -157,17 +169,28 @@ def test_generate_returns_correct_invoice_entity(
 ):
     mock_aws_client.get_billing_views_by_account_id.return_value = single_billing_view
     mock_aws_client.get_cost_and_usage.side_effect = [
-        [{"Groups": [{"Keys": ["ACT-1"]}]}],
-        [{"Groups": []}],
-        [{"Groups": [{"Keys": ["AmazonEC2", "Amazon Web Services, Inc."]}]}],
         [
             {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [{"Keys": ["ACT-1"]}],
+            }
+        ],
+        [{"TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"}, "Groups": []}],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
+                "Groups": [{"Keys": ["AmazonEC2", "Amazon Web Services, Inc."]}],
+            }
+        ],
+        [
+            {
+                "TimePeriod": {"Start": "2025-10-01", "End": "2025-10-02"},
                 "Groups": [
                     {
                         "Keys": [AWSRecordTypeEnum.USAGE, "AmazonEC2"],
                         "Metrics": {"UnblendedCost": {"Amount": "10.0"}},
                     }
-                ]
+                ],
             }
         ],
     ]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add support for AWS **Bundled Discount** and **Other** service record types in the billing journal generation flow.

## Changes

- `swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/bundle_discount.py`: new processor that handles `BundleDiscount` record types, prefixes the service name with `BUNDLE_DISCOUNT_PREFIX`, and skips zero-amount entries.
- `swo_aws_extension/flows/jobs/billing_journal/generators/journal_line.py`: wire `BundleDiscountJournalLineProcessor` into the generator; add `# noqa: E501` to the long import line.
- `tests/flows/jobs/billing_journal/generators/line_processors/test_bundle_discount.py`: new test module covering prefix labeling, zero-amount skipping, amount preservation, multiple services, and invoice entity inclusion.
- `tests/flows/jobs/billing_journal/generators/test_usage.py`: update fixtures to include `TimePeriod` in AWS cost mock responses to match the real API shape; correct the `end_date` assertion to reflect the parsed value.

## Why

MPT-22019 requires the billing journal to recognise and correctly classify AWS Bundled Discount line items. Without this processor those entries were ignored, resulting in incomplete billing journal output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22019](https://softwareone.atlassian.net/browse/MPT-22019)

**Release Notes:**

- Added support for AWS Bundled Discount, Other, and Flat Rate Subscription record types in the AWS cost enumeration
- Implemented `BundleDiscountJournalLineProcessor` to handle Bundled Discount line items in the billing journal generation flow, with automatic prefixing of service names and filtering of zero-amount entries
- Wired the new bundle discount processor into the journal line generator registry
- Added comprehensive test coverage for the bundle discount processor, validating prefix labeling, zero-amount filtering, amount preservation, multi-service handling, and invoice entity inclusion
- Updated billing journal usage processor to correctly parse and adjust the end_date field from AWS API responses
- Updated test fixtures to include TimePeriod in AWS cost mock responses to align with actual API response structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22019]: https://softwareone.atlassian.net/browse/MPT-22019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ