### PR TITLE
[HF] MPT-23003 fix PLES billing to honor agreement supportType parameter

### DIFF
--- a/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
@@ -114,7 +114,15 @@ class AgreementJournalGenerator:
         journal_details: JournalDetails,
         organization_invoice,
     ) -> AgreementJournalResult:
-        all_lines = self._generate_usage_lines(usage_result, journal_details, organization_invoice)
+        pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
+        report_has_enterprise = usage_result.has_enterprise_support()
+
+        all_lines = self._generate_usage_lines(
+            is_pls=pls_in_order and report_has_enterprise,
+            usage_result=usage_result,
+            journal_details=journal_details,
+            organization_invoice=organization_invoice,
+        )
 
         # Process extra discounts after generating all usage lines.
         all_lines.extend(
@@ -126,9 +134,6 @@ class AgreementJournalGenerator:
             )
         )
 
-        pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
-        report_has_enterprise = usage_result.has_enterprise_support()
-
         pls_mismatches: list[PlsMismatch] = []
         if pls_in_order != report_has_enterprise:
             pls_mismatches.append(
@@ -139,7 +144,7 @@ class AgreementJournalGenerator:
                 )
             )
 
-        if report_has_enterprise:
+        if pls_in_order and report_has_enterprise:
             all_lines.extend(
                 PlSChargeManager().process(
                     self._pls_charge_percentage,
@@ -165,11 +170,12 @@ class AgreementJournalGenerator:
 
     def _generate_usage_lines(
         self,
+        *,
+        is_pls: bool,
         usage_result: OrganizationUsageResult,
         journal_details: JournalDetails,
         organization_invoice,
     ) -> list[JournalLine]:
-        is_pls = usage_result.has_enterprise_support()
         line_generator = JournalLineGenerator(is_pls=is_pls)
 
         lines: list[JournalLine] = []

--- a/tests/flows/jobs/billing_journal/generators/test_agreement.py
+++ b/tests/flows/jobs/billing_journal/generators/test_agreement.py
@@ -422,23 +422,18 @@ def test_pls_mismatch_param_resold_but_enterprise_in_report(
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
 ):
-    """When param says Resold but report has Enterprise Support, record mismatch and apply PLS."""
     mock_builder = mocker.MagicMock()
     mock_builder.build.return_value = []
     mock_builder.build_by_account.return_value = []
     mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="ResoldSupport")
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
-    mock_pls_line = mocker.MagicMock(spec=JournalLine)
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
     mock_line_generator_cls.return_value = mock_generator_instance
     mock_discounts_instance = mocker.MagicMock(spec=ExtraDiscountsManager)
     mock_discounts_instance.process.return_value = []
     mock_extra_discounts_manager_cls.return_value = mock_discounts_instance
-    mock_pls_instance = mocker.MagicMock(spec=PlSChargeManager)
-    mock_pls_instance.process.return_value = [mock_pls_line]
-    mock_pls_charge_manager_cls.return_value = mock_pls_instance
     mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
     mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
     mock_usage_result.reports = OrganizationReport()
@@ -461,5 +456,6 @@ def test_pls_mismatch_param_resold_but_enterprise_in_report(
     assert len(result.pls_mismatches) == 1
     assert result.pls_mismatches[0].pls_in_order is False
     assert result.pls_mismatches[0].report_has_enterprise is True
-    mock_pls_instance.process.assert_called_once()
-    assert mock_pls_line in result.lines
+    mock_pls_charge_manager_cls.assert_not_called()
+    assert result.lines == [mock_journal_line]
+    mock_line_generator_cls.assert_called_once_with(is_pls=False)


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Backport of MPT-23003 (#402, merged to `main`) to `release/5`: fix Enterprise Support billing so it honors the agreement's `supportType` order parameter (`PartnerLedSupport` vs `ResoldSupport`), instead of deciding PLES billing solely from whether AWS Cost Explorer reports `AWS Support (Enterprise)` usage.

## Why

`is_pls` (used to suppress the raw Enterprise Support usage line) and the `PlSChargeManager` 5% charge were both gated only on `usage_result.has_enterprise_support()`. The agreement's `supportType` parameter was already being compared against the report to log a `PlsMismatch`, but was never used to drive the actual billing decision.

As a result, any customer with AWS-reported Enterprise Support was always billed as PLES, even when their agreement was configured as `ResoldSupport` — they should instead be billed the normal resold Enterprise Support amount.

## Change

`release/5` predates the MPT-21796 split-billing refactor, so the fix on `main` (which touches `pls_charge.py`/`PlSChargeProcessor`) doesn't apply directly — that file doesn't exist on this branch. The equivalent fix is applied to the pre-refactor code path instead:

- `swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py`: `is_pls` now requires **both** `supportType == PartnerLedSupport` **and** `has_enterprise_support()`; the `PlSChargeManager` 5% charge call site uses the same combined condition instead of `report_has_enterprise` alone.
- As a side effect, this also correctly handles the case where the agreement is configured as PLES but AWS hasn't activated Enterprise Support yet (e.g. first billing month): since `has_enterprise_support()` is `False` that month, billing falls back to normal usage billing automatically.

## Testing

- Updated `tests/flows/jobs/billing_journal/generators/test_agreement.py::test_pls_mismatch_param_resold_but_enterprise_in_report` to assert the fixed behavior (resold + AWS-enterprise no longer triggers the PLES charge).
- `ruff format --check` / `ruff check` pass on changed files.
- Full test suite: 1024 passed, 1 xpassed.

Jira: MPT-23003
