### PR TITLE
MPT-22449 Refactor additional line processors

### DIFF
--- a/swo_aws_extension/billing/generators/additional_line_processors/base.py
+++ b/swo_aws_extension/billing/generators/additional_line_processors/base.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+from decimal import Decimal
+
+from swo_aws_extension.billing.models.invoice import OrganizationInvoice
+from swo_aws_extension.billing.models.journal_line import (
+    InvoiceDetails,
+    JournalDetails,
+    JournalLine,
+)
+from swo_aws_extension.billing.models.usage import OrganizationUsageResult
+from swo_aws_extension.constants import ItemSkuEnum
+
+
+class AdditionalLineProcessor(ABC):
+    """Base for processors that add journal lines after the main per-account usage pass."""
+
+    item_sku: str = ItemSkuEnum.ADDITIONAL_CHARGES_SKU
+    is_organization_charge: bool = False
+
+    @abstractmethod
+    def process(
+        self,
+        agreement: dict,
+        usage_result: OrganizationUsageResult,
+        journal_details: JournalDetails,
+        organization_invoice: OrganizationInvoice,
+    ) -> list[JournalLine]:
+        """Return additional journal lines for the given agreement and usage data."""
+
+    def _calculate_percentage_amount(self, base_amount: Decimal, percentage: Decimal) -> Decimal:
+        return round(base_amount * (percentage / Decimal(100)), 6)
+
+    def _build_org_journal_line(
+        self,
+        service_name: str,
+        amount: Decimal,
+        journal_details: JournalDetails,
+        organization_invoice: OrganizationInvoice,
+    ) -> JournalLine:
+        invoice_details = InvoiceDetails(
+            service_name=service_name,
+            amount=amount,
+            account_id=journal_details.mpa_id,
+            invoice_entity=organization_invoice.primary_entity_name,
+            invoice_id=organization_invoice.primary_invoice_id,
+            start_date=journal_details.start_date,
+            end_date=journal_details.end_date,
+        )
+        return JournalLine.build(
+            self.item_sku,
+            journal_details,
+            invoice_details,
+            is_organization_charge=self.is_organization_charge,
+        )

--- a/swo_aws_extension/billing/generators/additional_line_processors/extra_discounts.py
+++ b/swo_aws_extension/billing/generators/additional_line_processors/extra_discounts.py
@@ -1,12 +1,14 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from decimal import Decimal
 from typing import override
 
+from swo_aws_extension.billing.generators.additional_line_processors.base import (
+    AdditionalLineProcessor,
+)
 from swo_aws_extension.billing.generators.currency import resolve_service_amount
 from swo_aws_extension.billing.generators.usage_utils import calculate_total_by_record_types
 from swo_aws_extension.billing.models.invoice import OrganizationInvoice
 from swo_aws_extension.billing.models.journal_line import (
-    InvoiceDetails,
     JournalDetails,
     JournalLine,
 )
@@ -15,7 +17,6 @@ from swo_aws_extension.constants import (
     DEC_ZERO,
     AWSRecordTypeEnum,
     ChannelHandshakeDeployed,
-    ItemSkuEnum,
     SupportTypesEnum,
 )
 from swo_aws_extension.logger import get_logger
@@ -30,15 +31,15 @@ from swo_aws_extension.parameters import (
 logger = get_logger(__name__)
 
 
-class BaseExtraDiscountProcessor(ABC):
+class BaseExtraDiscountProcessor(AdditionalLineProcessor):
     """Base class for all extra discounts processor."""
 
-    item_sku: str = ItemSkuEnum.ADDITIONAL_CHARGES_SKU
     is_organization_charge: bool = True
 
     def __init__(self, service_name: str) -> None:
         self._service_name = service_name
 
+    @override
     def process(
         self,
         agreement: dict,
@@ -46,17 +47,10 @@ class BaseExtraDiscountProcessor(ABC):
         journal_details: JournalDetails,
         organization_invoice: OrganizationInvoice,
     ) -> list[JournalLine]:
-        """Process extra discount and return journal lines.
+        if organization_invoice.principal_invoice_amount == DEC_ZERO:
+            logger.info("Principal invoice amount is zero, skipping extra discounts processing.")
+            return []
 
-        Args:
-            agreement: The agreement data containing the parameters.
-            usage_result: The global organization usage result.
-            journal_details: Shared journal details containing the MPA ID.
-            organization_invoice: The organization invoice.
-
-        Returns:
-            List of journal lines containing the discount refund.
-        """
         if not self._is_applicable(agreement):
             return []
 
@@ -68,23 +62,10 @@ class BaseExtraDiscountProcessor(ABC):
         if base_amount == DEC_ZERO:
             return []
 
-        refund_amount = self._calculate_refund_amount(base_amount, discount_percentage)
-
-        invoice_details = InvoiceDetails(
-            service_name=self._service_name,
-            amount=refund_amount,
-            account_id=journal_details.mpa_id,
-            invoice_entity=organization_invoice.primary_entity_name,
-            invoice_id=organization_invoice.primary_invoice_id,
-            start_date=journal_details.start_date,
-            end_date=journal_details.end_date,
-        )
+        refund_amount = self._calculate_percentage_amount(base_amount, discount_percentage)
         return [
-            JournalLine.build(
-                self.item_sku,
-                journal_details,
-                invoice_details,
-                is_organization_charge=self.is_organization_charge,
+            self._build_org_journal_line(
+                self._service_name, refund_amount, journal_details, organization_invoice
             )
         ]
 
@@ -103,10 +84,6 @@ class BaseExtraDiscountProcessor(ABC):
         organization_invoice: OrganizationInvoice,
     ) -> Decimal:
         """Calculate the sum of metrics over which the discount is applied."""
-
-    def _calculate_refund_amount(self, base_amount: Decimal, percentage: Decimal) -> Decimal:
-        refund = base_amount * (percentage / Decimal(100))
-        return round(refund, 6)
 
 
 class ServiceDiscountProcessor(BaseExtraDiscountProcessor):
@@ -235,39 +212,3 @@ class PlSDiscountProcessor(BaseExtraDiscountProcessor):
             organization_invoice,
             {AWSRecordTypeEnum.USAGE},
         )
-
-
-class ExtraDiscountsManager:
-    """Manager to process all extra discounts globally across an organization."""
-
-    def __init__(self, pls_charge_percentage: Decimal) -> None:
-        self._processors = [
-            ServiceDiscountProcessor(),
-            SupportDiscountProcessor(),
-            PlSDiscountProcessor(pls_charge_percentage),
-        ]
-
-    def process(
-        self,
-        agreement: dict,
-        usage_result: OrganizationUsageResult,
-        journal_details: JournalDetails,
-        organization_invoice: OrganizationInvoice,
-    ) -> list[JournalLine]:
-        """Apply all extra discounts over the organization usage result."""
-        lines = []
-        principal_amount = organization_invoice.principal_invoice_amount
-        if principal_amount == DEC_ZERO:
-            logger.info("Principal invoice amount is zero, skipping extra discounts processing.")
-            return lines
-
-        for processor in self._processors:
-            lines.extend(
-                processor.process(
-                    agreement,
-                    usage_result,
-                    journal_details,
-                    organization_invoice,
-                )
-            )
-        return lines

--- a/swo_aws_extension/billing/generators/additional_line_processors/pls_charge.py
+++ b/swo_aws_extension/billing/generators/additional_line_processors/pls_charge.py
@@ -1,52 +1,45 @@
 from decimal import Decimal
+from typing import override
 
+from swo_aws_extension.billing.generators.additional_line_processors.base import (
+    AdditionalLineProcessor,
+)
 from swo_aws_extension.billing.generators.usage_utils import calculate_total_by_record_types
 from swo_aws_extension.billing.models.invoice import OrganizationInvoice
-from swo_aws_extension.billing.models.journal_line import (
-    InvoiceDetails,
-    JournalDetails,
-    JournalLine,
-)
+from swo_aws_extension.billing.models.journal_line import JournalDetails, JournalLine
 from swo_aws_extension.billing.models.usage import OrganizationUsageResult
-from swo_aws_extension.constants import DEC_ZERO, AWSRecordTypeEnum, ItemSkuEnum
+from swo_aws_extension.constants import DEC_ZERO, AWSRecordTypeEnum
 from swo_aws_extension.logger import get_logger
 
 logger = get_logger(__name__)
 
 
-class PlSChargeProcessor:
+class PlSChargeProcessor(AdditionalLineProcessor):
     """Processor to calculate and generate SWO Enterprise Support for AWS (PLS) charges."""
 
-    item_sku: str = ItemSkuEnum.ADDITIONAL_CHARGES_SKU
     is_organization_charge: bool = True
 
-    def __init__(self) -> None:
+    def __init__(self, charge_percentage: Decimal) -> None:
         self._service_name = "SWO Enterprise support for AWS"
+        self._charge_percentage = charge_percentage
 
+    @override
     def process(
         self,
-        charge_percentage: Decimal,
+        agreement: dict,
         usage_result: OrganizationUsageResult,
         journal_details: JournalDetails,
         organization_invoice: OrganizationInvoice,
     ) -> list[JournalLine]:
-        """Process PLS charge and return journal lines.
+        if not usage_result.has_enterprise_support():
+            return []
 
-        Args:
-            charge_percentage: The PLS percentage scalar to compute the charge.
-            usage_result: The global organization usage result.
-            journal_details: Shared journal details containing the MPA ID.
-            organization_invoice: The organization invoice.
-
-        Returns:
-            List containing the PLS Charge journal line, if applicable.
-        """
-        logger.info("Processing '%s' charge with %s", self._service_name, charge_percentage)
+        logger.info("Processing '%s' charge with %s", self._service_name, self._charge_percentage)
         principal_amount = organization_invoice.principal_invoice_amount
         if principal_amount == DEC_ZERO:
             return []
 
-        if charge_percentage <= DEC_ZERO:
+        if self._charge_percentage <= DEC_ZERO:
             return []
 
         base_amount = self._calculate_base_amount(usage_result, organization_invoice)
@@ -54,24 +47,12 @@ class PlSChargeProcessor:
         if base_amount <= DEC_ZERO:
             return []
 
-        charge_amount = self._calculate_charge_amount(base_amount, charge_percentage)
+        charge_amount = self._calculate_percentage_amount(base_amount, self._charge_percentage)
         logger.info("PLS Charge amount: %s ", charge_amount)
 
-        invoice_details = InvoiceDetails(
-            service_name=self._service_name,
-            amount=charge_amount,
-            account_id=journal_details.mpa_id,
-            invoice_entity=organization_invoice.primary_entity_name,
-            invoice_id=organization_invoice.primary_invoice_id,
-            start_date=journal_details.start_date,
-            end_date=journal_details.end_date,
-        )
         return [
-            JournalLine.build(
-                self.item_sku,
-                journal_details,
-                invoice_details,
-                is_organization_charge=self.is_organization_charge,
+            self._build_org_journal_line(
+                self._service_name, charge_amount, journal_details, organization_invoice
             )
         ]
 
@@ -85,7 +66,3 @@ class PlSChargeProcessor:
             organization_invoice,
             {AWSRecordTypeEnum.USAGE},
         )
-
-    def _calculate_charge_amount(self, base_amount: Decimal, percentage: Decimal) -> Decimal:
-        charge = base_amount * (percentage / Decimal(100))
-        return round(charge, 6)

--- a/swo_aws_extension/billing/generators/additional_line_processors/saving_plans.py
+++ b/swo_aws_extension/billing/generators/additional_line_processors/saving_plans.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import override
 
+from swo_aws_extension.billing.generators.additional_line_processors.base import (
+    AdditionalLineProcessor,
+)
 from swo_aws_extension.billing.generators.currency import resolve_service_amount
 from swo_aws_extension.billing.models.invoice import OrganizationInvoice
 from swo_aws_extension.billing.models.journal_line import (
@@ -23,7 +27,7 @@ class _SPFeeData:
     invoice_id: str
 
 
-class SavingPlansDistributionProcessor:
+class SavingPlansDistributionProcessor(AdditionalLineProcessor):
     """Distribute org-level Saving Plans recurring fee to linked accounts by covered usage share.
 
     Only runs when split billing is enabled (splitBillingPolicy=LINKED_ACCOUNT_PERCENTAGE).
@@ -37,22 +41,18 @@ class SavingPlansDistributionProcessor:
 
     item_sku: str = ItemSkuEnum.USAGE_SKU
 
+    @override
     def process(
         self,
+        agreement: dict,
         usage_result: OrganizationUsageResult,
         journal_details: JournalDetails,
         organization_invoice: OrganizationInvoice,
     ) -> list[JournalLine]:
-        """Return one journal line per linked account with non-zero covered SP usage.
+        """Return one journal line per linked account with non-zero covered SP usage."""
+        if not journal_details.split_billing_enabled:
+            return []
 
-        Args:
-            usage_result: Usage data for all accounts in the organization.
-            journal_details: Journal metadata including agreement and MPA IDs.
-            organization_invoice: The organization invoice for currency resolution.
-
-        Returns:
-            Journal lines targeting each linked-account subscription directly.
-        """
         fee_data = self._collect_recurring_fee(usage_result, organization_invoice)
         if fee_data.total == DEC_ZERO:
             logger.info("No Saving Plans recurring fee found; skipping SP distribution.")
@@ -63,7 +63,7 @@ class SavingPlansDistributionProcessor:
             logger.info("No Saving Plans covered usage found; skipping SP distribution.")
             return []
 
-        total_covered = sum(covered_by_account.values())
+        total_covered = sum(covered_by_account.values(), DEC_ZERO)
         return self._build_distribution_lines(
             covered_by_account, total_covered, fee_data, journal_details
         )
@@ -79,11 +79,14 @@ class SavingPlansDistributionProcessor:
             return _SPFeeData(DEC_ZERO, "", "", "")
         return _SPFeeData(
             total=sum(
-                resolve_service_amount(
-                    metric.amount,
-                    organization_invoice.entities.get(metric.invoice_entity or ""),
-                )
-                for metric in metrics
+                (
+                    resolve_service_amount(
+                        metric.amount,
+                        organization_invoice.entities.get(metric.invoice_entity or ""),
+                    )
+                    for metric in metrics
+                ),
+                DEC_ZERO,
             ),
             service_name=metrics[0].service_name,
             invoice_entity=metrics[0].invoice_entity or "",
@@ -106,10 +109,13 @@ class SavingPlansDistributionProcessor:
         covered: dict[str, Decimal] = {}
         for account_id, account_usage in usage_result.usage_by_account.items():
             amount = sum(
-                metric.amount
-                for metric in account_usage.get_metrics_by_record_type(
-                    AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE
-                )
+                (
+                    metric.amount
+                    for metric in account_usage.get_metrics_by_record_type(
+                        AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE
+                    )
+                ),
+                DEC_ZERO,
             )
             if amount > DEC_ZERO:
                 covered[account_id] = amount

--- a/swo_aws_extension/billing/generators/agreement.py
+++ b/swo_aws_extension/billing/generators/agreement.py
@@ -3,7 +3,9 @@ import datetime as dt
 from mpt_extension_sdk.runtime.tracer import dynamic_trace_span
 
 from swo_aws_extension.billing.generators.additional_line_processors.extra_discounts import (
-    ExtraDiscountsManager,
+    PlSDiscountProcessor,
+    ServiceDiscountProcessor,
+    SupportDiscountProcessor,
 )
 from swo_aws_extension.billing.generators.additional_line_processors.pls_charge import (
     PlSChargeProcessor,
@@ -49,12 +51,18 @@ class AgreementJournalGenerator:
         invoice_generator: InvoiceGenerator,
     ) -> None:
         self._auth_context = auth_context
-        self._pls_charge_percentage = context.pls_charge_percentage
         self._config = context.config
         self._mpt_client = context.mpt_client
         self._billing_period = context.billing_period
         self._usage_generator = usage_generator
         self._invoice_generator = invoice_generator
+        self._additional_processors = [
+            ServiceDiscountProcessor(),
+            SupportDiscountProcessor(),
+            PlSDiscountProcessor(context.pls_charge_percentage),
+            PlSChargeProcessor(context.pls_charge_percentage),
+            SavingPlansDistributionProcessor(),
+        ]
 
     @with_log_context(lambda _, agreement, **kwargs: agreement.get("id"))
     @dynamic_trace_span(lambda _, agreement, **kwargs: f"Agreement {agreement.get('id')}")
@@ -114,16 +122,13 @@ class AgreementJournalGenerator:
         journal_details: JournalDetails,
         organization_invoice,
     ) -> AgreementJournalResult:
+        # Generate lines from AWS usage report
         all_lines = self._generate_usage_lines(usage_result, journal_details, organization_invoice)
-
-        # Process extra discounts after generating all usage lines.
+        # Generate additional lines from custom processors
         all_lines.extend(
-            ExtraDiscountsManager(self._pls_charge_percentage).process(
-                agreement,
-                usage_result,
-                journal_details,
-                organization_invoice,
-            )
+            line
+            for proc in self._additional_processors
+            for line in proc.process(agreement, usage_result, journal_details, organization_invoice)
         )
 
         pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
@@ -136,25 +141,6 @@ class AgreementJournalGenerator:
                     agreement_id=agreement.get("id", ""),
                     pls_in_order=pls_in_order,
                     report_has_enterprise=report_has_enterprise,
-                )
-            )
-
-        if report_has_enterprise:
-            all_lines.extend(
-                PlSChargeProcessor().process(
-                    self._pls_charge_percentage,
-                    usage_result,
-                    journal_details,
-                    organization_invoice,
-                )
-            )
-
-        if journal_details.split_billing_enabled:
-            all_lines.extend(
-                SavingPlansDistributionProcessor().process(
-                    usage_result,
-                    journal_details,
-                    organization_invoice,
                 )
             )
 

--- a/tests/billing/generators/additional_line_processors/test_extra_discounts.py
+++ b/tests/billing/generators/additional_line_processors/test_extra_discounts.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 import pytest
 
 from swo_aws_extension.billing.generators.additional_line_processors.extra_discounts import (
-    ExtraDiscountsManager,
     PlSDiscountProcessor,
     ServiceDiscountProcessor,
     SupportDiscountProcessor,
@@ -160,7 +159,7 @@ def test_returns_empty_when_handshake_not_approved(
     assert len(lines) == 0
 
 
-def test_extra_discounts_manager(
+def test_extra_discounts_processors_combined(
     agreement,
     usage_result,
     journal_details,
@@ -184,11 +183,13 @@ def test_extra_discounts_manager(
             create_metric("Support", AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT, "-5.00"),
         ]
     )
-    manager = ExtraDiscountsManager(Decimal("5.0"))
+    processors = [ServiceDiscountProcessor(), SupportDiscountProcessor()]
 
-    lines = manager.process(  # act
-        agreement, usage_result, journal_details, organization_invoice
-    )
+    lines = [  # act
+        line
+        for proc in processors
+        for line in proc.process(agreement, usage_result, journal_details, organization_invoice)
+    ]
 
     assert len(lines) == 2
     service_line = next(
@@ -326,15 +327,18 @@ def test_pls_discount_processor(
     [None, Decimal(0)],
     ids=["none", "zero"],
 )
-def test_extra_discounts_manager_skips_when_principal_amount_is_zero_or_none(
+def test_extra_discount_skips_when_principal_amount_is_zero_or_none(
     agreement,
     usage_result,
     journal_details,
     principal_amount,
 ):
+    agreement["parameters"]["fulfillment"].append(
+        {"externalId": "serviceDiscount", "value": "5.0"},
+    )
     invoice = OrganizationInvoice(principal_invoice_amount=principal_amount)
-    manager = ExtraDiscountsManager(Decimal("5.0"))
+    processor = ServiceDiscountProcessor()
 
-    result = manager.process(agreement, usage_result, journal_details, invoice)
+    result = processor.process(agreement, usage_result, journal_details, invoice)
 
     assert not result

--- a/tests/billing/generators/additional_line_processors/test_pls_charge.py
+++ b/tests/billing/generators/additional_line_processors/test_pls_charge.py
@@ -31,6 +31,10 @@ def create_metric(service_name, record_type, amount, invoice_entity="Entity1"):
     )
 
 
+def create_enterprise_metric(account="ACC-1"):
+    return create_metric("AWS Support (Enterprise)", AWSRecordTypeEnum.SUPPORT, "0.00")
+
+
 def build_usage_result(metrics_by_account):
     return OrganizationUsageResult(
         reports=OrganizationReport(),
@@ -71,11 +75,12 @@ def test_process_with_custom_percentage(journal_details, organization_invoice):
         "ACC-1": [
             create_metric("EC2", AWSRecordTypeEnum.USAGE, "200.00"),
             create_metric("RDS", AWSRecordTypeEnum.USAGE, "100.00"),
+            create_enterprise_metric(),
         ],
     })
-    manager = PlSChargeProcessor()
+    manager = PlSChargeProcessor(Decimal("10.0"))
 
-    result = manager.process(Decimal("10.0"), usage_result, journal_details, organization_invoice)
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("30.0")
@@ -85,11 +90,14 @@ def test_process_with_custom_percentage(journal_details, organization_invoice):
 
 def test_process_with_default_percentage(journal_details, organization_invoice):
     usage_result = build_usage_result({
-        "ACC-1": [create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00")],
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
+            create_enterprise_metric(),
+        ],
     })
-    manager = PlSChargeProcessor()
+    manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process(Decimal("5.0"), usage_result, journal_details, organization_invoice)
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("5.0")
@@ -97,12 +105,15 @@ def test_process_with_default_percentage(journal_details, organization_invoice):
 
 def test_process_sums_across_multiple_accounts(journal_details, organization_invoice):
     usage_result = build_usage_result({
-        "ACC-1": [create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00")],
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
+            create_enterprise_metric(),
+        ],
         "ACC-2": [create_metric("RDS", AWSRecordTypeEnum.USAGE, "100.00")],
     })
-    manager = PlSChargeProcessor()
+    manager = PlSChargeProcessor(Decimal("10.0"))
 
-    result = manager.process(Decimal("10.0"), usage_result, journal_details, organization_invoice)
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("20.0")
@@ -110,20 +121,25 @@ def test_process_sums_across_multiple_accounts(journal_details, organization_inv
 
 def test_process_returns_empty_when_zero_percentage(journal_details, organization_invoice):
     usage_result = build_usage_result({
-        "ACC-1": [create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00")],
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
+            create_enterprise_metric(),
+        ],
     })
-    manager = PlSChargeProcessor()
+    manager = PlSChargeProcessor(Decimal("0.0"))
 
-    result = manager.process(Decimal("0.0"), usage_result, journal_details, organization_invoice)
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 0
 
 
 def test_process_returns_empty_when_no_usage(journal_details, organization_invoice):
-    usage_result = build_usage_result({"ACC-1": []})
-    manager = PlSChargeProcessor()
+    usage_result = build_usage_result({
+        "ACC-1": [create_enterprise_metric()],
+    })
+    manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process(Decimal("5.0"), usage_result, journal_details, organization_invoice)
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 0
 
@@ -135,11 +151,12 @@ def test_process_only_sums_usage_record_type(journal_details, organization_invoi
             create_metric("Support", AWSRecordTypeEnum.SUPPORT, "50.00"),
             create_metric("EC2", AWSRecordTypeEnum.CREDIT, "-10.00"),
             create_metric("EC2", AWSRecordTypeEnum.RECURRING, "20.00"),
+            create_enterprise_metric(),
         ],
     })
-    manager = PlSChargeProcessor()
+    manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process(Decimal("5.0"), usage_result, journal_details, organization_invoice)
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("5.0")
@@ -158,11 +175,14 @@ def test_process_applies_exchange_rate(journal_details):
         },
     )
     usage_result = build_usage_result({
-        "ACC-1": [create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00", "AWS EMEA")],
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00", "AWS EMEA"),
+            create_enterprise_metric(),
+        ],
     })
-    manager = PlSChargeProcessor()
+    manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process(Decimal("5.0"), usage_result, journal_details, invoice)
+    result = manager.process({}, usage_result, journal_details, invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("4.5")
@@ -171,10 +191,24 @@ def test_process_applies_exchange_rate(journal_details):
 def test_process_returns_empty_when_invoice_amount_is_zero(journal_details, organization_invoice):
     organization_invoice.principal_invoice_amount = Decimal(0)
     usage_result = build_usage_result({
-        "ACC-1": [create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00")],
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
+            create_enterprise_metric(),
+        ],
     })
-    manager = PlSChargeProcessor()
+    manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process(Decimal("5.0"), usage_result, journal_details, organization_invoice)
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 0
+
+
+def test_returns_empty_when_no_enterprise_support(journal_details, organization_invoice):
+    usage_result = build_usage_result({
+        "ACC-1": [create_metric("EC2", AWSRecordTypeEnum.USAGE, "200.00")],
+    })
+    manager = PlSChargeProcessor(Decimal("10.0"))
+
+    result = manager.process({}, usage_result, journal_details, organization_invoice)
+
+    assert result == []

--- a/tests/billing/generators/additional_line_processors/test_saving_plans.py
+++ b/tests/billing/generators/additional_line_processors/test_saving_plans.py
@@ -64,7 +64,7 @@ def test_distributes_sp_fee_proportionally(journal_details, organization_invoice
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 2
     amounts_by_account = {line.search.source.criteria_value: line.price.pp_x1 for line in result}
@@ -79,7 +79,7 @@ def test_routes_to_linked_account_subscription(journal_details, organization_inv
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     source = result[0].search.source
@@ -95,7 +95,7 @@ def test_uses_usage_sku(journal_details, organization_invoice):
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].search.search_item.criteria_value == ItemSkuEnum.USAGE_SKU
@@ -109,7 +109,7 @@ def test_skips_account_with_zero_covered_usage(journal_details, organization_inv
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     account_ids = [line.search.source.criteria_value for line in result]
     assert "ACC-A" in account_ids
@@ -122,7 +122,7 @@ def test_returns_empty_when_no_recurring_fee(journal_details, organization_invoi
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     assert result == []
 
@@ -133,7 +133,7 @@ def test_returns_empty_when_no_covered_usage(journal_details, organization_invoi
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     assert result == []
 
@@ -152,10 +152,29 @@ def test_sums_multiple_recurring_fee_metrics(journal_details, organization_invoi
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.pp_x1 == Decimal("36000.00")
+
+
+def test_returns_empty_when_split_billing_disabled(organization_invoice):
+    journal_details_no_split = JournalDetails(
+        agreement_id="AGR-123",
+        mpa_id="MPA-001",
+        start_date="2025-01-01",
+        end_date="2025-01-31",
+        split_billing_enabled=False,
+    )
+    usage_result = _make_usage_result({
+        "MPA-001": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "1000")],
+        "ACC-A": [_make_metric(AWSRecordTypeEnum.SAVING_PLAN_COVERED_USAGE, "500")],
+    })
+    processor = SavingPlansDistributionProcessor()
+
+    result = processor.process({}, usage_result, journal_details_no_split, organization_invoice)
+
+    assert result == []
 
 
 def test_skips_account_when_distributed_amount_rounds_to_zero(
@@ -171,7 +190,7 @@ def test_skips_account_when_distributed_amount_rounds_to_zero(
     })
     processor = SavingPlansDistributionProcessor()
 
-    result = processor.process(usage_result, journal_details, organization_invoice)
+    result = processor.process({}, usage_result, journal_details, organization_invoice)
 
     account_ids = [line.search.source.criteria_value for line in result]
     assert "ACC-A" in account_ids

--- a/tests/billing/generators/test_agreement.py
+++ b/tests/billing/generators/test_agreement.py
@@ -3,9 +3,6 @@ import datetime as dt
 import pytest
 
 from swo_aws_extension.aws.client import AWSClient
-from swo_aws_extension.billing.generators.additional_line_processors.extra_discounts import (
-    ExtraDiscountsManager,
-)
 from swo_aws_extension.billing.generators.additional_line_processors.pls_charge import (
     PlSChargeProcessor,
 )
@@ -78,12 +75,22 @@ def mock_line_generator_cls(mocker):
 
 @pytest.fixture
 def mock_extra_discounts_manager_cls(mocker):
-    return mocker.patch(f"{MODULE}.ExtraDiscountsManager", autospec=True)
+    service_mock = mocker.patch(f"{MODULE}.ServiceDiscountProcessor", autospec=True)
+    service_mock.return_value.process.return_value = []
+    mocker.patch(
+        f"{MODULE}.SupportDiscountProcessor", autospec=True
+    ).return_value.process.return_value = []
+    mocker.patch(
+        f"{MODULE}.PlSDiscountProcessor", autospec=True
+    ).return_value.process.return_value = []
+    return service_mock
 
 
 @pytest.fixture
 def mock_pls_charge_manager_cls(mocker):
-    return mocker.patch(f"{MODULE}.PlSChargeProcessor", autospec=True)
+    cls_mock = mocker.patch(f"{MODULE}.PlSChargeProcessor", autospec=True)
+    cls_mock.return_value.process.return_value = []
+    return cls_mock
 
 
 def _build_agreement(support_type="ResoldSupport"):
@@ -128,9 +135,7 @@ def test_run(
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
     mock_line_generator_cls.return_value = mock_generator_instance
-    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
-    mock_discounts_instance.process.return_value = [mock_discount_line]
-    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
+    mock_extra_discounts_manager_cls.return_value.process.return_value = [mock_discount_line]
     mock_pls_instance = mocker.MagicMock(spec=PlSChargeProcessor)
     mock_pls_instance.process.return_value = [mock_pls_line]
     mock_pls_charge_manager_cls.return_value = mock_pls_instance
@@ -157,7 +162,6 @@ def test_run(
     assert result.lines == [mock_journal_line, mock_discount_line, mock_pls_line]
     mock_invoice_generator.run.assert_called_once()
     mock_generator_instance.generate.assert_called_once()
-    mock_discounts_instance.process.assert_called_once()
     mock_pls_instance.process.assert_called_once()
     call_args = mock_generator_instance.generate.call_args
     assert call_args[0][0] == "ACC-1"
@@ -183,9 +187,6 @@ def test_run_without_pls(
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
     mock_line_generator_cls.return_value = mock_generator_instance
-    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
-    mock_discounts_instance.process.return_value = []
-    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
     mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()
@@ -206,7 +207,6 @@ def test_run_without_pls(
     result = generator.run(agreement)
 
     assert result.lines == [mock_journal_line]
-    mock_pls_charge_manager_cls.assert_not_called()
 
 
 def test_run_returns_empty_when_no_mpa_account(
@@ -343,9 +343,6 @@ def test_run_processes_when_transfer_started_on_billing_start(
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = []
     mock_line_generator_cls.return_value = mock_generator_instance
-    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
-    mock_discounts_instance.process.return_value = []
-    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
     mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()
@@ -388,9 +385,6 @@ def test_pls_mismatch_param_pls_but_no_enterprise_in_report(
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = []
     mock_line_generator_cls.return_value = mock_generator_instance
-    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
-    mock_discounts_instance.process.return_value = []
-    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
     mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()
@@ -413,7 +407,6 @@ def test_pls_mismatch_param_pls_but_no_enterprise_in_report(
     assert len(result.pls_mismatches) == 1
     assert result.pls_mismatches[0].pls_in_order is True
     assert result.pls_mismatches[0].report_has_enterprise is False
-    mock_pls_charge_manager_cls.assert_not_called()
 
 
 def test_pls_mismatch_param_resold_but_enterprise_in_report(
@@ -436,9 +429,6 @@ def test_pls_mismatch_param_resold_but_enterprise_in_report(
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
     mock_line_generator_cls.return_value = mock_generator_instance
-    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
-    mock_discounts_instance.process.return_value = []
-    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
     mock_pls_instance = mocker.MagicMock(spec=PlSChargeProcessor)
     mock_pls_instance.process.return_value = [mock_pls_line]
     mock_pls_charge_manager_cls.return_value = mock_pls_instance
@@ -501,9 +491,6 @@ def test_run_with_split_billing_enabled(
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = []
     mock_line_generator_cls.return_value = mock_generator_instance
-    mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
-    mock_discounts_instance.process.return_value = []
-    mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
     mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()


### PR DESCRIPTION
## Summary

- Introduce `AdditionalLineProcessor` ABC (`base.py`) with a unified `process(agreement, usage_result, journal_details, organization_invoice)` signature and shared `_build_org_journal_line` / `_calculate_percentage_amount` helpers
- Remove `ExtraDiscountsManager` wrapper — `ServiceDiscountProcessor`, `SupportDiscountProcessor`, and `PlSDiscountProcessor` are registered directly in the processors list
- `PlSChargeProcessor` now self-guards on `usage_result.has_enterprise_support()`; `charge_percentage` moved to constructor
- `SavingPlansDistributionProcessor` now self-guards on `journal_details.split_billing_enabled`
- `AgreementJournalGenerator.__init__` builds `_additional_processors` once; `_generate_lines_for_accounts` iterates them uniformly — no more conditional dispatch

## Test plan

- [ ] `make check-all` passes (1071 tests, all hooks green)
- [ ] New tests: `test_returns_empty_when_no_enterprise_support` (pls_charge), `test_returns_empty_when_split_billing_disabled` (saving_plans)
- [ ] Existing tests for mismatch, split billing, and PLS charge paths updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- **Introduced `AdditionalLineProcessor` abstract base class** to standardize processing of additional journal lines generated during agreement processing, with shared helper methods for percentage calculation and organization-level journal line construction.

- **Removed `ExtraDiscountsManager` wrapper**: `ServiceDiscountProcessor`, `SupportDiscountProcessor`, and `PlSDiscountProcessor` are now registered directly in the processors list for unified iteration and processing.

- **Refactored `BaseExtraDiscountProcessor`** to inherit from `AdditionalLineProcessor` and implement the unified `process()` signature, consolidating control flow and journal-line construction logic.

- **Updated `PlSChargeProcessor`** to inherit from `AdditionalLineProcessor`, move `charge_percentage` parameter to the constructor, and self-guard on `usage_result.has_enterprise_support()`.

- **Updated `SavingPlansDistributionProcessor`** to inherit from `AdditionalLineProcessor` and self-guard on `journal_details.split_billing_enabled`.

- **Simplified `AgreementJournalGenerator`** to build the processors list once during initialization and iterate through them uniformly in `_generate_lines_for_accounts`, eliminating conditional dispatch logic.

- **Enhanced test coverage** with new edge case tests for missing enterprise support (PLS charge) and disabled split billing (Saving Plans), along with updated tests for all refactored processors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->