### PR TITLE
MPT-22312 add Additional Charges item to subscriptions in split billing migration

### DIFF
--- a/migrations/20260610073112_split_billing.py
+++ b/migrations/20260610073112_split_billing.py
@@ -13,6 +13,40 @@ _TERMINATION_DATE_EXTERNAL_ID = "terminationDate"
 _SPLIT_BILLING_POLICY_EXTERNAL_ID = "splitBillingPolicy"
 _SPLIT_BILLING_MASTER_PAYER = "MASTER_PAYER"
 _SPLIT_BILLING_LINKED_ACCOUNT_PERCENTAGE = "LINKED_ACCOUNT_PERCENTAGE"
+_ADDITIONAL_CHARGES_SKU = "Additional Charges"
+
+
+def _get_product_item_by_sku(mpt_client, product_id: str, sku: str) -> Any | None:
+    items_service = mpt_client.catalog.products.items(product_id)
+    item_query = RQLQuery(externalIds__vendor=sku)
+    found = list(items_service.filter(item_query).select().iterate())
+    return found[0] if found else None
+
+
+def _line_item_id(line: dict[str, Any]) -> str | None:
+    return line.get("item", {}).get("id")
+
+
+def _subscription_has_item(subscription: dict[str, Any], item_id: str) -> bool:
+    existing_ids = {_line_item_id(line) for line in subscription.get("lines", [])}
+    return item_id in existing_ids
+
+
+def _add_item_to_subscription(mpt_client, subscription: dict[str, Any], catalog_item: Any) -> None:
+    subscription_id = subscription["id"]
+    item_id = catalog_item.id
+    if _subscription_has_item(subscription, item_id):
+        logger.info(
+            "Item '%s' already present in subscription '%s'; skipping",
+            _ADDITIONAL_CHARGES_SKU,
+            subscription_id,
+        )
+        return
+    logger.info("Adding item '%s' to subscription '%s'", _ADDITIONAL_CHARGES_SKU, subscription_id)
+    new_line = {"item": {"id": item_id}, "quantity": 1}
+    updated_lines = [*subscription.get("lines", []), new_line]
+    mpt_client.commerce.subscriptions.update(subscription_id, {"lines": updated_lines})
+
 
 _termination_date_parameter = {
     "name": "Termination Date",
@@ -84,6 +118,17 @@ class Migration(SchemaBaseMigration, MPTAPIClientMixin):
 
     def _migrate_product(self, product_id: str) -> None:
         logger.info("Migrating product '%s'", product_id)
+
+        additional_charges_item = _get_product_item_by_sku(
+            self.mpt_client, product_id, _ADDITIONAL_CHARGES_SKU
+        )
+        if additional_charges_item is None:
+            raise RuntimeError(
+                f"Item with vendor external ID '{_ADDITIONAL_CHARGES_SKU}' does not exist "
+                f"for product '{product_id}'. Create the item in the platform before running "
+                "this migration."
+            )
+
         existing_termination_date = self._get_product_parameter(
             product_id, _TERMINATION_DATE_EXTERNAL_ID
         )
@@ -96,13 +141,16 @@ class Migration(SchemaBaseMigration, MPTAPIClientMixin):
             product_id, existing_split_billing_policy, _split_billing_policy_parameter
         )
 
-        self._migrate_agreements(product_id)
+        self._migrate_agreements(product_id, additional_charges_item)
 
-    def _migrate_agreements(self, product_id: str) -> None:
+    def _migrate_agreements(self, product_id: str, additional_charges_item: Any) -> None:
         logger.info("Migrating agreements for product '%s'", product_id)
         query = RQLQuery(product__id=product_id) & RQLQuery(status="Active")
         agreements = list(
-            self.mpt_client.commerce.agreements.filter(query).select("+parameters").iterate()
+            self.mpt_client.commerce.agreements
+            .filter(query)
+            .select("+parameters", "+subscriptions", "+subscriptions.lines")
+            .iterate()
         )
         logger.info(
             "Found %s active agreement(s) for product '%s'",
@@ -110,7 +158,12 @@ class Migration(SchemaBaseMigration, MPTAPIClientMixin):
             product_id,
         )
         for agreement in agreements:
-            self._ensure_agreement_split_billing_policy(agreement.to_dict())
+            agreement_dict = agreement.to_dict()
+            self._ensure_agreement_split_billing_policy(agreement_dict)
+            for subscription in agreement_dict.get("subscriptions", []):
+                if subscription.get("status") not in {"Active", "Updating"}:
+                    continue
+                _add_item_to_subscription(self.mpt_client, subscription, additional_charges_item)
 
     def _ensure_agreement_split_billing_policy(self, agreement: dict[str, Any]) -> None:
         agreement_id = agreement["id"]

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -226,7 +226,7 @@ class ExpirationPeriodEnum(IntEnum):
     NEXT_MONTH = 2
 
 
-AWS_ITEMS_SKUS = ("AWS Usage",)
+AWS_ITEMS_SKUS = ("AWS Usage", "Additional Charges")
 COMMAND_INVALID_BILLING_DATE = (
     "Invalid billing date. The billing date must be in the past. "
     "You can't generate the billing of the current month until the 5th."


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

- Extends the split billing migration to verify the `Additional Charges` catalog item exists for each product before proceeding; fails with a descriptive `RuntimeError` if the item has not been created in the platform yet.
- For each active (`Active`/`Updating`) agreement subscription that does not already carry the `Additional Charges` line, the migration appends `{"item": {"id": <item_id>}, "quantity": 1}` so every subscription holds both `AWS Usage` and `Additional Charges` before split billing runs.
- Expands the agreements query to select `+subscriptions` and `+subscriptions.lines` in a single API call per product to avoid N+1 fetches.

## Test plan

- [ ] Verify migration fails with a clear error message when the `Additional Charges` item does not exist for the product.
- [ ] Verify migration completes successfully when the item exists and adds the line to subscriptions that are missing it.
- [ ] Verify migration is idempotent: re-running does not duplicate the line on subscriptions that already have it.
- [ ] Verify subscriptions with status other than `Active`/`Updating` are skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22312](https://softwareone.atlassian.net/browse/MPT-22312)

### Release Notes

- **Split billing migration enhancement**: Extended the AWS split billing migration to verify the presence of an "Additional Charges" catalog item for each product, failing with a descriptive error if absent
- **Subscription line item management**: Automatically appends the "Additional Charges" line item to active subscriptions (with status `Active` or `Updating`) that are missing it, ensuring all subscriptions contain both required line items before split billing execution
- **API query optimization**: Improved agreements API queries by fetching subscriptions and their line items in a single call per product, eliminating N+1 query patterns
- **Constants update**: Added "Additional Charges" to the `AWS_ITEMS_SKUS` constant alongside the existing "AWS Usage" entry
- **Idempotent migration**: The migration safely handles re-execution without duplicating line items in subscriptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22312]: https://softwareone.atlassian.net/browse/MPT-22312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ