### PR TITLE
MPT-22809 Update navision country mapping for MX to SWO_MXO

### DIFF
--- a/seller_external_id_map.json
+++ b/seller_external_id_map.json
@@ -63,7 +63,7 @@
   "LATAM": "SWO_LATAM",
   "MY": "SWO_MY",
   "MU": "SWO_MU",
-  "MX": "SWO_MX",
+  "MX": "SWO_MXO",
   "MXO": "SWO_MXO",
   "QA": "SWO_QA",
   "MXS": "SWO_MXS",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22809](https://softwareone.atlassian.net/browse/MPT-22809)

- Updated the Navision country mapping for `MX` to point to `SWO_MXO` instead of `SWO_MX`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22809]: https://softwareone.atlassian.net/browse/MPT-22809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ