### PR TITLE
MPT-21952 add splitBillingPolicy agreement parameter to migration

### DIFF
--- a/migrations/20260610073112_split_billing.py
+++ b/migrations/20260610073112_split_billing.py
@@ -9,6 +9,11 @@ from mpt_tool.migration.mixins import MPTAPIClientMixin
 
 logger = logging.getLogger(__name__)
 
+_TERMINATION_DATE_EXTERNAL_ID = "terminationDate"
+_SPLIT_BILLING_POLICY_EXTERNAL_ID = "splitBillingPolicy"
+_SPLIT_BILLING_MASTER_PAYER = "MASTER_PAYER"
+_SPLIT_BILLING_LINKED_ACCOUNT_PERCENTAGE = "LINKED_ACCOUNT_PERCENTAGE"
+
 _termination_date_parameter = {
     "name": "Termination Date",
     "scope": "Subscription",
@@ -16,7 +21,7 @@ _termination_date_parameter = {
     "context": "None",
     "description": "Termination Date",
     "multiple": False,
-    "externalId": "terminationDate",
+    "externalId": _TERMINATION_DATE_EXTERNAL_ID,
     "displayOrder": 130,
     "constraints": {"required": False},
     "options": {
@@ -27,9 +32,38 @@ _termination_date_parameter = {
     "status": "Active",
 }
 
+_split_billing_policy_parameter = {
+    "name": "Shared-Charges Policy",
+    "scope": "Agreement",
+    "phase": "Fulfillment",
+    "context": "None",
+    "description": "Shared-Charges Policy",
+    "multiple": False,
+    "externalId": _SPLIT_BILLING_POLICY_EXTERNAL_ID,
+    "constraints": {"hidden": True, "required": False},
+    "options": {
+        "placeholderText": "Shared-Charges Policy",
+        "hintText": "Shared-Charges Policy",
+        "defaultValue": _SPLIT_BILLING_MASTER_PAYER,
+        "optionsList": [
+            {
+                "label": "Split billing - global concept to master payer",
+                "value": _SPLIT_BILLING_MASTER_PAYER,
+            },
+            {
+                "label": "Split billing - global concept to linked account in percentage",
+                "value": _SPLIT_BILLING_LINKED_ACCOUNT_PERCENTAGE,
+            },
+        ],
+    },
+    "type": "DropDown",
+    "status": "Active",
+    "displayOrder": 100,
+}
+
 
 class Migration(SchemaBaseMigration, MPTAPIClientMixin):
-    """Migration to add terminationDate subscription parameter for split billing."""
+    """Migration to add terminationDate and splitBillingPolicy parameters for split billing."""
 
     def run(self) -> None:
         """Run the migration."""
@@ -50,8 +84,61 @@ class Migration(SchemaBaseMigration, MPTAPIClientMixin):
 
     def _migrate_product(self, product_id: str) -> None:
         logger.info("Migrating product '%s'", product_id)
-        existing = self._get_product_parameter(product_id, "terminationDate")
-        self._ensure_parameter(product_id, existing, _termination_date_parameter)
+        existing_termination_date = self._get_product_parameter(
+            product_id, _TERMINATION_DATE_EXTERNAL_ID
+        )
+        self._ensure_parameter(product_id, existing_termination_date, _termination_date_parameter)
+
+        existing_split_billing_policy = self._get_product_parameter(
+            product_id, _SPLIT_BILLING_POLICY_EXTERNAL_ID
+        )
+        self._ensure_parameter(
+            product_id, existing_split_billing_policy, _split_billing_policy_parameter
+        )
+
+        self._migrate_agreements(product_id)
+
+    def _migrate_agreements(self, product_id: str) -> None:
+        logger.info("Migrating agreements for product '%s'", product_id)
+        query = RQLQuery(product__id=product_id) & RQLQuery(status="Active")
+        agreements = list(
+            self.mpt_client.commerce.agreements.filter(query).select("+parameters").iterate()
+        )
+        logger.info(
+            "Found %s active agreement(s) for product '%s'",
+            len(agreements),
+            product_id,
+        )
+        for agreement in agreements:
+            self._ensure_agreement_split_billing_policy(agreement.to_dict())
+
+    def _ensure_agreement_split_billing_policy(self, agreement: dict[str, Any]) -> None:
+        agreement_id = agreement["id"]
+        fulfillment_params = agreement.get("parameters", {}).get("fulfillment", [])
+        already_present = any(
+            parameter.get("externalId") == _SPLIT_BILLING_POLICY_EXTERNAL_ID
+            for parameter in fulfillment_params
+        )
+        if already_present:
+            logger.info(
+                "Parameter 'splitBillingPolicy' already exists for agreement '%s'; skipping",
+                agreement_id,
+            )
+            return
+        logger.info("Adding parameter 'splitBillingPolicy' to agreement '%s'", agreement_id)
+        self.mpt_client.commerce.agreements.update(
+            agreement_id,
+            {
+                "parameters": {
+                    "fulfillment": [
+                        {
+                            "externalId": _SPLIT_BILLING_POLICY_EXTERNAL_ID,
+                            "value": _SPLIT_BILLING_MASTER_PAYER,
+                        }
+                    ]
+                }
+            },
+        )
 
     def _ensure_parameter(
         self,

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -130,6 +130,7 @@ class FulfillmentParametersEnum(StrEnum):
     CCO_CONTRACT_NUMBER = "ccoContractNumber"
     ERP_PROJECT_NO = "erpProjectNo"
     TERMINATION_DATE = "terminationDate"
+    SPLIT_BILLING_POLICY = "splitBillingPolicy"
 
 
 class OrderProcessingTemplateEnum(StrEnum):
@@ -279,3 +280,10 @@ DEFAULT_SCU = "DM-SCU-000000"
 
 
 ROLES_DEPLOYED_CRM_TICKET_COMMENT = "Customer roles have been deployed. Please resolve this ticket."
+
+
+class SplitBillingPolicyEnum(StrEnum):
+    """Enum for split billing policies."""
+
+    MASTER_PAYER = "MASTER_PAYER"
+    LINKED_ACCOUNT_PERCENTAGE = "LINKED_ACCOUNT_PERCENTAGE"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Extends the `20260610073112_split_billing` migration to cover the `splitBillingPolicy` agreement parameter defined in the [AWS TDR Split billing per linked account](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/7489421328/AWS+TDR+Split+billing+per+linked+account#Agreement-Parameters).

**Changes:**

- `swo_aws_extension/constants.py`: adds `FulfillmentParametersEnum.SPLIT_BILLING_POLICY` and `SplitBillingPolicyEnum` (`MASTER_PAYER`, `LINKED_ACCOUNT_PERCENTAGE`).
- `migrations/20260610073112_split_billing.py`:
  - Creates the `splitBillingPolicy` product parameter (DropDown, Agreement scope, Fulfillment phase, hidden, optional) alongside the existing `terminationDate` parameter.
  - Iterates all active agreements for each product and initialises `splitBillingPolicy` to `MASTER_PAYER` on any agreement that does not yet have the parameter, satisfying the migration requirement from the TDR.

## Why

The TDR requires that `splitBillingPolicy` be added to all existing AWS agreements so the billing journal can read the shared-charges policy on the first run after deployment.

## Testing

- `make check-all` passes locally (1056 tests, 99 % coverage).
- Migration is idempotent: skips agreements and products that already have the parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21952](https://softwareone.atlassian.net/browse/MPT-21952)

**Release Notes:**
- Added `FulfillmentParametersEnum.SPLIT_BILLING_POLICY` and introduced `SplitBillingPolicyEnum` (`MASTER_PAYER`, `LINKED_ACCOUNT_PERCENTAGE`)
- Extended the `20260610073112_split_billing` migration to add the `splitBillingPolicy` product parameter (hidden, optional dropdown, Agreement scope, Fulfillment phase)
- Migration initializes `splitBillingPolicy` to `MASTER_PAYER` for all active agreements that do not yet have the parameter set, ensuring the billing journal can read the policy after deployment
- Migration is idempotent and skips agreements/products where `splitBillingPolicy` is already configured
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21952]: https://softwareone.atlassian.net/browse/MPT-21952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ