### PR TITLE
[HF] MPT-23198 fix SPP recovery line not matched by period

### DIFF
--- a/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/credit.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/line_processors/credit.py
@@ -42,8 +42,7 @@ class CreditJournalLineProcessor(JournalLineProcessor):
 
         if self._should_add_spp_line(context):
             spp_metric = self._find_spp_for_service(
-                context.account_usage,
-                metric.service_name,
+                context.account_usage, metric.service_name, metric.start_date, metric.end_date
             )
             if spp_metric:
                 lines.extend(self._spp_processor.process(spp_metric, context))
@@ -55,13 +54,13 @@ class CreditJournalLineProcessor(JournalLineProcessor):
         return principal_amount == DEC_ZERO
 
     def _find_spp_for_service(
-        self,
-        account_usage: AccountUsage,
-        service_name: str,
+        self, account_usage: AccountUsage, service_name: str, start_date: str, end_date: str
     ) -> ServiceMetric | None:
         spp_metrics = [
             metric
             for metric in account_usage.get_metrics_by_service(service_name)
             if metric.record_type == AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT
+            and metric.start_date == start_date
+            and metric.end_date == end_date
         ]
         return spp_metrics[0] if spp_metrics else None

--- a/tests/flows/jobs/billing_journal/generators/line_processors/test_credit.py
+++ b/tests/flows/jobs/billing_journal/generators/line_processors/test_credit.py
@@ -121,3 +121,79 @@ def test_process_adds_spp_when_principal_zero(
     assert result[0].description.value1 == f"{CREDIT_PREFIX}Amazon S3"
     assert result[1].description.value1 == f"{SPP_PREFIX}Amazon S3{SPP_SUFFIX}"
     assert result[1].price.pp_x1 == Decimal("-5.00")
+
+
+def test_process_matches_spp_by_period_not_first_in_list(
+    processor,
+    journal_details,
+):
+    credit_jan02 = ServiceMetric(
+        service_name="Amazon CloudWatch",
+        record_type=AWSRecordTypeEnum.CREDIT,
+        amount=Decimal("-2.00"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-02",
+        end_date="2026-01-02",
+    )
+    spp_jan01 = ServiceMetric(
+        service_name="Amazon CloudWatch",
+        record_type=AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT,
+        amount=Decimal("-0.11"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-01",
+        end_date="2026-01-01",
+    )
+    spp_jan02 = ServiceMetric(
+        service_name="Amazon CloudWatch",
+        record_type=AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT,
+        amount=Decimal("-0.22"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-02",
+        end_date="2026-01-02",
+    )
+    context = LineProcessorContext(
+        account_id="ACC-001",
+        account_usage=AccountUsage(metrics=[credit_jan02, spp_jan01, spp_jan02]),
+        journal_details=journal_details,
+        organization_invoice=OrganizationInvoice(principal_invoice_amount=Decimal(0)),
+    )
+
+    result = processor.process(credit_jan02, context)
+
+    assert len(result) == 2
+    assert result[1].price.pp_x1 == Decimal("-0.22"), (
+        "SPP line must use the Jan-02 SPP metric, not the first (Jan-01) one"
+    )
+
+
+def test_process_skips_spp_when_no_matching_period(
+    processor,
+    journal_details,
+):
+    credit_jan02 = ServiceMetric(
+        service_name="AWS Data Transfer",
+        record_type=AWSRecordTypeEnum.CREDIT,
+        amount=Decimal("-1.00"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-02",
+        end_date="2026-01-02",
+    )
+    spp_jan01 = ServiceMetric(
+        service_name="AWS Data Transfer",
+        record_type=AWSRecordTypeEnum.SOLUTION_PROVIDER_PROGRAM_DISCOUNT,
+        amount=Decimal("-0.10"),
+        invoice_entity="AWS Inc.",
+        start_date="2026-01-01",
+        end_date="2026-01-01",
+    )
+    context = LineProcessorContext(
+        account_id="ACC-001",
+        account_usage=AccountUsage(metrics=[credit_jan02, spp_jan01]),
+        journal_details=journal_details,
+        organization_invoice=OrganizationInvoice(principal_invoice_amount=Decimal(0)),
+    )
+
+    result = processor.process(credit_jan02, context)
+
+    assert len(result) == 1
+    assert result[0].description.value1 == f"{CREDIT_PREFIX}AWS Data Transfer"


### PR DESCRIPTION
## What was done

Hotfix backport of #400 to `release/5`.

`CreditJournalLineProcessor._find_spp_for_service` matched a Solution Provider Program (SPP) discount metric by service name only and returned the first match. When multiple SPP metrics existed for the same service across different billing periods, the credit line processor could attach an SPP recovery line from the wrong period, breaking zero-amount credit invoices.

`_find_spp_for_service` now also matches on `start_date`/`end_date`, so the SPP recovery line always corresponds to the same billing period as the credit it is attached to.

Cherry-picked commit: 61e8a247437c28b706d21fdcad35f5bf76854c83

## Testing

- Added `test_process_matches_spp_by_period_not_first_in_list`: verifies the SPP line uses the metric for the matching period instead of the first SPP metric found for the service.
- Added `test_process_skips_spp_when_no_matching_period`: verifies no SPP line is attached when there is no SPP metric for the same period.
- `make test`: 1024 passed, 1 xpassed, 99% coverage.
- Note: `make check` (ruff lint) currently fails on `release/5` with 47 pre-existing docstring-style errors in unrelated files (`config.py`, `billing_period.py`, `invoice.py`, `order.py`); confirmed these failures exist on the `release/5` tip before this cherry-pick and are unrelated to this change. The two files touched by this hotfix (`credit.py`, `test_credit.py`) pass `ruff check` cleanly on their own.