### PR TITLE
MPT-21801 Distribute Saving Plans recurring fee per linked account by covered usage share

### DIFF
--- a/swo_aws_extension/billing/generators/additional_line_processors/saving_plans.py
+++ b/swo_aws_extension/billing/generators/additional_line_processors/saving_plans.py
@@ -1,0 +1,156 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+from swo_aws_extension.billing.generators.currency import resolve_service_amount
+from swo_aws_extension.billing.models.invoice import OrganizationInvoice
+from swo_aws_extension.billing.models.journal_line import (
+    InvoiceDetails,
+    JournalDetails,
+    JournalLine,
+)
+from swo_aws_extension.billing.models.usage import OrganizationUsageResult, ServiceMetric
+from swo_aws_extension.constants import DEC_ZERO, AWSRecordTypeEnum, ItemSkuEnum
+from swo_aws_extension.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class _SPFeeData:
+    total: Decimal
+    service_name: str
+    invoice_entity: str
+    invoice_id: str
+
+
+class SavingPlansDistributionProcessor:
+    """Distribute org-level Saving Plans recurring fee to linked accounts by covered usage share.
+
+    Only runs when split billing is enabled (splitBillingPolicy=LINKED_ACCOUNT_PERCENTAGE).
+    Under MASTER_PAYER, SAVING_PLAN_RECURRING_FEE is handled by the normal line processor.
+
+    AWS reports three Saving Plans record types:
+      - SavingsPlanRecurringFee  (org level)  — the actual cost to distribute
+      - SavingsPlanCoveredUsage  (per account) — positive weight for proportional split
+      - SavingsPlanNegation      (per account) — cancels CoveredUsage in AWS totals; ignored here
+    """
+
+    item_sku: str = ItemSkuEnum.USAGE_SKU
+
+    def process(
+        self,
+        usage_result: OrganizationUsageResult,
+        journal_details: JournalDetails,
+        organization_invoice: OrganizationInvoice,
+    ) -> list[JournalLine]:
+        """Return one journal line per linked account with non-zero covered SP usage.
+
+        Args:
+            usage_result: Usage data for all accounts in the organization.
+            journal_details: Journal metadata including agreement and MPA IDs.
+            organization_invoice: The organization invoice for currency resolution.
+
+        Returns:
+            Journal lines targeting each linked-account subscription directly.
+        """
+        fee_data = self._collect_recurring_fee(usage_result, organization_invoice)
+        if fee_data.total == DEC_ZERO:
+            logger.info("No Saving Plans recurring fee found; skipping SP distribution.")
+            return []
+
+        covered_by_account = self._collect_covered_usage(usage_result)
+        if not covered_by_account:
+            logger.info("No Saving Plans covered usage found; skipping SP distribution.")
+            return []
+
+        total_covered = sum(covered_by_account.values())
+        return self._build_distribution_lines(
+            covered_by_account, total_covered, fee_data, journal_details
+        )
+
+    def _collect_recurring_fee(
+        self,
+        usage_result: OrganizationUsageResult,
+        organization_invoice: OrganizationInvoice,
+    ) -> _SPFeeData:
+        """Sum all SAVING_PLAN_RECURRING_FEE metrics and return fee metadata."""
+        metrics = self._get_sp_recurring_metrics(usage_result)
+        if not metrics:
+            return _SPFeeData(DEC_ZERO, "", "", "")
+        return _SPFeeData(
+            total=sum(
+                resolve_service_amount(
+                    metric.amount,
+                    organization_invoice.entities.get(metric.invoice_entity or ""),
+                )
+                for metric in metrics
+            ),
+            service_name=metrics[0].service_name,
+            invoice_entity=metrics[0].invoice_entity or "",
+            invoice_id=metrics[0].invoice_id or "",
+        )
+
+    def _get_sp_recurring_metrics(
+        self, usage_result: OrganizationUsageResult
+    ) -> list[ServiceMetric]:
+        return [
+            metric
+            for account_usage in usage_result.usage_by_account.values()
+            for metric in account_usage.get_metrics_by_record_type(
+                AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE
+            )
+        ]
+
+    def _collect_covered_usage(self, usage_result: OrganizationUsageResult) -> dict[str, Decimal]:
+        """Return covered SP usage per account (only accounts with positive covered usage)."""
+        covered: dict[str, Decimal] = {}
+        for account_id, account_usage in usage_result.usage_by_account.items():
+            amount = sum(
+                metric.amount
+                for metric in account_usage.get_metrics_by_record_type(
+                    AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE
+                )
+            )
+            if amount > DEC_ZERO:
+                covered[account_id] = amount
+        return covered
+
+    def _build_distribution_lines(
+        self,
+        covered_by_account: dict[str, Decimal],
+        total_covered: Decimal,
+        fee_data: _SPFeeData,
+        journal_details: JournalDetails,
+    ) -> list[JournalLine]:
+        lines: list[JournalLine] = []
+        for account_id, covered in covered_by_account.items():
+            amount = round(fee_data.total * (covered / total_covered), 6)
+            if amount == DEC_ZERO:
+                continue
+            logger.info(
+                "Distributing %s SP fee to account %s (covered: %s / %s)",
+                amount,
+                account_id,
+                covered,
+                total_covered,
+            )
+            lines.append(self._build_line(account_id, amount, fee_data, journal_details))
+        return lines
+
+    def _build_line(
+        self,
+        account_id: str,
+        amount: Decimal,
+        fee_data: _SPFeeData,
+        journal_details: JournalDetails,
+    ) -> JournalLine:
+        invoice_details = InvoiceDetails(
+            service_name=fee_data.service_name,
+            amount=amount,
+            account_id=account_id,
+            invoice_entity=fee_data.invoice_entity,
+            invoice_id=fee_data.invoice_id,
+            start_date=journal_details.start_date,
+            end_date=journal_details.end_date,
+        )
+        return JournalLine.build(self.item_sku, journal_details, invoice_details)

--- a/swo_aws_extension/billing/generators/agreement.py
+++ b/swo_aws_extension/billing/generators/agreement.py
@@ -8,6 +8,9 @@ from swo_aws_extension.billing.generators.additional_line_processors.extra_disco
 from swo_aws_extension.billing.generators.additional_line_processors.pls_charge import (
     PlSChargeProcessor,
 )
+from swo_aws_extension.billing.generators.additional_line_processors.saving_plans import (
+    SavingPlansDistributionProcessor,
+)
 from swo_aws_extension.billing.generators.billing_report_rows import (
     BillingReportRowsBuilder,
     ReportContext,
@@ -140,6 +143,15 @@ class AgreementJournalGenerator:
             all_lines.extend(
                 PlSChargeProcessor().process(
                     self._pls_charge_percentage,
+                    usage_result,
+                    journal_details,
+                    organization_invoice,
+                )
+            )
+
+        if journal_details.split_billing_enabled:
+            all_lines.extend(
+                SavingPlansDistributionProcessor().process(
                     usage_result,
                     journal_details,
                     organization_invoice,

--- a/swo_aws_extension/billing/generators/journal_line.py
+++ b/swo_aws_extension/billing/generators/journal_line.py
@@ -8,6 +8,9 @@ from swo_aws_extension.billing.generators.line_processors.credit import CreditJo
 from swo_aws_extension.billing.generators.line_processors.marketplace import (
     MarketplaceJournalLineProcessor,
 )
+from swo_aws_extension.billing.generators.line_processors.saving_plans import (
+    SavingsPlanJournalLineProcessor,
+)
 from swo_aws_extension.billing.generators.line_processors.support import SupportJournalLineProcessor
 from swo_aws_extension.billing.models.context import LineProcessorContext
 from swo_aws_extension.billing.models.invoice import OrganizationInvoice
@@ -40,6 +43,7 @@ def _build_processor_registry() -> dict[str, JournalLineProcessor]:
             AWSRecordTypeEnum.CREDIT: credit,
             "MARKETPLACE": marketplace,
             AWSRecordTypeEnum.BUNDLE_DISCOUNT: bundle_discount,
+            AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE: SavingsPlanJournalLineProcessor(),
         },
     )
 

--- a/swo_aws_extension/billing/generators/line_processors/saving_plans.py
+++ b/swo_aws_extension/billing/generators/line_processors/saving_plans.py
@@ -1,0 +1,26 @@
+from typing import override
+
+from swo_aws_extension.billing.generators.line_processors.base import JournalLineProcessor
+from swo_aws_extension.billing.models.context import LineProcessorContext
+from swo_aws_extension.billing.models.journal_line import JournalLine
+from swo_aws_extension.billing.models.usage import ServiceMetric
+
+
+class SavingsPlanJournalLineProcessor(JournalLineProcessor):
+    """Processor for SavingsPlanRecurringFee lines.
+
+    When split billing is enabled the recurring fee is distributed per linked account
+    by SavingPlansDistributionProcessor, so this processor skips it to avoid double-billing.
+    When split billing is disabled the fee goes to the master payer subscription via the
+    default base processor behaviour.
+    """
+
+    @override
+    def process(
+        self,
+        metric: ServiceMetric,
+        context: LineProcessorContext,
+    ) -> list[JournalLine]:
+        if context.journal_details.split_billing_enabled:
+            return []
+        return super().process(metric, context)

--- a/tests/billing/generators/additional_line_processors/test_saving_plans.py
+++ b/tests/billing/generators/additional_line_processors/test_saving_plans.py
@@ -1,0 +1,178 @@
+from decimal import Decimal
+
+import pytest
+
+from swo_aws_extension.billing.generators.additional_line_processors.saving_plans import (
+    SavingPlansDistributionProcessor,
+)
+from swo_aws_extension.billing.models.invoice import OrganizationInvoice
+from swo_aws_extension.billing.models.journal_line import JournalDetails
+from swo_aws_extension.billing.models.usage import (
+    AccountUsage,
+    OrganizationReport,
+    OrganizationUsageResult,
+    ServiceMetric,
+)
+from swo_aws_extension.constants import AWSRecordTypeEnum, ItemSkuEnum
+
+
+def _make_metric(record_type, amount, service_name="AWS Savings Plans", invoice_id="INV-001"):
+    return ServiceMetric(
+        service_name=service_name,
+        record_type=record_type,
+        amount=Decimal(str(amount)),
+        invoice_entity="AWS Inc./AWS",
+        invoice_id=invoice_id,
+        start_date="2025-01-01",
+        end_date="2025-01-31",
+    )
+
+
+def _make_usage_result(
+    metrics_by_account: dict[str, list[ServiceMetric]],
+) -> OrganizationUsageResult:
+    return OrganizationUsageResult(
+        reports=OrganizationReport(),
+        usage_by_account={
+            account_id: AccountUsage(metrics=metrics)
+            for account_id, metrics in metrics_by_account.items()
+        },
+    )
+
+
+@pytest.fixture
+def journal_details():
+    return JournalDetails(
+        agreement_id="AGR-123",
+        mpa_id="MPA-001",
+        start_date="2025-01-01",
+        end_date="2025-01-31",
+        split_billing_enabled=True,
+    )
+
+
+@pytest.fixture
+def organization_invoice():
+    return OrganizationInvoice()
+
+
+def test_distributes_sp_fee_proportionally(journal_details, organization_invoice):
+    usage_result = _make_usage_result({
+        "MPA-001": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "36000")],
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "3000")],
+        "ACC-B": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "1000")],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    assert len(result) == 2
+    amounts_by_account = {line.search.source.criteria_value: line.price.pp_x1 for line in result}
+    assert amounts_by_account["ACC-A"] == Decimal("27000.00")
+    assert amounts_by_account["ACC-B"] == Decimal("9000.00")
+
+
+def test_routes_to_linked_account_subscription(journal_details, organization_invoice):
+    usage_result = _make_usage_result({
+        "MPA-001": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "1000")],
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "500")],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    source = result[0].search.source
+    assert source.type == "Subscription"
+    assert source.criteria == "externalIds.vendor"
+    assert source.criteria_value == "ACC-A"
+
+
+def test_uses_usage_sku(journal_details, organization_invoice):
+    usage_result = _make_usage_result({
+        "MPA-001": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "100")],
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "100")],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    assert result[0].search.search_item.criteria_value == ItemSkuEnum.USAGE_SKU
+
+
+def test_skips_account_with_zero_covered_usage(journal_details, organization_invoice):
+    usage_result = _make_usage_result({
+        "MPA-001": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "1000")],
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "800")],
+        "ACC-B": [],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    account_ids = [line.search.source.criteria_value for line in result]
+    assert "ACC-A" in account_ids
+    assert "ACC-B" not in account_ids
+
+
+def test_returns_empty_when_no_recurring_fee(journal_details, organization_invoice):
+    usage_result = _make_usage_result({
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "500")],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    assert result == []
+
+
+def test_returns_empty_when_no_covered_usage(journal_details, organization_invoice):
+    usage_result = _make_usage_result({
+        "MPA-001": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "1000")],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    assert result == []
+
+
+def test_sums_multiple_recurring_fee_metrics(journal_details, organization_invoice):
+    usage_result = _make_usage_result({
+        "MPA-001": [
+            _make_metric(
+                AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "20000", "AWS Compute Savings Plans"
+            ),
+            _make_metric(
+                AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "16000", "AWS EC2 Savings Plans"
+            ),
+        ],
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "1")],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    assert result[0].price.pp_x1 == Decimal("36000.00")
+
+
+def test_skips_account_when_distributed_amount_rounds_to_zero(
+    journal_details, organization_invoice
+):
+    """Covers the `if amount == DEC_ZERO: continue` branch."""
+    usage_result = _make_usage_result({
+        "MPA-001": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "1")],
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "1000000")],
+        "ACC-B": [
+            _make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "0.000001"),
+        ],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process(usage_result, journal_details, organization_invoice)
+
+    account_ids = [line.search.source.criteria_value for line in result]
+    assert "ACC-A" in account_ids
+    assert "ACC-B" not in account_ids

--- a/tests/billing/generators/line_processors/test_saving_plans.py
+++ b/tests/billing/generators/line_processors/test_saving_plans.py
@@ -1,0 +1,77 @@
+from decimal import Decimal
+
+import pytest
+
+from swo_aws_extension.billing.generators.line_processors.saving_plans import (
+    SavingsPlanJournalLineProcessor,
+)
+from swo_aws_extension.billing.models.context import LineProcessorContext
+from swo_aws_extension.billing.models.invoice import InvoiceEntity, OrganizationInvoice
+from swo_aws_extension.billing.models.journal_line import JournalDetails
+from swo_aws_extension.billing.models.usage import AccountUsage, ServiceMetric
+from swo_aws_extension.constants import AWSRecordTypeEnum
+
+
+@pytest.fixture
+def metric():
+    return ServiceMetric(
+        service_name="AWS Savings Plans",
+        record_type=AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE,
+        amount=Decimal("1000.00"),
+        invoice_entity="INV-1",
+        invoice_id="INV-001",
+        start_date="2025-01-01",
+        end_date="2025-01-31",
+    )
+
+
+@pytest.fixture
+def processor_context():
+    return LineProcessorContext(
+        account_id="MPA-001",
+        account_usage=AccountUsage(),
+        journal_details=JournalDetails(
+            agreement_id="AGR-1",
+            mpa_id="MPA-001",
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            split_billing_enabled=False,
+        ),
+        organization_invoice=OrganizationInvoice(
+            entities={
+                "INV-1": InvoiceEntity(
+                    invoice_id="INV-001",
+                    base_currency_code="USD",
+                    payment_currency_code="USD",
+                    exchange_rate=Decimal("1.0"),
+                )
+            }
+        ),
+    )
+
+
+def test_skips_recurring_fee_when_split_billing_enabled(processor_context, metric):
+    processor_context.journal_details.split_billing_enabled = True
+
+    result = SavingsPlanJournalLineProcessor().process(metric, processor_context)
+
+    assert result == []
+
+
+def test_processes_recurring_fee_when_split_billing_disabled(processor_context, metric):
+    processor_context.journal_details.split_billing_enabled = False
+
+    result = SavingsPlanJournalLineProcessor().process(metric, processor_context)
+
+    assert len(result) == 1
+    assert result[0].price.pp_x1 == Decimal("1000.00")
+
+
+def test_routes_to_master_payer_subscription_when_not_split(processor_context, metric):
+    processor_context.journal_details.split_billing_enabled = False
+
+    result = SavingsPlanJournalLineProcessor().process(metric, processor_context)
+
+    source = result[0].search.source
+    assert source.type == "Subscription"
+    assert source.criteria_value == "MPA-001"

--- a/tests/billing/generators/test_agreement.py
+++ b/tests/billing/generators/test_agreement.py
@@ -9,6 +9,9 @@ from swo_aws_extension.billing.generators.additional_line_processors.extra_disco
 from swo_aws_extension.billing.generators.additional_line_processors.pls_charge import (
     PlSChargeProcessor,
 )
+from swo_aws_extension.billing.generators.additional_line_processors.saving_plans import (
+    SavingPlansDistributionProcessor,
+)
 from swo_aws_extension.billing.generators.agreement import (
     AgreementJournalGenerator,
 )
@@ -463,3 +466,62 @@ def test_pls_mismatch_param_resold_but_enterprise_in_report(
     assert result.pls_mismatches[0].report_has_enterprise is True
     mock_pls_instance.process.assert_called_once()
     assert mock_pls_line in result.lines
+
+
+def test_run_with_split_billing_enabled(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    mock_line_generator_cls,
+    mock_extra_discounts_manager_cls,
+    mock_pls_charge_manager_cls,
+):
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
+    mock_sp_processor = mocker.patch(f"{MODULE}.SavingPlansDistributionProcessor", autospec=True)
+    mock_sp_instance = mocker.MagicMock(spec=SavingPlansDistributionProcessor)
+    mock_sp_line = mocker.MagicMock(spec=JournalLine)
+    mock_sp_instance.process.return_value = [mock_sp_line]
+    mock_sp_processor.return_value = mock_sp_instance
+    agreement = {
+        "id": "AGR-1",
+        "externalIds": {"vendor": "MPA"},
+        "parameters": {
+            "ordering": [
+                {"externalId": "supportType", "value": "ResoldSupport"},
+            ],
+            "fulfillment": [
+                {"externalId": "splitBillingPolicy", "value": "LINKED_ACCOUNT_PERCENTAGE"},
+            ],
+        },
+    }
+    mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
+    mock_generator_instance.generate.return_value = []
+    mock_line_generator_cls.return_value = mock_generator_instance
+    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
+    mock_discounts_instance.process.return_value = []
+    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
+    mock_usage_result.reports = OrganizationReport()
+    mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_result.has_enterprise_support.return_value = False
+    mock_usage_generator.run.return_value = mock_usage_result
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
+        invoice=OrganizationInvoice(),
+    )
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)
+
+    mock_sp_instance.process.assert_called_once()
+    assert mock_sp_line in result.lines


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

- Add `SavingsPlanJournalLineProcessor` that skips `SAVING_PLAN_RECURRING_FEE` when split billing is enabled, so the org-level fee is not consumed by the default MPA-routing path.
- Add `SavingPlansDistributionProcessor` that collects the org-level recurring fee and distributes it proportionally to linked accounts weighted by `SavingsPlanCoveredUsage / total_covered` (one journal line per account, rounded to 6 dp).
- Register the new line processor in `journal_line.py` and invoke the distribution processor in `agreement.py` when `split_billing_enabled`.
- Under `MASTER_PAYER` the existing behaviour is preserved: the recurring fee is routed to the MPA subscription unchanged.

## Test plan

- [ ] `make check-all` passes (ruff, flake8, all 1067+ tests, 99% coverage)
- [ ] `test_distributes_sp_fee_proportionally` — proportional amounts for ACC-A (75%) and ACC-B (25%) are correct
- [ ] `test_routes_to_linked_account_subscription` — journal line targets the linked-account subscription, not MPA
- [ ] `test_uses_usage_sku` — USAGE SKU is applied
- [ ] `test_skips_account_with_zero_covered_usage` — accounts with no covered usage are excluded
- [ ] `test_returns_empty_when_no_recurring_fee` — no-op when fee is absent
- [ ] `test_returns_empty_when_no_covered_usage` — no-op when covered usage is absent
- [ ] `test_sums_multiple_recurring_fee_metrics` — multiple recurring fee entries are summed before distributing
- [ ] `test_skips_account_when_distributed_amount_rounds_to_zero` — accounts whose share rounds to zero are excluded
- [ ] `test_skips_recurring_fee_when_split_billing_enabled` — line processor returns empty list under split billing
- [ ] `test_processes_recurring_fee_when_split_billing_disabled` — line processor routes to MPA under MASTER_PAYER
- [ ] `test_routes_to_master_payer_subscription_when_not_split` — subscription search targets MPA vendor ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21801](https://softwareone.atlassian.net/browse/MPT-21801)

**Release Notes:**

- Implemented distributed billing for AWS Saving Plans recurring fees across linked accounts under the `LINKED_ACCOUNT_PERCENTAGE` split billing policy
- Added `SavingsPlanJournalLineProcessor` to suppress recurring fee processing when split billing is enabled, preventing duplicate billing to the org-level fee
- Added `SavingPlansDistributionProcessor` to collect org-level recurring fees and distribute them proportionally to linked accounts based on their `SavingsPlanCoveredUsage` share
- Generated journal lines allocated per account with amounts rounded to 6 decimal places (one line per account)
- Preserved existing behavior under `MASTER_PAYER` mode where recurring fees continue to route to the MPA subscription through the standard processor
- Registered the new processors in the billing pipeline for seamless integration with existing workflows
- Added comprehensive test coverage for proportional distribution, subscription targeting, SKU application, edge cases, and mode-specific routing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21801]: https://softwareone.atlassian.net/browse/MPT-21801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ