### PR TITLE
MPT-23003 fix PLES billing to honor agreement supportType parameter

### DIFF
--- a/swo_aws_extension/billing/generators/additional_line_processors/pls_charge.py
+++ b/swo_aws_extension/billing/generators/additional_line_processors/pls_charge.py
@@ -8,8 +8,9 @@ from swo_aws_extension.billing.generators.usage_utils import calculate_total_by_
 from swo_aws_extension.billing.models.invoice import OrganizationInvoice
 from swo_aws_extension.billing.models.journal_line import JournalDetails, JournalLine
 from swo_aws_extension.billing.models.usage import OrganizationUsageResult
-from swo_aws_extension.constants import DEC_ZERO, AWSRecordTypeEnum
+from swo_aws_extension.constants import DEC_ZERO, AWSRecordTypeEnum, SupportTypesEnum
 from swo_aws_extension.logger import get_logger
+from swo_aws_extension.parameters import get_support_type
 
 logger = get_logger(__name__)
 
@@ -31,7 +32,10 @@ class PlSChargeProcessor(AdditionalLineProcessor):
         journal_details: JournalDetails,
         organization_invoice: OrganizationInvoice,
     ) -> list[JournalLine]:
-        if not usage_result.has_enterprise_support():
+        if (
+            get_support_type(agreement) != SupportTypesEnum.PARTNER_LED_SUPPORT
+            or not usage_result.has_enterprise_support()
+        ):
             return []
 
         logger.info("Processing '%s' charge with %s", self._service_name, self._charge_percentage)

--- a/swo_aws_extension/billing/generators/agreement.py
+++ b/swo_aws_extension/billing/generators/agreement.py
@@ -122,17 +122,22 @@ class AgreementJournalGenerator:
         journal_details: JournalDetails,
         organization_invoice,
     ) -> AgreementJournalResult:
+        pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
+        report_has_enterprise = usage_result.has_enterprise_support()
+
         # Generate lines from AWS usage report
-        all_lines = self._generate_usage_lines(usage_result, journal_details, organization_invoice)
+        all_lines = self._generate_usage_lines(
+            is_pls=pls_in_order and report_has_enterprise,
+            usage_result=usage_result,
+            journal_details=journal_details,
+            organization_invoice=organization_invoice,
+        )
         # Generate additional lines from custom processors
         all_lines.extend(
             line
             for proc in self._additional_processors
             for line in proc.process(agreement, usage_result, journal_details, organization_invoice)
         )
-
-        pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
-        report_has_enterprise = usage_result.has_enterprise_support()
 
         pls_mismatches: list[PlsMismatch] = []
         if pls_in_order != report_has_enterprise:
@@ -160,11 +165,12 @@ class AgreementJournalGenerator:
 
     def _generate_usage_lines(
         self,
+        *,
+        is_pls: bool,
         usage_result: OrganizationUsageResult,
         journal_details: JournalDetails,
         organization_invoice,
     ) -> list[JournalLine]:
-        is_pls = usage_result.has_enterprise_support()
         line_generator = JournalLineGenerator(is_pls=is_pls)
 
         lines: list[JournalLine] = []

--- a/tests/billing/generators/additional_line_processors/test_pls_charge.py
+++ b/tests/billing/generators/additional_line_processors/test_pls_charge.py
@@ -45,6 +45,18 @@ def build_usage_result(metrics_by_account):
     )
 
 
+def build_agreement(support_type="PartnerLedSupport"):
+    return {
+        "id": "AGR-1",
+        "parameters": {
+            "ordering": [
+                {"externalId": "supportType", "value": support_type},
+            ],
+            "fulfillment": [],
+        },
+    }
+
+
 @pytest.fixture
 def organization_invoice():
     return OrganizationInvoice(
@@ -80,7 +92,7 @@ def test_process_with_custom_percentage(journal_details, organization_invoice):
     })
     manager = PlSChargeProcessor(Decimal("10.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("30.0")
@@ -97,7 +109,7 @@ def test_process_with_default_percentage(journal_details, organization_invoice):
     })
     manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("5.0")
@@ -113,7 +125,7 @@ def test_process_sums_across_multiple_accounts(journal_details, organization_inv
     })
     manager = PlSChargeProcessor(Decimal("10.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("20.0")
@@ -128,7 +140,7 @@ def test_process_returns_empty_when_zero_percentage(journal_details, organizatio
     })
     manager = PlSChargeProcessor(Decimal("0.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 0
 
@@ -139,7 +151,7 @@ def test_process_returns_empty_when_no_usage(journal_details, organization_invoi
     })
     manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 0
 
@@ -156,7 +168,7 @@ def test_process_only_sums_usage_record_type(journal_details, organization_invoi
     })
     manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("5.0")
@@ -182,7 +194,7 @@ def test_process_applies_exchange_rate(journal_details):
     })
     manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process({}, usage_result, journal_details, invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, invoice)
 
     assert len(result) == 1
     assert result[0].price.unit_pp == Decimal("4.5")
@@ -198,7 +210,7 @@ def test_process_returns_empty_when_invoice_amount_is_zero(journal_details, orga
     })
     manager = PlSChargeProcessor(Decimal("5.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
 
     assert len(result) == 0
 
@@ -209,6 +221,25 @@ def test_returns_empty_when_no_enterprise_support(journal_details, organization_
     })
     manager = PlSChargeProcessor(Decimal("10.0"))
 
-    result = manager.process({}, usage_result, journal_details, organization_invoice)
+    result = manager.process(build_agreement(), usage_result, journal_details, organization_invoice)
+
+    assert result == []
+
+
+def test_returns_empty_when_support_type_is_resold(journal_details, organization_invoice):
+    usage_result = build_usage_result({
+        "ACC-1": [
+            create_metric("EC2", AWSRecordTypeEnum.USAGE, "200.00"),
+            create_enterprise_metric(),
+        ],
+    })
+    manager = PlSChargeProcessor(Decimal("10.0"))
+
+    result = manager.process(
+        build_agreement(support_type="ResoldSupport"),
+        usage_result,
+        journal_details,
+        organization_invoice,
+    )
 
     assert result == []


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Fix Enterprise Support billing so it honors the agreement's `supportType` order parameter (`PartnerLedSupport` vs `ResoldSupport`), instead of deciding PLES billing solely from whether AWS Cost Explorer reports `AWS Support (Enterprise)` usage.

## Why

`is_pls` (used to suppress the raw Enterprise Support usage line) and `PlSChargeProcessor` (the 5% PLES charge) were both gated only on `usage_result.has_enterprise_support()`. The agreement's `supportType` parameter was already being compared against the report to log a `PlsMismatch`, but was never used to drive the actual billing decision.

As a result, any customer with AWS-reported Enterprise Support was always billed as PLES, even when their agreement was configured as `ResoldSupport` — they should instead be billed the normal resold Enterprise Support amount.

## Change

- `is_pls` now requires **both**: `supportType == PartnerLedSupport` **and** `has_enterprise_support()`.
- `PlSChargeProcessor.process()` applies the same combined condition before generating the 5% charge.
- As a side effect, this also correctly handles the case where the agreement is configured as PLES but AWS hasn't activated Enterprise Support yet (e.g. first billing month): since `has_enterprise_support()` is `False` that month, billing falls back to normal usage billing automatically, with no extra detection logic needed.

## Testing

- Updated `tests/billing/generators/additional_line_processors/test_pls_charge.py` fixtures to use a real agreement with `supportType` set, and added `test_returns_empty_when_support_type_is_resold` covering the resold + AWS-enterprise scenario from the bug report.
- `make check` (ruff format, ruff check, flake8, uv lock --check) passes repo-wide.
- Full test suite passes: 1087 passed, 1 xpassed.

Jira: MPT-23003


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23003](https://softwareone.atlassian.net/browse/MPT-23003)

- Gate PLES Enterprise Support charging on both agreement `supportType == PartnerLedSupport` and AWS Cost Explorer reporting Enterprise Support usage.
- Ensure resold-support agreements receive normal resold billing (no PLES 5% charge).
- Fall back to standard usage billing when Enterprise Support is not activated.
- Refactor billing line generation to compute and pass `is_pls` explicitly, and make it a required keyword-only parameter.
- Update/add PLES billing tests to exercise the configured `supportType` behavior, including the resold-support scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23003]: https://softwareone.atlassian.net/browse/MPT-23003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ