### PR TITLE
MPT-21792 create MPT subscription per linked account with usage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,10 @@ The runtime is organised as a pipeline-driven fulfilment flow:
 5. **Integration clients** (`aws/`, `swo/`, `airtable/`) — typed clients that
    wrap each external system behind a single boundary.
 6. **Background jobs** (`flows/jobs/`) — reporting and sync work invoked by
-   management commands, including billing journal generation.
+   management commands, including billing journal generation. The
+   `AgreementSyncer` background job also queries Cost Explorer for linked AWS
+   accounts with active usage and creates an MPT subscription per account that
+   does not already have one (`swo_aws_extension/swo/mpt/sync/syncer.py`).
 
 ## Major components
 
@@ -54,9 +57,9 @@ The runtime is organised as a pipeline-driven fulfilment flow:
 |---|---|
 | `swo_aws_extension/` | Extension config, runtime `config.py`, order `parameters.py`, `constants.py` |
 | `swo_aws_extension/flows/` | Fulfilment orchestration, pipelines, steps, validation, order context |
-| `swo_aws_extension/flows/jobs/` | Background jobs: billing journal, reports, FinOps entitlement sync |
+| `swo_aws_extension/flows/jobs/` | Background jobs: billing journal, reports, FinOps entitlement sync, MPT subscription sync for linked AWS accounts |
 | `swo_aws_extension/processors/` | Chain-of-responsibility processors for querying AWS roles, handshakes, transfers |
-| `swo_aws_extension/aws/` | `AWSClient` (boto3 AssumeRole, account/billing/CUR operations) |
+| `swo_aws_extension/aws/` | `AWSClient` (boto3 AssumeRole, account/billing/CUR operations, Cost Explorer with dimension attributes) |
 | `swo_aws_extension/swo/` | External-service clients (CCP, CRM, FinOps, CCO, Cloud Orchestrator, MPT, Key Vault, Blob, notifications, OpenID) |
 | `swo_aws_extension/airtable/` | FinOps entitlements Airtable sync |
 | `swo_aws_extension/management/` | Django management commands run by the worker |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ The repository currently has stable coverage in these areas:
 - AWS client and configuration behavior in [`tests/aws/`](../tests/aws)
 - fulfillment, jobs, steps, and validation flows in [`tests/flows/`](../tests/flows)
 - management commands and helpers in [`tests/management/`](../tests/management)
-- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), with per-service subdirectories such as [`tests/swo/mpt/`](../tests/swo/mpt), [`tests/swo/ccp/`](../tests/swo/ccp), [`tests/swo/cco/`](../tests/swo/cco), [`tests/swo/crm_service/`](../tests/swo/crm_service), [`tests/swo/finops/`](../tests/swo/finops), [`tests/swo/rql/`](../tests/swo/rql), and [`tests/swo/notifications/`](../tests/swo/notifications)
+- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), with per-service subdirectories such as [`tests/swo/mpt/`](../tests/swo/mpt), [`tests/swo/ccp/`](../tests/swo/ccp), [`tests/swo/cco/`](../tests/swo/cco), [`tests/swo/crm_service/`](../tests/swo/crm_service), [`tests/swo/finops/`](../tests/swo/finops), [`tests/swo/rql/`](../tests/swo/rql), and [`tests/swo/notifications/`](../tests/swo/notifications); subscription sync behavior for the `AgreementSyncer` (creation, idempotency, dry-run, and error handling) lives in [`tests/swo/mpt/sync/`](../tests/swo/mpt/sync)
 - Airtable, file-builder, processor, and utility behavior in [`tests/airtable/`](../tests/airtable), [`tests/file_builder/`](../tests/file_builder), [`tests/processor/`](../tests/processor), and [`tests/utils/`](../tests/utils)
 
 ## Commands

--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -134,22 +134,46 @@ class AWSClient:
         granularity: str = "MONTHLY",
     ) -> list[dict]:
         """Get cost and usage data for the specified date range."""
-        kwarg: dict = {
-            "TimePeriod": {"Start": billing_period.start_date, "End": billing_period.end_date},
-            "Granularity": granularity,
-            "Metrics": ["UnblendedCost"],
-        }
-        if group_by:
-            kwarg["GroupBy"] = group_by
-        if filter_by:
-            kwarg["Filter"] = filter_by
-        if view_arn:
-            kwarg["BillingViewArn"] = view_arn
+        api_params = self._build_cost_and_usage_params(
+            billing_period, group_by, filter_by, view_arn, granularity
+        )
         return get_paged_response(
             self._get_cost_explorer_client().get_cost_and_usage,
             "ResultsByTime",
-            kwarg,
+            api_params,
         )
+
+    @wrap_boto3_error
+    def get_cost_and_usage_with_attributes(
+        self,
+        billing_period: BillingPeriod,
+        group_by: list[dict] | None = None,
+        filter_by: dict | None = None,
+        view_arn: str | None = None,
+        granularity: str = "MONTHLY",
+    ) -> tuple[list[dict], list[dict]]:
+        """Get cost and usage data with dimension value attributes.
+
+        Returns a tuple of (ResultsByTime, DimensionValueAttributes).
+        DimensionValueAttributes contains descriptions/names for dimension values
+        (e.g., linked account names).
+        """
+        api_params = self._build_cost_and_usage_params(
+            billing_period, group_by, filter_by, view_arn, granularity
+        )
+        results_by_time: list[dict] = []
+        dimension_attrs: dict[str, dict] = {}
+
+        while True:
+            response = self._get_cost_explorer_client().get_cost_and_usage(**api_params)
+            results_by_time.extend(response.get("ResultsByTime", []))
+            for attr in response.get("DimensionValueAttributes", []):
+                dimension_attrs.setdefault(attr["Value"], attr)
+            if not response.get("NextPageToken"):
+                break
+            api_params["NextPageToken"] = response["NextPageToken"]
+
+        return results_by_time, list(dimension_attrs.values())
 
     @wrap_boto3_error
     def get_current_billing_view_by_account_id(self, account_id: str) -> list[dict]:
@@ -347,6 +371,28 @@ class AWSClient:
             },
         )
 
+    def _build_cost_and_usage_params(
+        self,
+        billing_period: BillingPeriod,
+        group_by: list[dict] | None = None,
+        filter_by: dict | None = None,
+        view_arn: str | None = None,
+        granularity: str = "MONTHLY",
+    ) -> dict:
+        """Build the parameters dict for a Cost Explorer get_cost_and_usage call."""
+        api_params: dict = {
+            "TimePeriod": {"Start": billing_period.start_date, "End": billing_period.end_date},
+            "Granularity": granularity,
+            "Metrics": ["UnblendedCost"],
+        }
+        if group_by:
+            api_params["GroupBy"] = group_by
+        if filter_by:
+            api_params["Filter"] = filter_by
+        if view_arn:
+            api_params["BillingViewArn"] = view_arn
+        return api_params
+
     @wrap_boto3_error
     def _get_credentials(self):
         if not self.account_id:
@@ -468,21 +514,51 @@ def _extract_linked_account_keys(cost_and_usage: list[dict]) -> list[str]:
     return keys
 
 
+def _build_account_names_map(dimension_attributes: list[dict]) -> dict[str, str]:
+    """Build a mapping of account ID to account name from DimensionValueAttributes."""
+    return {
+        attr.get("Value", ""): attr.get("Attributes", {}).get("description", "")
+        for attr in dimension_attributes
+    }
+
+
+def _collect_new_accounts(
+    results_by_time: list[dict],
+    dimension_attributes: list[dict],
+    seen_account_ids: set[str],
+) -> list[dict[str, str]]:
+    """Return new linked accounts from cost-and-usage results, updating seen set."""
+    accounts: list[dict[str, str]] = []
+    account_names = _build_account_names_map(dimension_attributes)
+    for account_id in _extract_linked_account_keys(results_by_time):
+        if account_id not in seen_account_ids:
+            seen_account_ids.add(account_id)
+            accounts.append({
+                "account_id": account_id,
+                "account_name": account_names.get(account_id, account_id),
+            })
+    return accounts
+
+
 def get_linked_accounts_with_usage(
     aws_client: AWSClient,
     mpa_account_id: str,
     billing_period: BillingPeriod,
     agreement_id: str = "",
-) -> list[str]:
-    """Return linked account IDs that have cost usage for the given MPA and billing period."""
-    accounts: list[str] = []
+) -> list[dict[str, str]]:
+    """Return linked accounts with usage for the given MPA and billing period.
+
+    Returns a list of dicts with 'account_id' and 'account_name' keys.
+    """
+    accounts: list[dict[str, str]] = []
+    seen_account_ids: set[str] = set()
     for billing_view in aws_client.get_billing_views_by_account_id(
         mpa_account_id,
         start_date=billing_period.start_date,
         end_date=billing_period.last_day,
     ):
         try:
-            cost_and_usage = aws_client.get_cost_and_usage(
+            results_by_time, dimension_attributes = aws_client.get_cost_and_usage_with_attributes(
                 billing_period=billing_period,
                 view_arn=billing_view.get("arn"),
                 group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
@@ -495,5 +571,7 @@ def get_linked_accounts_with_usage(
                 error,
             )
             continue
-        accounts.extend(_extract_linked_account_keys(cost_and_usage))
+        accounts.extend(
+            _collect_new_accounts(results_by_time, dimension_attributes, seen_account_ids)
+        )
     return accounts

--- a/swo_aws_extension/flows/jobs/finops_entitlements_processor.py
+++ b/swo_aws_extension/flows/jobs/finops_entitlements_processor.py
@@ -124,12 +124,16 @@ class FinOpsEntitlementsProcessor:  # noqa: WPS214
         accounts = get_linked_accounts_with_usage(
             aws_client, mpa_account_id, billing_period, agreement_id
         )
-        for account_id in accounts:
-            existing = self._find_existing_entitlement(finops_entitlements, account_id)
+        for account_info in accounts:
+            existing = self._find_existing_entitlement(
+                finops_entitlements, account_info["account_id"]
+            )
             if existing:
-                self._update_existing_entitlement(agreement_id, account_id, buyer_id, existing)
+                self._update_existing_entitlement(
+                    agreement_id, account_info["account_id"], buyer_id, existing
+                )
             else:
-                self._create_new_entitlement(agreement_id, account_id, buyer_id)
+                self._create_new_entitlement(agreement_id, account_info["account_id"], buyer_id)
 
     def _find_existing_entitlement(
         self, entitlements: list[FinOpsRecord], account_id: str

--- a/swo_aws_extension/swo/mpt/sync/syncer.py
+++ b/swo_aws_extension/swo/mpt/sync/syncer.py
@@ -3,9 +3,12 @@ import logging
 from functools import cache
 from typing import Any, override
 
+from mpt_api_client.exceptions import MPTError
 from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.mpt import (
+    create_agreement_subscription,
     get_agreements_by_query,
+    get_product_items_by_skus,
     get_subscriptions_by_query,
     terminate_subscription,
     update_agreement,
@@ -20,6 +23,8 @@ from swo_aws_extension.aws.client import (
 from swo_aws_extension.aws.errors import AWSError
 from swo_aws_extension.config import get_config
 from swo_aws_extension.constants import (
+    AWS_ITEMS_SKUS,
+    MPT_DATE_TIME_FORMAT,
     FulfillmentParametersEnum,
     ParamPhasesEnum,
     ResponsibilityTransferStatus,
@@ -267,6 +272,88 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
                     logger.exception(msg)
                     TeamsNotificationManager().send_exception("Inactive transfer", msg)
 
+    def _sync_subscriptions(
+        self, agreement: AgreementType, linked_accounts: list[dict[str, str]]
+    ) -> None:
+        if not linked_accounts:
+            return
+        subscription_items = get_product_items_by_skus(
+            self.mpt_client, agreement["product"]["id"], AWS_ITEMS_SKUS
+        )
+
+        for account_info in linked_accounts:
+            self._ensure_subscription(
+                agreement,
+                subscription_items,
+                account_info["account_id"],
+                account_info["account_name"],
+            )
+
+    def _ensure_subscription(
+        self,
+        agreement: AgreementType,
+        subscription_items: list[dict],
+        account_id: str,
+        account_name: str,
+    ) -> None:
+        agreement_id = agreement["id"]
+        active_statuses = {SubscriptionStatus.ACTIVE, SubscriptionStatus.UPDATING}
+        existing = next(
+            (
+                sub
+                for sub in agreement.get("subscriptions", [])
+                if sub.get("externalIds", {}).get("vendor") == account_id
+                and sub.get("status") in active_statuses
+            ),
+            None,
+        )
+        if existing:
+            logger.info(
+                "%s - Subscription for linked account %s already exists (%s), skipping",
+                agreement_id,
+                account_id,
+                existing.get("id"),
+            )
+            return
+        if self.dry_run:
+            logger.info(
+                "%s - dry run mode - skipping subscription creation for account: %s",
+                agreement_id,
+                account_id,
+            )
+            return
+        now = dt.datetime.now(dt.UTC)
+        start_date = now.strftime(MPT_DATE_TIME_FORMAT)
+        subscription = {
+            "name": f"Subscription for {account_name} ({account_id})",
+            "startDate": now.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            "commitmentDate": start_date,
+            "autoRenew": True,
+            "agreement": {"id": agreement_id},
+            "externalIds": {"vendor": account_id},
+            "template": None,
+            "lines": [
+                {"item": subscription_item, "quantity": 1}
+                for subscription_item in subscription_items
+            ],
+            "parameters": {"fulfillment": []},
+        }
+        try:
+            created = create_agreement_subscription(self.mpt_client, subscription)
+        except MPTError:
+            logger.warning(
+                "%s - Error creating subscription for linked account %s",
+                agreement_id,
+                account_id,
+            )
+            return
+        logger.info(
+            "%s - Created subscription %s for linked account %s",
+            agreement_id,
+            created.get("id"),
+            account_id,
+        )
+
     def _get_billing_period(self) -> BillingPeriod:
         today = dt.datetime.now(dt.UTC).date()
         next_month = today.replace(day=MINIMUM_DAYS_MONTH) + dt.timedelta(days=4)
@@ -293,10 +380,10 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
         linked_accounts = get_linked_accounts_with_usage(
             aws_client, mpa_account_id, self._get_billing_period(), agreement.get("id", "")
         )
-        # TODO MPT-21792: sync subscriptions for each linked account with usage
         logger.info(
             "%s - Found %d linked accounts with usage", agreement.get("id"), len(linked_accounts)
         )
+        self._sync_subscriptions(agreement, linked_accounts)
 
         logger.info("%s - End - Sync completed", agreement.get("id"))
 

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -732,19 +732,26 @@ def test_get_linked_accounts_with_usage(mocker):
     mock_aws.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/v1"}
     ]
-    mock_aws.get_cost_and_usage.return_value = [
-        {"Groups": [{"Keys": ["111111111111"]}, {"Keys": ["222222222222"]}]}
-    ]
+    mock_aws.get_cost_and_usage_with_attributes.return_value = (
+        [{"Groups": [{"Keys": ["111111111111"]}, {"Keys": ["222222222222"]}]}],
+        [
+            {"Value": "111111111111", "Attributes": {"description": "Account One"}},
+            {"Value": "222222222222", "Attributes": {"description": "Account Two"}},
+        ],
+    )
 
     result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period, "AGR-001")
 
-    assert result == ["111111111111", "222222222222"]
+    assert result == [
+        {"account_id": "111111111111", "account_name": "Account One"},
+        {"account_id": "222222222222", "account_name": "Account Two"},
+    ]
     mock_aws.get_billing_views_by_account_id.assert_called_once_with(
         "123456789012",
         start_date="2025-12-01",
         end_date="2025-12-31",
     )
-    mock_aws.get_cost_and_usage.assert_called_once_with(
+    mock_aws.get_cost_and_usage_with_attributes.assert_called_once_with(
         billing_period=billing_period,
         view_arn="arn:aws:billing::123:billingview/v1",
         group_by=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
@@ -758,15 +765,24 @@ def test_get_linked_accounts_multiple_views(mocker):
         {"arn": "arn:aws:billing::123:billingview/v1"},
         {"arn": "arn:aws:billing::123:billingview/v2"},
     ]
-    mock_aws.get_cost_and_usage.side_effect = [
-        [{"Groups": [{"Keys": ["111111111111"]}]}],
-        [{"Groups": [{"Keys": ["222222222222"]}]}],
+    mock_aws.get_cost_and_usage_with_attributes.side_effect = [
+        (
+            [{"Groups": [{"Keys": ["111111111111"]}]}],
+            [{"Value": "111111111111", "Attributes": {"description": "Account One"}}],
+        ),
+        (
+            [{"Groups": [{"Keys": ["222222222222"]}]}],
+            [{"Value": "222222222222", "Attributes": {"description": "Account Two"}}],
+        ),
     ]
 
     result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period)
 
-    assert result == ["111111111111", "222222222222"]
-    assert mock_aws.get_cost_and_usage.call_count == 2
+    assert result == [
+        {"account_id": "111111111111", "account_name": "Account One"},
+        {"account_id": "222222222222", "account_name": "Account Two"},
+    ]
+    assert mock_aws.get_cost_and_usage_with_attributes.call_count == 2
 
 
 def test_get_linked_accounts_skips_error_view(mocker):
@@ -776,15 +792,18 @@ def test_get_linked_accounts_skips_error_view(mocker):
         {"arn": "arn:aws:billing::123:billingview/v1"},
         {"arn": "arn:aws:billing::123:billingview/v2"},
     ]
-    mock_aws.get_cost_and_usage.side_effect = [
+    mock_aws.get_cost_and_usage_with_attributes.side_effect = [
         AWSError("Access denied"),
-        [{"Groups": [{"Keys": ["222222222222"]}]}],
+        (
+            [{"Groups": [{"Keys": ["222222222222"]}]}],
+            [{"Value": "222222222222", "Attributes": {"description": "Account Two"}}],
+        ),
     ]
 
     result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period, "AGR-001")
 
-    assert result == ["222222222222"]
-    assert mock_aws.get_cost_and_usage.call_count == 2
+    assert result == [{"account_id": "222222222222", "account_name": "Account Two"}]
+    assert mock_aws.get_cost_and_usage_with_attributes.call_count == 2
 
 
 def test_get_linked_accounts_no_billing_views(mocker):
@@ -795,4 +814,108 @@ def test_get_linked_accounts_no_billing_views(mocker):
     result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period)
 
     assert result == []
-    mock_aws.get_cost_and_usage.assert_not_called()
+    mock_aws.get_cost_and_usage_with_attributes.assert_not_called()
+
+
+def test_cost_and_usage_with_attrs_single_page(config, aws_client_factory):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.get_cost_and_usage.return_value = {
+        "ResultsByTime": [
+            {"Groups": [{"Keys": ["111"], "Metrics": {"UnblendedCost": {"Amount": "10"}}}]}
+        ],
+        "DimensionValueAttributes": [
+            {"Value": "111", "Attributes": {"description": "Account One"}},
+        ],
+    }
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+
+    result = mock_aws_client.get_cost_and_usage_with_attributes(billing_period)
+
+    assert result == (
+        [{"Groups": [{"Keys": ["111"], "Metrics": {"UnblendedCost": {"Amount": "10"}}}]}],
+        [{"Value": "111", "Attributes": {"description": "Account One"}}],
+    )
+
+
+def test_cost_and_usage_with_attrs_paginated(config, aws_client_factory):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.get_cost_and_usage.side_effect = [
+        {
+            "ResultsByTime": [
+                {"Groups": [{"Keys": ["111"], "Metrics": {"UnblendedCost": {"Amount": "10"}}}]}
+            ],
+            "DimensionValueAttributes": [
+                {"Value": "111", "Attributes": {"description": "Account One"}},
+            ],
+            "NextPageToken": "page2",
+        },
+        {
+            "ResultsByTime": [
+                {"Groups": [{"Keys": ["222"], "Metrics": {"UnblendedCost": {"Amount": "20"}}}]}
+            ],
+            "DimensionValueAttributes": [
+                {"Value": "222", "Attributes": {"description": "Account Two"}},
+            ],
+        },
+    ]
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+    group_by = [{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}]
+
+    result = mock_aws_client.get_cost_and_usage_with_attributes(billing_period, group_by)
+
+    assert len(result[0]) == 2
+    assert len(result[1]) == 2
+    assert mock_client.get_cost_and_usage.call_count == 2
+
+
+def test_cost_and_usage_attrs_dedup(config, aws_client_factory):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.get_cost_and_usage.side_effect = [
+        {
+            "ResultsByTime": [{"Groups": []}],
+            "DimensionValueAttributes": [
+                {"Value": "111", "Attributes": {"description": "Account One"}},
+            ],
+            "NextPageToken": "page2",
+        },
+        {
+            "ResultsByTime": [{"Groups": []}],
+            "DimensionValueAttributes": [
+                {"Value": "111", "Attributes": {"description": "Account One"}},
+            ],
+        },
+    ]
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+
+    result = mock_aws_client.get_cost_and_usage_with_attributes(billing_period)
+
+    assert len(result[1]) == 1
+
+
+def test_get_linked_accounts_dedup_across_views(mocker):
+    billing_period = BillingPeriod(start_date="2025-12-01", end_date="2026-01-01")
+    mock_aws = mocker.MagicMock()
+    mock_aws.get_billing_views_by_account_id.return_value = [
+        {"arn": "arn:aws:billing::123:billingview/v1"},
+        {"arn": "arn:aws:billing::123:billingview/v2"},
+    ]
+    mock_aws.get_cost_and_usage_with_attributes.side_effect = [
+        (
+            [{"Groups": [{"Keys": ["111111111111"]}]}],
+            [{"Value": "111111111111", "Attributes": {"description": "Account One"}}],
+        ),
+        (
+            [{"Groups": [{"Keys": ["111111111111"]}, {"Keys": ["222222222222"]}]}],
+            [
+                {"Value": "111111111111", "Attributes": {"description": "Account One"}},
+                {"Value": "222222222222", "Attributes": {"description": "Account Two"}},
+            ],
+        ),
+    ]
+
+    result = get_linked_accounts_with_usage(mock_aws, "123456789012", billing_period)
+
+    assert result == [
+        {"account_id": "111111111111", "account_name": "Account One"},
+        {"account_id": "222222222222", "account_name": "Account Two"},
+    ]

--- a/tests/flows/jobs/test_finops_entitlements_processor.py
+++ b/tests/flows/jobs/test_finops_entitlements_processor.py
@@ -103,7 +103,10 @@ def test_sync_creates_new_entitlement(
     mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
-    mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
+    mock_aws_client.get_cost_and_usage_with_attributes.return_value = (
+        [{"Groups": [{"Keys": ["123456789"]}]}],
+        [{"Value": "123456789", "Attributes": {"description": "Test Account"}}],
+    )
     processor = finops_processor()
 
     processor.sync()  # act
@@ -139,7 +142,10 @@ def test_sync_updates_existing(
     mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
-    mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
+    mock_aws_client.get_cost_and_usage_with_attributes.return_value = (
+        [{"Groups": [{"Keys": ["123456789"]}]}],
+        [{"Value": "123456789", "Attributes": {"description": "Test Account"}}],
+    )
     processor = finops_processor()
 
     processor.sync()  # act
@@ -330,7 +336,10 @@ def test_sync_uses_existing_finops_entitlement(
     mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
-    mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
+    mock_aws_client.get_cost_and_usage_with_attributes.return_value = (
+        [{"Groups": [{"Keys": ["123456789"]}]}],
+        [{"Value": "123456789", "Attributes": {"description": "Test Account"}}],
+    )
     processor = finops_processor()
 
     processor.sync()  # act
@@ -355,7 +364,10 @@ def test_sync_handles_finops_error_on_create(
     mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
-    mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
+    mock_aws_client.get_cost_and_usage_with_attributes.return_value = (
+        [{"Groups": [{"Keys": ["123456789"]}]}],
+        [{"Value": "123456789", "Attributes": {"description": "Test Account"}}],
+    )
     processor = finops_processor()
 
     processor.sync()  # act
@@ -380,7 +392,10 @@ def test_sync_finops_error_on_get_entitlement(
     mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
-    mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
+    mock_aws_client.get_cost_and_usage_with_attributes.return_value = (
+        [{"Groups": [{"Keys": ["123456789"]}]}],
+        [{"Value": "123456789", "Attributes": {"description": "Test Account"}}],
+    )
     processor = finops_processor()
 
     processor.sync()  # act
@@ -415,7 +430,10 @@ def test_sync_updates_existing_with_finops_error(
     mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
-    mock_aws_client.get_cost_and_usage.return_value = [{"Groups": [{"Keys": ["123456789"]}]}]
+    mock_aws_client.get_cost_and_usage_with_attributes.return_value = (
+        [{"Groups": [{"Keys": ["123456789"]}]}],
+        [{"Value": "123456789", "Attributes": {"description": "Test Account"}}],
+    )
     processor = finops_processor()
 
     processor.sync()  # act
@@ -437,7 +455,7 @@ def test_sync_handles_aws_error_on_cost_and_usage(
     mock_aws_client.get_billing_views_by_account_id.return_value = [
         {"arn": "arn:aws:billing::123:billingview/test"}
     ]
-    mock_aws_client.get_cost_and_usage.side_effect = AWSError("AWS API error")
+    mock_aws_client.get_cost_and_usage_with_attributes.side_effect = AWSError("AWS API error")
     processor = finops_processor()
 
     processor.sync()  # act

--- a/tests/swo/mpt/sync/conftest.py
+++ b/tests/swo/mpt/sync/conftest.py
@@ -61,6 +61,22 @@ def mock_get_linked_accounts_with_usage(mocker):
 
 
 @pytest.fixture
+def mock_get_product_items_by_skus(mocker):
+    return mocker.patch(
+        "swo_aws_extension.swo.mpt.sync.syncer.get_product_items_by_skus",
+        return_value=[{"id": "ITM-1234-1234-1234-0010"}],
+    )
+
+
+@pytest.fixture
+def mock_create_agreement_subscription(mocker):
+    return mocker.patch(
+        "swo_aws_extension.swo.mpt.sync.syncer.create_agreement_subscription",
+        return_value={"id": "SUB-NEW-0001"},
+    )
+
+
+@pytest.fixture
 def mock_get_accepted_transfer_for_account(mocker):
     return mocker.patch(
         "swo_aws_extension.swo.mpt.sync.syncer.get_accepted_transfer_for_account",

--- a/tests/swo/mpt/sync/test_syncer.py
+++ b/tests/swo/mpt/sync/test_syncer.py
@@ -1,4 +1,5 @@
 import pytest
+from mpt_api_client.exceptions import MPTError
 
 from swo_aws_extension.aws.errors import AWSError
 from swo_aws_extension.constants import (
@@ -494,3 +495,147 @@ def test_get_pma(agreement, syncer):
     result = syncer.get_pma(agreement)
 
     assert result == "651706759263"
+
+
+def test_sync_subscriptions_creates_new(
+    agreement,
+    syncer,
+    mock_get_accepted_transfer_for_account,
+    mock_awsclient,
+    mock_get_linked_accounts_with_usage,
+    mock_get_product_items_by_skus,
+    mock_create_agreement_subscription,
+    mock_sync_responsibility_transfer_id_method,
+):
+    mock_get_accepted_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+    }
+    mock_get_linked_accounts_with_usage.return_value = [
+        {"account_id": "111111111111", "account_name": "Test Account"}
+    ]
+    expected_subscription = {
+        "name": "Subscription for Test Account (111111111111)",
+        "autoRenew": True,
+        "externalIds": {"vendor": "111111111111"},
+        "agreement": {"id": "AGR-2119-4550-8674-5962"},
+        "template": None,
+        "lines": [{"item": {"id": "ITM-1234-1234-1234-0010"}, "quantity": 1}],
+        "parameters": {"fulfillment": []},
+    }
+
+    syncer.process(agreement)  # act
+
+    mock_create_agreement_subscription.assert_called_once()
+    call_args = mock_create_agreement_subscription.call_args[0]
+    subscription = call_args[1]
+    assert subscription == {
+        **expected_subscription,
+        "startDate": subscription["startDate"],
+        "commitmentDate": subscription["commitmentDate"],
+    }
+
+
+def test_sync_subscriptions_skips_existing(
+    agreement_factory,
+    syncer,
+    mock_get_accepted_transfer_for_account,
+    mock_awsclient,
+    mock_get_linked_accounts_with_usage,
+    mock_get_product_items_by_skus,
+    mock_create_agreement_subscription,
+    mock_sync_responsibility_transfer_id_method,
+):
+    existing_sub = {
+        "id": "SUB-EXISTING",
+        "status": "Active",
+        "externalIds": {"vendor": "111111111111"},
+    }
+    agreement = agreement_factory(subscriptions=[existing_sub])
+    mock_get_accepted_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+    }
+    mock_get_linked_accounts_with_usage.return_value = [
+        {"account_id": "111111111111", "account_name": "Test Account"}
+    ]
+
+    syncer.process(agreement)  # act
+
+    mock_create_agreement_subscription.assert_not_called()
+
+
+def test_sync_subscriptions_dry_run(
+    agreement,
+    syncer_dry_run,
+    mock_get_accepted_transfer_for_account,
+    mock_awsclient,
+    mock_get_linked_accounts_with_usage,
+    mock_get_product_items_by_skus,
+    mock_create_agreement_subscription,
+    mock_sync_responsibility_transfer_id_method,
+):
+    mock_get_accepted_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+    }
+    mock_get_linked_accounts_with_usage.return_value = [
+        {"account_id": "111111111111", "account_name": "Test Account"}
+    ]
+
+    syncer_dry_run.process(agreement)  # act
+
+    mock_create_agreement_subscription.assert_not_called()
+
+
+def test_sync_subscriptions_skips_terminated(
+    agreement_factory,
+    syncer,
+    mock_get_accepted_transfer_for_account,
+    mock_awsclient,
+    mock_get_linked_accounts_with_usage,
+    mock_get_product_items_by_skus,
+    mock_create_agreement_subscription,
+    mock_sync_responsibility_transfer_id_method,
+):
+    terminated_sub = {
+        "id": "SUB-OLD",
+        "status": "Terminated",
+        "externalIds": {"vendor": "111111111111"},
+    }
+    agreement = agreement_factory(subscriptions=[terminated_sub])
+    mock_get_accepted_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+    }
+    mock_get_linked_accounts_with_usage.return_value = [
+        {"account_id": "111111111111", "account_name": "Test Account"}
+    ]
+
+    syncer.process(agreement)  # act
+
+    mock_create_agreement_subscription.assert_called_once()
+
+
+def test_sync_subscriptions_create_error(
+    agreement,
+    syncer,
+    mock_get_accepted_transfer_for_account,
+    mock_awsclient,
+    mock_get_linked_accounts_with_usage,
+    mock_get_product_items_by_skus,
+    mock_create_agreement_subscription,
+    mock_sync_responsibility_transfer_id_method,
+):
+    mock_get_accepted_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+    }
+    mock_get_linked_accounts_with_usage.return_value = [
+        {"account_id": "111111111111", "account_name": "Test Account"}
+    ]
+    mock_create_agreement_subscription.side_effect = MPTError("create failed")
+
+    syncer.process(agreement)  # act
+
+    assert mock_create_agreement_subscription.call_count == 1


### PR DESCRIPTION
## Summary

- For each linked account with usage found in Cost Explorer, checks if an active subscription already exists in `agreement["subscriptions"]` (no extra API call — the list is already loaded by the `select` query in `synchronize_agreements`)
- Creates a new MPT subscription via `create_agreement_subscription` when no active (Active/Updating) subscription is found for that linked account
- Dry-run mode logs and skips creation
- `HTTPError` from the SDK call is caught and logged without re-raising, so one failed account doesn't abort the others

## Test plan

- [ ] `test_sync_subscriptions_creates_new` — new subscription created when none exists
- [ ] `test_sync_subscriptions_skips_existing` — creation skipped when an Active subscription is already present
- [ ] `test_sync_subscriptions_dry_run` — creation skipped in dry-run mode
- [ ] `test_sync_subscriptions_skips_terminated` — Terminated subscription does not block re-creation
- [ ] `test_sync_subscriptions_create_error` — HTTPError is swallowed and logged; does not propagate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21792](https://softwareone.atlassian.net/browse/MPT-21792)

## Changes

- Implemented MPT subscription synchronization in `AgreementSyncer`:
  - Pre-checks for an existing ACTIVE/UPDATING subscription per linked AWS account (using `synchronize_agreements` data)
  - Creates missing subscriptions via `create_agreement_subscription`
  - Supports dry-run mode by logging the intended creation without calling the API
  - Handles Terminated subscriptions as eligible for re-creation
  - Catches and logs SDK/HTTP errors so one account failure doesn’t block others
- Enhanced linked-account discovery from Cost Explorer:
  - Added `_build_cost_and_usage_params()` and centralized Cost Explorer request construction
  - Added `get_cost_and_usage_with_attributes()` with explicit pagination and deduplication of dimension attributes
  - Updated `get_linked_accounts_with_usage()` to return `{account_id, account_name}` objects (including name mapping from dimension attributes)
- Updated downstream processing to use the new linked-account shape in `FinOpsEntitlementsProcessor`.
- Expanded/updated tests:
  - Added AgreementSyncer subscription-sync coverage (new creates, skipping when active exists, dry-run, terminated re-creation, and error handling)
  - Expanded AWS client tests for `get_cost_and_usage_with_attributes`, pagination aggregation, and linked-account deduping across views
- Updated documentation to reflect the AgreementSyncer background job and the location/scope of the related test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21792]: https://softwareone.atlassian.net/browse/MPT-21792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ