### PR TITLE
[BACKPORT] MPT-21440 AWS split billing - Create serviceDiscountType agreement parameter

### DIFF
--- a/migrations/20260622000000_service_discount_type.py
+++ b/migrations/20260622000000_service_discount_type.py
@@ -1,0 +1,155 @@
+import logging
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from mpt_api_client.rql.query_builder import RQLQuery
+from mpt_tool.migration import SchemaBaseMigration
+from mpt_tool.migration.mixins import MPTAPIClientMixin
+
+logger = logging.getLogger(__name__)
+
+_SERVICE_DISCOUNT_TYPE_EXTERNAL_ID = "serviceDiscountType"
+_SERVICE_DISCOUNT_TYPE_SPP = "SPP_DISCOUNT"
+_SERVICE_DISCOUNT_TYPE_USAGE = "USAGE_AMOUNT"
+
+_service_discount_type_parameter = {
+    "name": "Service Discount Type",
+    "scope": "Agreement",
+    "phase": "Fulfillment",
+    "context": "None",
+    "description": "Service Discount Type",
+    "multiple": False,
+    "externalId": _SERVICE_DISCOUNT_TYPE_EXTERNAL_ID,
+    "constraints": {"hidden": True, "required": False},
+    "options": {
+        "placeholderText": "Service Discount Type",
+        "hintText": "Service Discount Type",
+        "defaultValue": _SERVICE_DISCOUNT_TYPE_SPP,
+        "optionsList": [
+            {
+                "label": "Percentage from disti discount to customer",
+                "value": _SERVICE_DISCOUNT_TYPE_SPP,
+            },
+            {
+                "label": "Percentage of usage to customer",
+                "value": _SERVICE_DISCOUNT_TYPE_USAGE,
+            },
+        ],
+    },
+    "type": "DropDown",
+    "status": "Active",
+    "displayOrder": 110,
+}
+
+
+class Migration(SchemaBaseMigration, MPTAPIClientMixin):
+    """Migration to add serviceDiscountType agreement parameter."""
+
+    def run(self) -> None:
+        """Run the migration."""
+        raw_ids = os.environ["MPT_PRODUCTS_IDS"].replace(" ", "").split(",")
+        product_ids = list(filter(None, raw_ids))
+        logger.info(
+            "Starting migration 20260622000000_service_discount_type for %s product(s)",
+            len(product_ids),
+        )
+
+        if not product_ids:
+            logger.info("No product IDs found in MPT_PRODUCTS_IDS; nothing to migrate")
+
+        for product_id in product_ids:
+            self._migrate_product(product_id)
+
+        logger.info("Migration 20260622000000_service_discount_type finished")
+
+    def _migrate_product(self, product_id: str) -> None:
+        logger.info("Migrating product '%s'", product_id)
+
+        existing = self._get_product_parameter(product_id, _SERVICE_DISCOUNT_TYPE_EXTERNAL_ID)
+        self._ensure_parameter(product_id, existing, _service_discount_type_parameter)
+        self._migrate_agreements(product_id)
+
+    def _migrate_agreements(self, product_id: str) -> None:
+        logger.info("Migrating agreements for product '%s'", product_id)
+        query = RQLQuery(product__id=product_id) & RQLQuery(status="Active")
+        agreements = list(
+            self.mpt_client.commerce.agreements.filter(query).select("+parameters").iterate()
+        )
+        logger.info(
+            "Found %s active agreement(s) for product '%s'",
+            len(agreements),
+            product_id,
+        )
+        for agreement in agreements:
+            self._ensure_agreement_service_discount_type(agreement.to_dict())
+
+    def _ensure_agreement_service_discount_type(self, agreement: dict[str, Any]) -> None:
+        agreement_id = agreement["id"]
+        fulfillment_params = agreement.get("parameters", {}).get("fulfillment", [])
+        already_present = any(
+            parameter.get("externalId") == _SERVICE_DISCOUNT_TYPE_EXTERNAL_ID
+            for parameter in fulfillment_params
+        )
+        if already_present:
+            logger.info(
+                "Parameter 'serviceDiscountType' already exists for agreement '%s'; skipping",
+                agreement_id,
+            )
+            return
+        logger.info("Adding parameter 'serviceDiscountType' to agreement '%s'", agreement_id)
+        self.mpt_client.commerce.agreements.update(
+            agreement_id,
+            {
+                "parameters": {
+                    "fulfillment": [
+                        {
+                            "externalId": _SERVICE_DISCOUNT_TYPE_EXTERNAL_ID,
+                            "value": _SERVICE_DISCOUNT_TYPE_SPP,
+                        }
+                    ]
+                }
+            },
+        )
+
+    def _ensure_parameter(
+        self,
+        product_id: str,
+        existing_parameter: Any | None,
+        parameter_data: Mapping[str, Any],
+    ) -> None:
+        external_id = parameter_data["externalId"]
+        if existing_parameter:
+            logger.info(
+                "Parameter '%s' already exists for product '%s'; skipping",
+                external_id,
+                product_id,
+            )
+            return
+
+        logger.info("Creating parameter '%s' for product '%s'", external_id, product_id)
+        self._create_product_parameter(product_id, parameter_data)
+
+    def _get_product_parameter(self, product_id: str, external_id: str) -> Any | None:
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        parameter_query = RQLQuery(externalId=external_id)
+        status_query = RQLQuery(status="Active")
+        product_parameters = list(
+            product_parameters_service
+            .filter(parameter_query)
+            .filter(status_query)
+            .select()
+            .iterate()
+        )
+        if product_parameters:
+            return product_parameters[0]
+        return None
+
+    def _create_product_parameter(self, product_id: str, parameter_data: Mapping[str, Any]) -> None:
+        logger.info(
+            "Creating product parameter '%s' for product '%s'",
+            parameter_data.get("externalId"),
+            product_id,
+        )
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        product_parameters_service.create(parameter_data)

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -129,6 +129,7 @@ class FulfillmentParametersEnum(StrEnum):
     FEATURE_VERSION_DEPLOYMENT_ERROR_NOTIFIED = "featureVersionDeploymentErrorNotified"
     CCO_CONTRACT_NUMBER = "ccoContractNumber"
     ERP_PROJECT_NO = "erpProjectNo"
+    SERVICE_DISCOUNT_TYPE = "serviceDiscountType"
 
 
 class OrderProcessingTemplateEnum(StrEnum):
@@ -278,3 +279,10 @@ DEFAULT_SCU = "DM-SCU-000000"
 
 
 ROLES_DEPLOYED_CRM_TICKET_COMMENT = "Customer roles have been deployed. Please resolve this ticket."
+
+
+class ServiceDiscountTypeEnum(StrEnum):
+    """Enum for service discount calculation types."""
+
+    SPP_DISCOUNT = "SPP_DISCOUNT"
+    USAGE_AMOUNT = "USAGE_AMOUNT"

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/discount/extra_discounts.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/discount/extra_discounts.py
@@ -6,6 +6,7 @@ from swo_aws_extension.constants import (
     DEC_ZERO,
     AWSRecordTypeEnum,
     ChannelHandshakeDeployed,
+    ServiceDiscountTypeEnum,
     SupportTypesEnum,
 )
 from swo_aws_extension.flows.jobs.billing_journal.generators.currency import (
@@ -28,6 +29,7 @@ from swo_aws_extension.parameters import (
     get_channel_handshake_approval_status,
     get_pls_discount,
     get_service_discount,
+    get_service_discount_type,
     get_support_discount,
     get_support_type,
 )
@@ -67,7 +69,7 @@ class BaseExtraDiscountProcessor(ABC):
         if not discount_percentage or discount_percentage <= DEC_ZERO:
             return []
 
-        base_amount = self._calculate_base_amount(usage_result, organization_invoice)
+        base_amount = self._calculate_base_amount(usage_result, organization_invoice, agreement)
         if base_amount == DEC_ZERO:
             return []
 
@@ -76,7 +78,7 @@ class BaseExtraDiscountProcessor(ABC):
         invoice_details = InvoiceDetails(
             item_sku=ITEM_SKU,
             service_name=self._service_name,
-            amount=refund_amount,
+            amount=-abs(refund_amount),
             account_id=journal_details.mpa_id,
             invoice_entity=organization_invoice.primary_entity_name,
             invoice_id=organization_invoice.primary_invoice_id,
@@ -98,6 +100,7 @@ class BaseExtraDiscountProcessor(ABC):
         self,
         usage_result: OrganizationUsageResult,
         organization_invoice: OrganizationInvoice,
+        agreement: dict,
     ) -> Decimal:
         """Calculate the sum of metrics over which the discount is applied."""
 
@@ -123,6 +126,17 @@ class ServiceDiscountProcessor(BaseExtraDiscountProcessor):
 
     @override
     def _calculate_base_amount(
+        self,
+        usage_result: OrganizationUsageResult,
+        organization_invoice: OrganizationInvoice,
+        agreement: dict,
+    ) -> Decimal:
+        discount_type = get_service_discount_type(agreement)
+        if discount_type == ServiceDiscountTypeEnum.USAGE_AMOUNT:
+            return self._calculate_base_amount_by_usage(usage_result, organization_invoice)
+        return self._calculate_base_amount_by_spp(usage_result, organization_invoice)
+
+    def _calculate_base_amount_by_spp(
         self,
         usage_result: OrganizationUsageResult,
         organization_invoice: OrganizationInvoice,
@@ -156,6 +170,21 @@ class ServiceDiscountProcessor(BaseExtraDiscountProcessor):
             )
         return total
 
+    def _calculate_base_amount_by_usage(
+        self,
+        usage_result: OrganizationUsageResult,
+        organization_invoice: OrganizationInvoice,
+    ) -> Decimal:
+        return calculate_total_by_record_types(
+            usage_result,
+            organization_invoice,
+            {
+                AWSRecordTypeEnum.USAGE,
+                AWSRecordTypeEnum.RECURRING,
+                AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE,
+            },
+        )
+
 
 class SupportDiscountProcessor(BaseExtraDiscountProcessor):
     """Processor for Support Extra Discount."""
@@ -179,6 +208,7 @@ class SupportDiscountProcessor(BaseExtraDiscountProcessor):
         self,
         usage_result: OrganizationUsageResult,
         organization_invoice: OrganizationInvoice,
+        agreement: dict,
     ) -> Decimal:
         total = DEC_ZERO
         for account_usage in usage_result.usage_by_account.values():
@@ -226,6 +256,7 @@ class PlSDiscountProcessor(BaseExtraDiscountProcessor):
         self,
         usage_result: OrganizationUsageResult,
         organization_invoice: OrganizationInvoice,
+        agreement: dict,
     ) -> Decimal:
         return calculate_total_by_record_types(
             usage_result,

--- a/swo_aws_extension/parameters.py
+++ b/swo_aws_extension/parameters.py
@@ -580,3 +580,12 @@ def set_erp_project_no(order: dict, erp_project_no: str) -> dict[str, Any]:
     )
     fulfillment_param["value"] = erp_project_no
     return updated_order
+
+
+def get_service_discount_type(source: dict[str, Any]) -> str | None:
+    """Get the service discount type from the fulfillment parameter or None if it is not set."""
+    fulfillment_param = get_fulfillment_parameter(
+        FulfillmentParametersEnum.SERVICE_DISCOUNT_TYPE.value,
+        source,
+    )
+    return fulfillment_param.get("value", None)

--- a/tests/flows/jobs/billing_journal/generators/discount_processors/test_extra_discounts.py
+++ b/tests/flows/jobs/billing_journal/generators/discount_processors/test_extra_discounts.py
@@ -5,6 +5,7 @@ import pytest
 from swo_aws_extension.constants import (
     AWSRecordTypeEnum,
     ChannelHandshakeDeployed,
+    ServiceDiscountTypeEnum,
     SupportTypesEnum,
 )
 from swo_aws_extension.flows.jobs.billing_journal.generators.discount.extra_discounts import (
@@ -295,6 +296,55 @@ def test_resolve_service_amount_with_exchange_rate_rules(
     assert result[0].price.unit_pp == expected_amount
 
 
+def test_service_discount_processor_usage_amount_type(
+    agreement,
+    journal_details,
+    organization_invoice,
+):
+    agreement["parameters"]["fulfillment"].extend([
+        {"externalId": "serviceDiscount", "value": "10.0"},
+        {"externalId": "serviceDiscountType", "value": ServiceDiscountTypeEnum.USAGE_AMOUNT},
+    ])
+    usage_result = build_usage_result({
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
+            create_metric("RDS", AWSRecordTypeEnum.RECURRING, "50.00"),
+            create_metric("SP", AWSRecordTypeEnum.SAVING_PLAN_RECURRING_FEE, "20.00"),
+            create_metric("EC2", AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT, "-10.00"),
+        ]
+    })
+    processor = ServiceDiscountProcessor()
+
+    result = processor.process(agreement, usage_result, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    assert result[0].price.unit_pp == Decimal("-17.000000")
+    assert result[0].description.value1 == "SWO additional Usage discount"
+
+
+def test_service_discount_processor_spp_type_explicit(
+    agreement,
+    journal_details,
+    organization_invoice,
+):
+    agreement["parameters"]["fulfillment"].extend([
+        {"externalId": "serviceDiscount", "value": "5.0"},
+        {"externalId": "serviceDiscountType", "value": ServiceDiscountTypeEnum.SPP_DISCOUNT},
+    ])
+    usage_result = build_usage_result({
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
+            create_metric("EC2", AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT, "-10.00"),
+        ]
+    })
+    processor = ServiceDiscountProcessor()
+
+    result = processor.process(agreement, usage_result, journal_details, organization_invoice)
+
+    assert len(result) == 1
+    assert result[0].price.unit_pp == Decimal("-0.5")
+
+
 def test_pls_discount_processor(
     agreement,
     usage_result,
@@ -316,7 +366,7 @@ def test_pls_discount_processor(
     result = processor.process(agreement, usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
-    assert result[0].price.unit_pp == Decimal("30.000000")
+    assert result[0].price.unit_pp == Decimal("-30.000000")
     assert result[0].description.value1 == "SWO additional PLS Support discount"
     assert result[0].external_ids.vendor == "MPA-1"
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Backport of #380 to `release/5`.

## Conflicts resolved

The billing package was moved from `swo_aws_extension/flows/jobs/billing_journal/generators/discount/` to `swo_aws_extension/billing/generators/additional_line_processors/` in main (MPT-21796 refactor, not present in release/5). Changes were applied to the release/5 paths:

- `swo_aws_extension/flows/jobs/billing_journal/generators/discount/extra_discounts.py`
- `tests/flows/jobs/billing_journal/generators/discount_processors/test_extra_discounts.py`

Functions and parameters not yet backported to release/5 (`TERMINATION_DATE`, `SPLIT_BILLING_POLICY`, `get_termination_date`, `set_termination_date`, `get_split_billing_policy`, `SplitBillingPolicyEnum`, `ItemSkuEnum`) were excluded from this backport.

## What

Adds the `serviceDiscountType` fulfillment agreement parameter and wires it into `ServiceDiscountProcessor` so the discount base amount can be calculated in two modes.

## Changes

**New parameter and migration**

- `FulfillmentParametersEnum.SERVICE_DISCOUNT_TYPE` and `ServiceDiscountTypeEnum` (`SPP_DISCOUNT` | `USAGE_AMOUNT`) added to `constants.py`.
- `get_service_discount_type()` accessor added to `parameters.py`.
- `migrations/20260622000000_service_discount_type.py`: creates the `serviceDiscountType` DropDown parameter on each product and backfills all active agreements with the default value `SPP_DISCOUNT`.

**Billing processor**

- `ServiceDiscountProcessor._calculate_base_amount` now branches on `serviceDiscountType`:
  - `USAGE_AMOUNT` — sums `USAGE`, `RECURRING`, and `SAVING_PLAN_RECURRING_FEE` record types.
  - `SPP_DISCOUNT` (default) — retains the previous SPP-based calculation.
- `BaseExtraDiscountProcessor.process` now passes `agreement` down to `_calculate_base_amount` and negates `refund_amount` so discount lines are emitted with the correct sign.

**Tests**

- New tests for `USAGE_AMOUNT` and explicit `SPP_DISCOUNT` paths in `ServiceDiscountProcessor`.
- Updated `test_pls_discount_processor` assertion to reflect the corrected negative sign.
