### PR TITLE
[BACKPORT] MPT-22809 Update navision country mapping for MX to SWO_MXO

### DIFF
--- a/seller_external_id_map.json
+++ b/seller_external_id_map.json
@@ -63,7 +63,7 @@
   "LATAM": "SWO_LATAM",
   "MY": "SWO_MY",
   "MU": "SWO_MU",
-  "MX": "SWO_MX",
+  "MX": "SWO_MXO",
   "MXO": "SWO_MXO",
   "QA": "SWO_QA",
   "MXS": "SWO_MXS",


### PR DESCRIPTION
(cherry picked from commit 8c699c7941c217ebcf1b35c42caf91013e9461f4)

- Updated the Navision country mapping for MX to point to SWO_MXO instead of SWO_MX.