### PR TITLE
MPT-23198 fix SPP recovery line not matched by period

### DIFF
--- a/swo_aws_extension/billing/generators/line_processors/credit.py
+++ b/swo_aws_extension/billing/generators/line_processors/credit.py
@@ -52,8 +52,7 @@ class CreditJournalLineProcessor(JournalLineProcessor):
 
         if self._should_add_spp_line(context):
             spp_metric = self._find_spp_for_service(
-                context.account_usage,
-                metric.service_name,
+                context.account_usage, metric.service_name, metric.start_date, metric.end_date
             )
             if spp_metric:
                 lines.extend(self._spp_processor.process(spp_metric, context))
@@ -69,13 +68,13 @@ class CreditJournalLineProcessor(JournalLineProcessor):
         return principal_amount == DEC_ZERO
 
     def _find_spp_for_service(
-        self,
-        account_usage: AccountUsage,
-        service_name: str,
+        self, account_usage: AccountUsage, service_name: str, start_date: str, end_date: str
     ) -> ServiceMetric | None:
         spp_metrics = [
             metric
             for metric in account_usage.get_metrics_by_service(service_name)
             if metric.record_type == AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT
+            and metric.start_date == start_date
+            and metric.end_date == end_date
         ]
         return spp_metrics[0] if spp_metrics else None

--- a/tests/billing/generators/line_processors/test_credit.py
+++ b/tests/billing/generators/line_processors/test_credit.py
@@ -130,6 +130,82 @@ def test_process_adds_spp_when_principal_zero(
     assert result[1].price.pp_x1 == Decimal("-5.00")
 
 
+def test_process_matches_spp_by_period_not_first_in_list(
+    processor,
+    journal_details,
+):
+    credit_jan02 = ServiceMetric(
+        service_name="Amazon CloudWatch",
+        record_type=AWSRecordTypeEnum.CREDIT,
+        amount=Decimal("-2.00"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-02",
+        end_date="2026-01-02",
+    )
+    spp_jan01 = ServiceMetric(
+        service_name="Amazon CloudWatch",
+        record_type=AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT,
+        amount=Decimal("-0.11"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-01",
+        end_date="2026-01-01",
+    )
+    spp_jan02 = ServiceMetric(
+        service_name="Amazon CloudWatch",
+        record_type=AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT,
+        amount=Decimal("-0.22"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-02",
+        end_date="2026-01-02",
+    )
+    context = LineProcessorContext(
+        account_id="ACC-001",
+        account_usage=AccountUsage(metrics=[credit_jan02, spp_jan01, spp_jan02]),
+        journal_details=journal_details,
+        organization_invoice=OrganizationInvoice(principal_invoice_amount=Decimal(0)),
+    )
+
+    result = processor.process(credit_jan02, context)
+
+    assert len(result) == 2
+    assert result[1].price.pp_x1 == Decimal("-0.22"), (
+        "SPP line must use the Jan-02 SPP metric, not the first (Jan-01) one"
+    )
+
+
+def test_process_skips_spp_when_no_matching_period(
+    processor,
+    journal_details,
+):
+    credit_jan02 = ServiceMetric(
+        service_name="AWS Data Transfer",
+        record_type=AWSRecordTypeEnum.CREDIT,
+        amount=Decimal("-1.00"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-02",
+        end_date="2026-01-02",
+    )
+    spp_jan01 = ServiceMetric(
+        service_name="AWS Data Transfer",
+        record_type=AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT,
+        amount=Decimal("-0.10"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-01",
+        end_date="2026-01-01",
+    )
+    context = LineProcessorContext(
+        account_id="ACC-001",
+        account_usage=AccountUsage(metrics=[credit_jan02, spp_jan01]),
+        journal_details=journal_details,
+        organization_invoice=OrganizationInvoice(principal_invoice_amount=Decimal(0)),
+    )
+
+    result = processor.process(credit_jan02, context)
+
+    assert len(result) == 1
+    assert result[0].description.value1 == f"{CREDIT_PREFIX}AWS Data Transfer"
+
+
 def test_spp_recovery_processor_uses_usage_sku_for_spp_metric(journal_details, spp_metric):
     context = LineProcessorContext(
         account_id="ACC-001",


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

`CreditJournalLineProcessor._find_spp_for_service` matched a Solution Provider Program (SPP) discount metric by service name only and returned the first match. When multiple SPP metrics existed for the same service across different billing periods, the credit line processor could attach an SPP recovery line from the wrong period, breaking zero-amount credit invoices.

`_find_spp_for_service` now also matches on `start_date`/`end_date`, so the SPP recovery line always corresponds to the same billing period as the credit it is attached to.

## Testing

- Added `test_process_matches_spp_by_period_not_first_in_list`: verifies the SPP line uses the metric for the matching period instead of the first SPP metric found for the service.
- Added `test_process_skips_spp_when_no_matching_period`: verifies no SPP line is attached when there is no SPP metric for the same period.
- `make check-all`: 1086 passed, 1 xpassed, 100% coverage on changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updates SPP metric selection to match both service name and billing period.
- Prevents recovery lines from using metrics from incorrect periods.
- Adds tests for matching and missing SPP billing periods.
- Validation: 1086 tests passed, 1 xpassed, with 100% coverage on changed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->