### PR TITLE
feat(MPT-21791): extract linked accounts with usage from Cost Explorer

### DIFF
--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -458,3 +458,42 @@ class AWSClient:
             aws_session_token=self.credentials["SessionToken"],
             region_name="us-east-1",
         )
+
+
+def _extract_linked_account_keys(cost_and_usage: list[dict]) -> list[str]:
+    keys: list[str] = []
+    for period in cost_and_usage:
+        for group in period.get("Groups", []):
+            keys.extend(group.get("Keys", []))
+    return keys
+
+
+def get_linked_accounts_with_usage(
+    aws_client: AWSClient,
+    mpa_account_id: str,
+    billing_period: BillingPeriod,
+    agreement_id: str = "",
+) -> list[str]:
+    """Return linked account IDs that have cost usage for the given MPA and billing period."""
+    accounts: list[str] = []
+    for billing_view in aws_client.get_billing_views_by_account_id(
+        mpa_account_id,
+        start_date=billing_period.start_date,
+        end_date=billing_period.last_day,
+    ):
+        try:
+            cost_and_usage = aws_client.get_cost_and_usage(
+                billing_period=billing_period,
+                view_arn=billing_view.get("arn"),
+                group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
+            )
+        except AWSError as error:
+            logger.info(
+                "%s - Error retrieving cost and usage for billing view %s: %s",
+                agreement_id,
+                billing_view.get("arn"),
+                error,
+            )
+            continue
+        accounts.extend(_extract_linked_account_keys(cost_and_usage))
+    return accounts

--- a/swo_aws_extension/flows/jobs/finops_entitlements_processor.py
+++ b/swo_aws_extension/flows/jobs/finops_entitlements_processor.py
@@ -6,8 +6,11 @@ from mpt_extension_sdk.mpt_http.mpt import get_agreements_by_query
 
 from swo_aws_extension.airtable.finops_table import FinOpsEntitlementsTable
 from swo_aws_extension.airtable.models import FinOpsRecord
-from swo_aws_extension.aws.client import MINIMUM_DAYS_MONTH, AWSClient
-from swo_aws_extension.aws.errors import AWSError
+from swo_aws_extension.aws.client import (
+    MINIMUM_DAYS_MONTH,
+    AWSClient,
+    get_linked_accounts_with_usage,
+)
 from swo_aws_extension.config import Config
 from swo_aws_extension.constants import FinOpsStatusEnum
 from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
@@ -117,13 +120,14 @@ class FinOpsEntitlementsProcessor:  # noqa: WPS214
         finops_entitlements: list[FinOpsRecord],
     ):
         aws_client = AWSClient(self.config, pma_account_id, self.config.management_role_name)
-        billing_views = aws_client.get_current_billing_view_by_account_id(mpa_account_id)
-        accounts = self._get_accounts_with_usage(agreement_id, billing_views, aws_client)
+        billing_period = self._get_billing_period()
+        accounts = get_linked_accounts_with_usage(
+            aws_client, mpa_account_id, billing_period, agreement_id
+        )
         for account_id in accounts:
             existing = self._find_existing_entitlement(finops_entitlements, account_id)
             if existing:
                 self._update_existing_entitlement(agreement_id, account_id, buyer_id, existing)
-
             else:
                 self._create_new_entitlement(agreement_id, account_id, buyer_id)
 
@@ -163,38 +167,6 @@ class FinOpsEntitlementsProcessor:  # noqa: WPS214
         else:
             rql_filter = RQLQuery(status="Active") & RQLQuery(product__id__in=self.product_ids)
         return get_agreements_by_query(self.mpt_client, f"{rql_filter}{select}")
-
-    def _get_accounts_with_usage(
-        self, agreement_id: str, billing_views: list[dict], aws_client: AWSClient
-    ) -> list[str]:
-        accounts_with_usage = []
-        billing_period = self._get_billing_period()
-        for billing_view in billing_views:
-            try:
-                cost_and_usage = aws_client.get_cost_and_usage(
-                    billing_period=billing_period,
-                    view_arn=billing_view.get("arn"),
-                    group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
-                )
-            except AWSError as error:
-                logger.info(
-                    "%s - Error retrieving cost and usage for billing view %s: %s",
-                    agreement_id,
-                    billing_view.get("arn"),
-                    error,
-                )
-                continue
-            accounts_with_usage.extend(self._get_account_keys(cost_and_usage))
-
-        return accounts_with_usage
-
-    def _get_account_keys(self, cost_and_usage) -> list[str]:
-        keys: list[str] = []
-        for period in cost_and_usage:
-            for group in period.get("Groups", []):
-                keys.extend(group.get("Keys", []))
-
-        return keys
 
     def _get_or_create_entitlement_in_finops(
         self, agreement_id: str, account_id: str, buyer_id: str

--- a/swo_aws_extension/swo/mpt/sync/syncer.py
+++ b/swo_aws_extension/swo/mpt/sync/syncer.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import logging
 from functools import cache
 from typing import Any, override
@@ -11,7 +12,11 @@ from mpt_extension_sdk.mpt_http.mpt import (
 )
 from mpt_extension_sdk.mpt_http.wrap_http_error import wrap_mpt_http_error
 
-from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.aws.client import (
+    MINIMUM_DAYS_MONTH,
+    AWSClient,
+    get_linked_accounts_with_usage,
+)
 from swo_aws_extension.aws.errors import AWSError
 from swo_aws_extension.config import get_config
 from swo_aws_extension.constants import (
@@ -20,6 +25,7 @@ from swo_aws_extension.constants import (
     ResponsibilityTransferStatus,
     SubscriptionStatus,
 )
+from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import BillingPeriod
 from swo_aws_extension.parameters import (
     get_billing_group_arn,
     get_relationship_id,
@@ -261,6 +267,13 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
                     logger.exception(msg)
                     TeamsNotificationManager().send_exception("Inactive transfer", msg)
 
+    def _get_billing_period(self) -> BillingPeriod:
+        today = dt.datetime.now(dt.UTC).date()
+        next_month = today.replace(day=MINIMUM_DAYS_MONTH) + dt.timedelta(days=4)
+        return BillingPeriod(
+            today.replace(day=1).isoformat(), next_month.replace(day=1).isoformat()
+        )
+
     @override
     def _process(self, agreement: AgreementType) -> None:
         logger.info("%s - Action - Start sync agreement", agreement.get("id"))
@@ -274,6 +287,17 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
             return
 
         self.sync_responsibility_transfer_id(self.mpt_client, agreement, accepted_transfer["Id"])
+
+        config = get_config()
+        aws_client = AWSClient(config, pma_account_id, config.management_role_name)
+        linked_accounts = get_linked_accounts_with_usage(
+            aws_client, mpa_account_id, self._get_billing_period(), agreement.get("id", "")
+        )
+        # TODO MPT-21792: sync subscriptions for each linked account with usage
+        logger.info(
+            "%s - Found %d linked accounts with usage", agreement.get("id"), len(linked_accounts)
+        )
+
         logger.info("%s - End - Sync completed", agreement.get("id"))
 
 

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -3,7 +3,11 @@ import datetime as dt
 import pytest
 from botocore.exceptions import ClientError
 
-from swo_aws_extension.aws.client import MAX_RESULTS_PER_PAGE, get_paged_response
+from swo_aws_extension.aws.client import (
+    MAX_RESULTS_PER_PAGE,
+    get_linked_accounts_with_usage,
+    get_paged_response,
+)
 from swo_aws_extension.aws.errors import (
     AWSError,
     InvalidDateInTerminateResponsibilityError,
@@ -720,3 +724,75 @@ def test_list_invoice_summaries_success(config, aws_client_factory, mock_get_pag
     assert len(result) == 1
     assert result[0]["InvoiceId"] == "INV-001"
     mock_get_paged_response.assert_called_once()
+
+
+def test_get_linked_accounts_with_usage(mocker):
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+    mock_aws = mocker.MagicMock()
+    mock_aws.get_billing_views_by_account_id.return_value = [
+        {"arn": "arn:aws:billing::123:billingview/v1"}
+    ]
+    mock_aws.get_cost_and_usage.return_value = [
+        {"Groups": [{"Keys": ["111111111111"]}, {"Keys": ["222222222222"]}]}
+    ]
+
+    result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period, "AGR-001")
+
+    assert result == ["111111111111", "222222222222"]
+    mock_aws.get_billing_views_by_account_id.assert_called_once_with(
+        "123456789012",
+        start_date="2025-12-01",
+        end_date="2025-12-31",
+    )
+    mock_aws.get_cost_and_usage.assert_called_once_with(
+        billing_period=billing_period,
+        view_arn="arn:aws:billing::123:billingview/v1",
+        group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
+    )
+
+
+def test_get_linked_accounts_multiple_views(mocker):
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+    mock_aws = mocker.MagicMock()
+    mock_aws.get_billing_views_by_account_id.return_value = [
+        {"arn": "arn:aws:billing::123:billingview/v1"},
+        {"arn": "arn:aws:billing::123:billingview/v2"},
+    ]
+    mock_aws.get_cost_and_usage.side_effect = [
+        [{"Groups": [{"Keys": ["111111111111"]}]}],
+        [{"Groups": [{"Keys": ["222222222222"]}]}],
+    ]
+
+    result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period)
+
+    assert result == ["111111111111", "222222222222"]
+    assert mock_aws.get_cost_and_usage.call_count == 2
+
+
+def test_get_linked_accounts_skips_error_view(mocker):
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+    mock_aws = mocker.MagicMock()
+    mock_aws.get_billing_views_by_account_id.return_value = [
+        {"arn": "arn:aws:billing::123:billingview/v1"},
+        {"arn": "arn:aws:billing::123:billingview/v2"},
+    ]
+    mock_aws.get_cost_and_usage.side_effect = [
+        AWSError("Access denied"),
+        [{"Groups": [{"Keys": ["222222222222"]}]}],
+    ]
+
+    result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period, "AGR-001")
+
+    assert result == ["222222222222"]
+    assert mock_aws.get_cost_and_usage.call_count == 2
+
+
+def test_get_linked_accounts_no_billing_views(mocker):
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+    mock_aws = mocker.MagicMock()
+    mock_aws.get_billing_views_by_account_id.return_value = []
+
+    result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period)
+
+    assert result == []
+    mock_aws.get_cost_and_usage.assert_not_called()

--- a/tests/flows/jobs/test_finops_entitlements_processor.py
+++ b/tests/flows/jobs/test_finops_entitlements_processor.py
@@ -100,7 +100,7 @@ def test_sync_creates_new_entitlement(
     mock_entitlements_table.get_by_agreement_id.return_value = []
     mock_finops_client.get_entitlement_by_datasource.return_value = None
     mock_finops_client.create_entitlement.return_value = {"id": "ENT-001"}
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = [
+    mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
     mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
@@ -136,7 +136,7 @@ def test_sync_updates_existing(
         "id": "ENT-001",
         "status": "active",
     }
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = [
+    mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
     mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
@@ -171,7 +171,7 @@ def test_sync_terminates_inactive(
         "id": "ENT-001",
         "status": "active",
     }
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = []
+    mock_aws_client.get_billing_views_by_account_id.return_value = []
     processor = finops_processor()
 
     processor.sync()  # act
@@ -207,7 +207,7 @@ def test_sync_deletes_new_entitlement(
         "id": "ENT-001",
         "status": "new",
     }
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = []
+    mock_aws_client.get_billing_views_by_account_id.return_value = []
     processor = finops_processor()
 
     processor.sync()  # act
@@ -277,7 +277,7 @@ def test_sync_with_agreement_ids(
 ):
     mock_agreements_response(url=AGREEMENTS_WITH_IDS_URL)
     mock_entitlements_table.get_by_agreement_id.return_value = []
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = []
+    mock_aws_client.get_billing_views_by_account_id.return_value = []
     processor = finops_processor(agreement_ids=["AGR-0001"])
 
     processor.sync()  # act
@@ -304,7 +304,7 @@ def test_sync_skips_terminated(
         last_usage_date=OLD_DATE,
     )
     mock_entitlements_table.get_by_agreement_id.return_value = [terminated_record]
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = []
+    mock_aws_client.get_billing_views_by_account_id.return_value = []
     processor = finops_processor()
 
     processor.sync()  # act
@@ -327,7 +327,7 @@ def test_sync_uses_existing_finops_entitlement(
         "id": "ENT-EXISTING",
         "status": "active",
     }
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = [
+    mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
     mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
@@ -352,7 +352,7 @@ def test_sync_handles_finops_error_on_create(
     mock_entitlements_table.get_by_agreement_id.return_value = []
     mock_finops_client.get_entitlement_by_datasource.return_value = None
     mock_finops_client.create_entitlement.side_effect = FinOpsError("FinOps API error")
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = [
+    mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
     mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
@@ -377,7 +377,7 @@ def test_sync_finops_error_on_get_entitlement(
     mock_agreements_response()
     mock_entitlements_table.get_by_agreement_id.return_value = []
     mock_finops_client.get_entitlement_by_datasource.side_effect = FinOpsError("FinOps API error")
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = [
+    mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
     mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
@@ -412,7 +412,7 @@ def test_sync_updates_existing_with_finops_error(
     )
     mock_entitlements_table.get_by_agreement_id.return_value = [existing_record]
     mock_finops_client.get_entitlement_by_datasource.side_effect = FinOpsError("FinOps API error")
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = [
+    mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
     mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
@@ -434,7 +434,7 @@ def test_sync_handles_aws_error_on_cost_and_usage(
 ):
     mock_agreements_response()
     mock_entitlements_table.get_by_agreement_id.return_value = []
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = [
+    mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
     mock_aws_client.get_cost_and_usage.side_effect = AWSError("AWS API error")
@@ -467,7 +467,7 @@ def test_sync_terminate_not_found_in_finops(
     )
     mock_entitlements_table.get_by_agreement_id.return_value = [inactive_record]
     mock_finops_client.get_entitlement_by_datasource.return_value = None
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = []
+    mock_aws_client.get_billing_views_by_account_id.return_value = []
     processor = finops_processor()
 
     processor.sync()  # act
@@ -505,7 +505,7 @@ def test_sync_deletes_new_entitlement_and_update(
         "id": "ENT-001",
         "status": "new",
     }
-    mock_aws_client.get_current_billing_view_by_account_id.return_value = []
+    mock_aws_client.get_billing_views_by_account_id.return_value = []
     processor = finops_processor()
 
     processor.sync()  # act

--- a/tests/swo/mpt/sync/conftest.py
+++ b/tests/swo/mpt/sync/conftest.py
@@ -53,6 +53,14 @@ def mock_awsclient(mocker):
 
 
 @pytest.fixture
+def mock_get_linked_accounts_with_usage(mocker):
+    return mocker.patch(
+        "swo_aws_extension.swo.mpt.sync.syncer.get_linked_accounts_with_usage",
+        return_value=[],
+    )
+
+
+@pytest.fixture
 def mock_get_accepted_transfer_for_account(mocker):
     return mocker.patch(
         "swo_aws_extension.swo.mpt.sync.syncer.get_accepted_transfer_for_account",

--- a/tests/swo/mpt/sync/test_syncer.py
+++ b/tests/swo/mpt/sync/test_syncer.py
@@ -23,6 +23,8 @@ def test_agreement_syncer_sync_success(
     agreement,
     mock_get_accepted_transfer_for_account,
     mock_sync_responsibility_transfer_id_method,
+    mock_awsclient,
+    mock_get_linked_accounts_with_usage,
     syncer,
 ):
     mock_get_accepted_transfer_for_account.return_value = {
@@ -116,6 +118,8 @@ def test_sync_agreements_with_active_transfer(
     mock_terminate_agreement_method,
     mock_delete_billing_group_method,
     mock_sync_responsibility_transfer_id_method,
+    mock_awsclient,
+    mock_get_linked_accounts_with_usage,
     mpt_client,
 ):
     mock_get_agreements_by_query.return_value = [agreement]


### PR DESCRIPTION
## Summary

- Extracted `get_linked_accounts_with_usage` from `FinOpsEntitlementsProcessor` into a shared module-level function in `swo_aws_extension/aws/client.py` so both the FinOps entitlements sync and the agreement syncer can reuse it
- Added a private `_extract_linked_account_keys` helper to keep local variable count within WPS210 limits
- Added `_get_billing_period` and the linked-account fetch call to `AgreementSyncer._process`, with a `# TODO MPT-21792` comment marking where subscription-management logic will follow
- Added tests for the new shared function in `tests/aws/test_client.py` and updated syncer fixtures/tests to mock the new dependency

## Related issues

- Jira: [MPT-21791](https://softwareone.atlassian.net/browse/MPT-21791)
- Next: [MPT-21792](https://softwareone.atlassian.net/browse/MPT-21792)

## Test plan

- [ ] `make check-all` passes (1025 passed, 1 xpassed)
- [ ] `test_get_linked_accounts_with_usage` — success case, single billing view
- [ ] `test_get_linked_accounts_multiple_views` — two billing views combined
- [ ] `test_get_linked_accounts_skips_error_view` — AWSError on one view, continues to next
- [ ] `test_get_linked_accounts_no_billing_views` — empty billing views returns []
- [ ] Existing finops entitlements processor tests still pass after refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MPT-21791]: https://softwareone.atlassian.net/browse/MPT-21791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-21792]: https://softwareone.atlassian.net/browse/MPT-21792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21791](https://softwareone.atlassian.net/browse/MPT-21791)

- Extracted `get_linked_accounts_with_usage()` into `swo_aws_extension/aws/client.py` for shared reuse by both FinOps entitlements sync and agreement syncer
- Added `_extract_linked_account_keys()` helper to flatten linked account keys from `cost_and_usage` responses
- Refactored `FinOpsEntitlementsProcessor` to use the shared `get_linked_accounts_with_usage()` instead of its prior `_get_accounts_with_usage` implementation
- Updated `AgreementSyncer` to call `get_linked_accounts_with_usage()` using a computed billing window, with a TODO placeholder for subscription-management logic (MPT-21792)
- Added tests for `get_linked_accounts_with_usage()` covering single/multiple billing views, error handling, and empty billing view scenarios
- Updated syncer fixtures/tests to mock the new dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->