### PR TITLE
MPT-22660 Pin mpt-extension-sdk to 5.x and cap requests in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,16 @@ updates:
         versions: ["*"]
       - dependency-name: "opentelemetry-instrumentation-botocore"
         versions: ["*"]
+      # This repo must stay on mpt-extension-sdk 5.x: the 6.x line pulls
+      # opentelemetry-instrumentation 0.61b0 (via -fastapi), incompatible with
+      # opentelemetry-instrumentation-botocore 0.60b0, so a 6.x bump is
+      # unresolvable and must never be selected.
+      - dependency-name: "mpt-extension-sdk"
+        versions: [">=6"]
+      # mpt-extension-sdk 5.21.* pins requests==2.32.*, so a newer requests is
+      # unresolvable until the sdk lifts that cap.
+      - dependency-name: "requests"
+        versions: [">=2.33"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add two Dependabot ignore rules in `.github/dependabot.yml` (uv ecosystem):
- `mpt-extension-sdk` `>=6`
- `requests` `>=2.33`

No `pyproject.toml` pin or `uv.lock` change — the current pins already resolve.

## Why

The weekly Dependabot `uv` updater run failed with `dependency_file_not_resolvable` (uv: *No solution found*) — see [failing run](https://github.com/softwareone-platform/swo-aws-extension/actions/runs/27938491507).

- Dependabot tried to bump `mpt-extension-sdk` 5.21.* → 6.3.3. The 6.x line pulls `opentelemetry-instrumentation==0.61b0` (via `-fastapi`), which is **incompatible with `opentelemetry-instrumentation-botocore==0.60b0`**. This repo must stay on `mpt-extension-sdk` 5.x; 6.x must never be selected.
- `mpt-tool` 6.0.* is **correct and compatible** with sdk 5.x (it pairs with `mpt-api-client` 5.4.*), and 6.0.0 is the latest, so it is intentionally left uncapped.
- Separately, Dependabot tried `requests` 2.32.* → 2.34.2, but `mpt-extension-sdk` 5.21.* pins `requests==2.32.*`.

## Testing

- `dependabot.yml` validated (parses; ignore list = django, opentelemetry-instrumentation-botocore, mpt-extension-sdk, requests).
- Config-only change; no dependency resolution or code is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `.github/dependabot.yml` to ignore incompatible `uv` dependency upgrades.
- Added an ignore rule for `mpt-extension-sdk` versions `>=6`.
- Added an ignore rule for `requests` versions `>=2.33` to preserve compatibility with `mpt-extension-sdk` 5.21.*.
- Documented the dependency conflict that was causing Dependabot’s `dependency_file_not_resolvable` failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->