### PR TITLE
MPT-23245 add SPP Summary sheet reconciling journal SP against invoice PP

### DIFF
--- a/swo_aws_extension/billing/billing_journal_service.py
+++ b/swo_aws_extension/billing/billing_journal_service.py
@@ -107,9 +107,8 @@ class BillingJournalService:
             if (auth_result := self._process_authorization(auth)) is not None
         ]
 
-        self._process_journal_results(journal_results)
+        self._generate_billing_report(journal_results)
 
-    def _process_journal_results(self, journal_results: list[AuthorizationJournalResult]) -> None:
         pls_mismatches = [
             mismatch for auth_result in journal_results for mismatch in auth_result.pls_mismatches
         ]
@@ -120,6 +119,7 @@ class BillingJournalService:
                 text=f"{len(pls_mismatches)} agreement(s) with PLS mismatch:\n\n{details}",
             )
 
+    def _generate_billing_report(self, journal_results: list[AuthorizationJournalResult]) -> None:
         report_rows = [
             row for auth_result in journal_results for row in auth_result.billing_report_rows
         ]
@@ -128,10 +128,16 @@ class BillingJournalService:
             for auth_result in journal_results
             for row in auth_result.billing_report_rows_by_account
         ]
+        spp_summary_rows = [
+            row for auth_result in journal_results for row in auth_result.spp_summary_rows
+        ]
         if report_rows and not self._context.dry_run:
             report_creator = BillingReportCreator(self._context.config, self._context.notifier)
             report_creator.create_and_notify_teams(
-                str(self._context.billing_period), report_rows, report_rows_by_account
+                str(self._context.billing_period),
+                report_rows,
+                report_rows_by_account,
+                spp_summary_rows,
             )
 
     def _process_authorization(self, authorization: dict) -> AuthorizationJournalResult | None:

--- a/swo_aws_extension/billing/billing_report_creator.py
+++ b/swo_aws_extension/billing/billing_report_creator.py
@@ -1,53 +1,85 @@
-from decimal import Decimal
+from enum import StrEnum
 
-from swo_aws_extension.billing.models.journal_result import BillingReportRow
+from swo_aws_extension.billing.models.journal_result import (
+    BillingReportRow,
+    OrganizationSppSummaryRow,
+)
 from swo_aws_extension.config import Config
 from swo_aws_extension.logger import get_logger
 from swo_aws_extension.swo.azure_blob_uploader import AzureBlobUploader
-from swo_aws_extension.swo.excel_report_builder import ExcelReportBuilder
+from swo_aws_extension.swo.excel_report_builder import CellValue, ExcelReportBuilder, Percent
 from swo_aws_extension.swo.notifications.teams import Button, TeamsNotificationManager
 
 logger = get_logger(__name__)
 
 
-def _format_spp_discount_pct(discount_pct: Decimal) -> str:
-    rounded = discount_pct.quantize(Decimal("0.0001"))
-    ratio_str = f"{rounded:.4f}".replace(".", ",")
-    pct = discount_pct * 100
-    return f"{ratio_str} ({pct:.2f}%)"
+class BillingReportHeader(StrEnum):
+    """Column headers used across the billing report sheets."""
+
+    AUTHORIZATION_ID = "Authorization ID"
+    PMA = "PMA"
+    AGREEMENT_ID = "Agreement ID"
+    MPA = "MPA"
+    LINKED_ACCOUNT = "Linked Account"
+    SERVICE_NAME = "Service Name"
+    PP = "PP"
+    SP = "SP"
+    CURRENCY = "Currency"
+    INVOICE_ID = "Invoice ID"
+    INVOICE_ENTITY = "Invoice Entity"
+    EXCHANGE_RATE = "Exchange Rate"
+    SPP_DISCOUNT = "SPP Discount"
+    SPP_DISCOUNT_PCT = "SPP Discount %"
+    LIST_PRICE = "List price"
+    MARKUP = "Markup"
 
 
 BILLING_REPORT_HEADERS = (
-    "Authorization ID",
-    "PMA",
-    "Agreement ID",
-    "MPA",
-    "Service Name",
-    "PP",
-    "SP",
-    "Currency",
-    "Invoice ID",
-    "Invoice Entity",
-    "Exchange Rate",
-    "SPP Discount",
-    "SPP Discount %",
+    BillingReportHeader.AUTHORIZATION_ID,
+    BillingReportHeader.PMA,
+    BillingReportHeader.AGREEMENT_ID,
+    BillingReportHeader.MPA,
+    BillingReportHeader.SERVICE_NAME,
+    BillingReportHeader.PP,
+    BillingReportHeader.SP,
+    BillingReportHeader.CURRENCY,
+    BillingReportHeader.INVOICE_ID,
+    BillingReportHeader.INVOICE_ENTITY,
+    BillingReportHeader.EXCHANGE_RATE,
+    BillingReportHeader.SPP_DISCOUNT,
+    BillingReportHeader.SPP_DISCOUNT_PCT,
 )
 
 BILLING_REPORT_BY_ACCOUNT_HEADERS = (
-    "Authorization ID",
-    "PMA",
-    "Agreement ID",
-    "MPA",
-    "Linked Account",
-    "Service Name",
-    "PP",
-    "SP",
-    "Currency",
-    "Invoice ID",
-    "Invoice Entity",
-    "Exchange Rate",
-    "SPP Discount",
-    "SPP Discount %",
+    BillingReportHeader.AUTHORIZATION_ID,
+    BillingReportHeader.PMA,
+    BillingReportHeader.AGREEMENT_ID,
+    BillingReportHeader.MPA,
+    BillingReportHeader.LINKED_ACCOUNT,
+    BillingReportHeader.SERVICE_NAME,
+    BillingReportHeader.PP,
+    BillingReportHeader.SP,
+    BillingReportHeader.CURRENCY,
+    BillingReportHeader.INVOICE_ID,
+    BillingReportHeader.INVOICE_ENTITY,
+    BillingReportHeader.EXCHANGE_RATE,
+    BillingReportHeader.SPP_DISCOUNT,
+    BillingReportHeader.SPP_DISCOUNT_PCT,
+)
+
+SPP_SUMMARY_HEADERS = (
+    BillingReportHeader.AUTHORIZATION_ID,
+    BillingReportHeader.PMA,
+    BillingReportHeader.AGREEMENT_ID,
+    BillingReportHeader.MPA,
+    BillingReportHeader.PP,
+    BillingReportHeader.SP,
+    BillingReportHeader.CURRENCY,
+    BillingReportHeader.EXCHANGE_RATE,
+    BillingReportHeader.SPP_DISCOUNT,
+    BillingReportHeader.SPP_DISCOUNT_PCT,
+    BillingReportHeader.LIST_PRICE,
+    BillingReportHeader.MARKUP,
 )
 
 
@@ -69,6 +101,7 @@ class BillingReportCreator:
         billing_period_str: str,
         report_rows: list[BillingReportRow],
         rows_by_account: list[BillingReportRow] | None = None,
+        spp_summary_rows: list[OrganizationSppSummaryRow] | None = None,
     ) -> None:
         """Create the report, upload to Azure, and notify teams."""
         if not report_rows:
@@ -78,7 +111,9 @@ class BillingReportCreator:
         logger.info("Creating billing report Excel file...")
         rows_data = self._build_rows_data(report_rows)
         excel_bytes = self._generate_excel(
-            rows_data, self._build_rows_by_account_data(rows_by_account or [])
+            rows_data,
+            self._build_rows_by_account_data(rows_by_account or []),
+            self._build_spp_summary_rows_data(spp_summary_rows or []),
         )
         folder = self._config.report_billing_folder
         blob_name = f"{folder}{billing_period_str}.xlsx"
@@ -104,17 +139,21 @@ class BillingReportCreator:
         logger.info("Billing report uploaded and Teams notification sent.")
 
     def _generate_excel(
-        self, rows_data: list[list[str]], by_account_data: list[list[str]]
+        self,
+        rows_data: list[list[CellValue]],
+        by_account_data: list[list[CellValue]],
+        spp_summary_data: list[list[CellValue]],
     ) -> bytes:
         return self._excel_builder.build_multi_sheet([
             ("Billing Report", list(BILLING_REPORT_HEADERS), rows_data),
             ("By Linked Account", list(BILLING_REPORT_BY_ACCOUNT_HEADERS), by_account_data),
+            ("SPP Summary", list(SPP_SUMMARY_HEADERS), spp_summary_data),
         ])
 
     def _upload(self, excel_bytes: bytes, blob_name: str) -> str:
         return self._blob_uploader.upload_and_get_sas_url(excel_bytes, blob_name)
 
-    def _build_rows_data(self, report_rows: list[BillingReportRow]) -> list[list[str]]:
+    def _build_rows_data(self, report_rows: list[BillingReportRow]) -> list[list[CellValue]]:
         return [
             [
                 row.authorization_id,
@@ -122,19 +161,19 @@ class BillingReportCreator:
                 row.agreement_id,
                 row.mpa,
                 row.service_name,
-                str(row.pp),
-                str(row.sp),
+                float(row.pp),
+                float(row.sp),
                 row.currency,
                 row.invoice_id,
                 row.invoice_entity,
-                str(row.exchange_rate),
-                str(row.spp_discount),
-                _format_spp_discount_pct(row.spp_discount_pct),
+                float(row.exchange_rate),
+                float(row.spp_discount),
+                Percent(float(row.spp_discount_pct)),
             ]
             for row in report_rows
         ]
 
-    def _build_rows_by_account_data(self, rows: list[BillingReportRow]) -> list[list[str]]:
+    def _build_rows_by_account_data(self, rows: list[BillingReportRow]) -> list[list[CellValue]]:
         return [
             [
                 row.authorization_id,
@@ -143,14 +182,35 @@ class BillingReportCreator:
                 row.mpa,
                 row.linked_account,
                 row.service_name,
-                str(row.pp),
-                str(row.sp),
+                float(row.pp),
+                float(row.sp),
                 row.currency,
                 row.invoice_id,
                 row.invoice_entity,
-                str(row.exchange_rate),
-                str(row.spp_discount),
-                _format_spp_discount_pct(row.spp_discount_pct),
+                float(row.exchange_rate),
+                float(row.spp_discount),
+                Percent(float(row.spp_discount_pct)),
+            ]
+            for row in rows
+        ]
+
+    def _build_spp_summary_rows_data(
+        self, rows: list[OrganizationSppSummaryRow]
+    ) -> list[list[CellValue]]:
+        return [
+            [
+                row.authorization_id,
+                row.pma,
+                row.agreement_id,
+                row.mpa,
+                float(row.pp),
+                float(row.sp),
+                row.currency,
+                float(row.exchange_rate),
+                float(row.spp_discount),
+                Percent(float(row.spp_discount_pct)),
+                float(row.list_price),
+                Percent(float(row.markup)),
             ]
             for row in rows
         ]

--- a/swo_aws_extension/billing/generators/agreement.py
+++ b/swo_aws_extension/billing/generators/agreement.py
@@ -16,6 +16,7 @@ from swo_aws_extension.billing.generators.additional_line_processors.saving_plan
 from swo_aws_extension.billing.generators.billing_report_rows import (
     BillingReportRowsBuilder,
     ReportContext,
+    build_spp_summary_row,
 )
 from swo_aws_extension.billing.generators.invoice import InvoiceGenerator
 from swo_aws_extension.billing.generators.journal_line import JournalLineGenerator
@@ -164,6 +165,12 @@ class AgreementJournalGenerator:
             billing_report_rows_by_account=report_builder.build_by_account(),
             pls_mismatches=pls_mismatches,
             invoice_ids=invoice_ids,
+            spp_summary_row=build_spp_summary_row(
+                ReportContext.from_contexts(self._auth_context, journal_details),
+                all_lines,
+                report_builder.build(),
+                organization_invoice,
+            ),
         )
 
     def _generate_usage_lines(

--- a/swo_aws_extension/billing/generators/authorization.py
+++ b/swo_aws_extension/billing/generators/authorization.py
@@ -136,17 +136,16 @@ class AuthorizationJournalGenerator:
             return
 
         result.lines.extend(agreement_result.lines)
+        result.billing_report_rows.extend(agreement_result.billing_report_rows)
+        result.billing_report_rows_by_account.extend(
+            agreement_result.billing_report_rows_by_account
+        )
+        result.pls_mismatches.extend(agreement_result.pls_mismatches)
+        result.invoice_ids.update(agreement_result.invoice_ids)
         if agreement_result.report:
             result.reports_by_agreement[agreement_id] = agreement_result.report
-        if agreement_result.billing_report_rows:
-            result.billing_report_rows.extend(agreement_result.billing_report_rows)
-        if agreement_result.billing_report_rows_by_account:
-            result.billing_report_rows_by_account.extend(
-                agreement_result.billing_report_rows_by_account
-            )
-        if agreement_result.pls_mismatches:
-            result.pls_mismatches.extend(agreement_result.pls_mismatches)
-        result.invoice_ids.update(agreement_result.invoice_ids)
+        if agreement_result.spp_summary_row:
+            result.spp_summary_rows.append(agreement_result.spp_summary_row)
 
     def _apply_pma_usage_to_report(
         self,

--- a/swo_aws_extension/billing/generators/billing_report_rows.py
+++ b/swo_aws_extension/billing/generators/billing_report_rows.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from decimal import Decimal
 from itertools import starmap
 from typing import TYPE_CHECKING, TypedDict
 
 from swo_aws_extension.billing.models.invoice import OrganizationInvoice
-from swo_aws_extension.billing.models.journal_result import BillingReportRow
+from swo_aws_extension.billing.models.journal_result import (
+    BillingReportRow,
+    OrganizationSppSummaryRow,
+)
 from swo_aws_extension.billing.models.usage import (
     OrganizationUsageResult,
     ServiceMetric,
@@ -16,7 +21,7 @@ if TYPE_CHECKING:
     from swo_aws_extension.billing.models.context import (
         AuthorizationContext,
     )
-    from swo_aws_extension.billing.models.journal_line import JournalDetails
+    from swo_aws_extension.billing.models.journal_line import JournalDetails, JournalLine
 
 logger = get_logger(__name__)
 
@@ -41,9 +46,9 @@ class ReportContext:
     @classmethod
     def from_contexts(
         cls,
-        auth_context: "AuthorizationContext",
-        journal_details: "JournalDetails",
-    ) -> "ReportContext":
+        auth_context: AuthorizationContext,
+        journal_details: JournalDetails,
+    ) -> ReportContext:
         """Build a ReportContext from existing auth and journal contexts."""
         return cls(
             authorization_id=auth_context.id,
@@ -146,3 +151,44 @@ class BillingReportRowsBuilder:
             rate = self._invoice.entities[inv_entity].exchange_rate
             return rate if rate > DEC_ZERO else Decimal("1.0")
         return Decimal("1.0")
+
+
+def build_spp_summary_row(
+    context: ReportContext,
+    all_lines: list[JournalLine],
+    billing_report_rows: list[BillingReportRow],
+    organization_invoice: OrganizationInvoice,
+) -> OrganizationSppSummaryRow:
+    """Build one organization-level row reconciling the journal total (SP) against PP."""
+    sp = sum((line.price.pp_x1 for line in all_lines if line.is_valid()), DEC_ZERO)
+    pp = (
+        organization_invoice.base_total_amount_before_tax
+        if context.currency == "USD"
+        else organization_invoice.payment_currency_total_amount_before_tax
+    )
+    spp_discount = sum((row.spp_discount for row in billing_report_rows), DEC_ZERO)
+    exchange_rate = _resolve_org_exchange_rate(organization_invoice)
+
+    return OrganizationSppSummaryRow(
+        authorization_id=context.authorization_id,
+        pma=context.pma,
+        agreement_id=context.agreement_id,
+        mpa=context.mpa,
+        pp=pp,
+        sp=sp,
+        currency=context.currency,
+        exchange_rate=exchange_rate,
+        spp_discount=spp_discount,
+        spp_discount_pct=abs(spp_discount) / pp if pp else DEC_ZERO,
+        list_price=organization_invoice.payment_currency_subtotal_amount,
+        markup=(sp - pp) / pp if pp else DEC_ZERO,
+    )
+
+
+def _resolve_org_exchange_rate(organization_invoice: OrganizationInvoice) -> Decimal:
+    rates = [
+        entity.exchange_rate
+        for entity in organization_invoice.entities.values()
+        if entity.exchange_rate > DEC_ZERO
+    ]
+    return max(rates) if rates else Decimal("1.0")

--- a/swo_aws_extension/billing/generators/invoice.py
+++ b/swo_aws_extension/billing/generators/invoice.py
@@ -1,6 +1,13 @@
 from decimal import Decimal
 
 from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.billing.generators.invoice_utils import (
+    belongs_to_mpa,
+    get_invoice_rate,
+    invoice_amount,
+    is_primary_invoice,
+    merge_invoice_ids,
+)
 from swo_aws_extension.billing.models.invoice import (
     InvoiceEntity,
     OrganizationInvoice,
@@ -11,52 +18,6 @@ from swo_aws_extension.logger import get_logger
 from swo_aws_extension.models import BillingPeriod
 
 logger = get_logger(__name__)
-SPP_DISCOUNT_DESCRIPTION = "Discount (AWS SPP Discount)"
-MAX_INVOICE_ID_LENGTH = 20
-_INVOICE_ID_SUFFIX_LENGTH = 4
-_OVERFLOW_MARKER = ".."
-_SUFFIX_PREFIX = "-"
-
-_SEPARATOR = ","
-
-
-def merge_invoice_ids(existing_id: str, new_id: str) -> str:
-    """Merge invoice IDs keeping only the unique suffix (last 4 chars) of each.
-
-    Each suffix is prefixed with ``-`` to signal truncation.
-    The result must fit within MAX_INVOICE_ID_LENGTH characters.
-    When it overflows, an ellipsis marker replaces the newest suffix.
-    """
-    if not new_id:
-        return existing_id
-    new_suffix = _SUFFIX_PREFIX + new_id[-_INVOICE_ID_SUFFIX_LENGTH:]
-    if _SEPARATOR not in existing_id:
-        existing_id = _SUFFIX_PREFIX + existing_id[-_INVOICE_ID_SUFFIX_LENGTH:]
-    candidate = _SEPARATOR.join((existing_id, new_suffix))
-    if len(candidate) <= MAX_INVOICE_ID_LENGTH:
-        return candidate
-    truncated = _SEPARATOR.join((existing_id, _OVERFLOW_MARKER))
-    if len(truncated) <= MAX_INVOICE_ID_LENGTH:
-        return truncated
-    return existing_id
-
-
-def _belongs_to_mpa(invoice: dict, mpa_account: str) -> bool:
-    bill_source_accounts = invoice.get("BillSourceAccounts")
-    if bill_source_accounts is not None:
-        return mpa_account in bill_source_accounts
-    return invoice.get("AccountId") == mpa_account
-
-
-def _is_primary_invoice(invoice: dict) -> bool:
-    breakdowns = (
-        invoice
-        .get("BaseCurrencyAmount", {})
-        .get("AmountBreakdown", {})
-        .get("Discounts", {})
-        .get("Breakdown", [])
-    )
-    return any(breakdown.get("Description") == SPP_DISCOUNT_DESCRIPTION for breakdown in breakdowns)
 
 
 class ExchangeRateResolver:
@@ -75,7 +36,7 @@ class ExchangeRateResolver:
     def get_payment_currency(self, exchange_rate: Decimal) -> str:
         """Get the payment currency code for the given exchange rate."""
         for inv in self._raw_invoices:
-            rate = self._get_invoice_rate(inv)
+            rate = get_invoice_rate(inv)
             if rate == exchange_rate:
                 return inv.get("PaymentCurrencyAmount", {}).get("CurrencyCode", "USD")
         return "USD"
@@ -87,16 +48,93 @@ class ExchangeRateResolver:
                 continue
             if entity_name and inv.get("Entity", {}).get("InvoicingEntity") != entity_name:
                 continue
-            rates.append(self._get_invoice_rate(inv))
+            rates.append(get_invoice_rate(inv))
         return rates
 
-    def _get_invoice_rate(self, invoice: dict) -> Decimal:
-        return Decimal(
-            invoice
-            .get("PaymentCurrencyAmount", {})
-            .get("CurrencyExchangeDetails", {})
-            .get("Rate", 0)
+
+class OrganizationInvoiceBuilder:
+    """Builds an OrganizationInvoice from a list of raw invoice dicts."""
+
+    def __init__(self, raw_invoices: list[dict], currency: str) -> None:
+        self._raw_invoices = raw_invoices
+        self._currency = currency
+        self._resolver = ExchangeRateResolver(raw_invoices)
+
+    def build(self) -> OrganizationInvoice:
+        """Aggregate the raw invoices into a single OrganizationInvoice."""
+        return OrganizationInvoice(
+            entities=self._build_entities(),
+            base_total_amount=self._sum_amounts("BaseCurrencyAmount", "TotalAmount"),
+            base_total_amount_before_tax=self._sum_amounts(
+                "BaseCurrencyAmount", "TotalAmountBeforeTax"
+            ),
+            payment_currency_total_amount=self._sum_amounts("PaymentCurrencyAmount", "TotalAmount"),
+            payment_currency_total_amount_before_tax=self._sum_amounts(
+                "PaymentCurrencyAmount", "TotalAmountBeforeTax"
+            ),
+            payment_currency_subtotal_amount=self._sum_breakdown_amounts(
+                "PaymentCurrencyAmount", "SubTotalAmount"
+            ),
+            principal_invoice_amount=self._get_principal_amount(),
         )
+
+    def _build_entities(self) -> dict[str, InvoiceEntity]:
+        entities: dict[str, InvoiceEntity] = {}
+        for invoice in self._raw_invoices:
+            entity = invoice.get("Entity", {})
+            entity_key = f"{entity.get('InvoicingEntity', '')}:{entity.get('BillingEntity', 'AWS')}"
+            entities[entity_key] = self._build_invoice_entity(
+                invoice, entity, entities.get(entity_key)
+            )
+        return entities
+
+    def _build_invoice_entity(
+        self,
+        invoice: dict,
+        entity: dict,
+        existing: InvoiceEntity | None,
+    ) -> InvoiceEntity:
+        billing_entity = entity.get("BillingEntity", "AWS")
+        if existing:
+            merged_id = merge_invoice_ids(existing.invoice_id, invoice.get("InvoiceId", ""))
+            return InvoiceEntity(
+                invoice_id=merged_id,
+                base_currency_code=existing.base_currency_code,
+                payment_currency_code=existing.payment_currency_code,
+                exchange_rate=existing.exchange_rate,
+                billing_entity=billing_entity,
+                primary=is_primary_invoice(invoice) or existing.primary,
+            )
+        exchange_rate = self._resolver.get_rate(entity.get("InvoicingEntity", ""), self._currency)
+        return InvoiceEntity(
+            invoice_id=invoice.get("InvoiceId", ""),
+            base_currency_code=invoice.get("BaseCurrencyAmount", {}).get("CurrencyCode", ""),
+            payment_currency_code=self._resolver.get_payment_currency(exchange_rate),
+            exchange_rate=exchange_rate,
+            billing_entity=billing_entity,
+            primary=is_primary_invoice(invoice),
+        )
+
+    def _sum_amounts(self, currency_key: str, amount_key: str) -> Decimal:
+        return sum(
+            (invoice_amount(inv, currency_key, amount_key) for inv in self._raw_invoices),
+            DEC_ZERO,
+        )
+
+    def _sum_breakdown_amounts(self, currency_key: str, amount_key: str) -> Decimal:
+        return sum(
+            (
+                invoice_amount(inv.get(currency_key, {}), "AmountBreakdown", amount_key)
+                for inv in self._raw_invoices
+            ),
+            DEC_ZERO,
+        )
+
+    def _get_principal_amount(self) -> Decimal | None:
+        for invoice in self._raw_invoices:
+            if is_primary_invoice(invoice):
+                return Decimal(invoice.get("BaseCurrencyAmount", {}).get("TotalAmount", 0))
+        return None
 
 
 class InvoiceGenerator:
@@ -126,8 +164,8 @@ class InvoiceGenerator:
         invoice_summaries = self._aws_client.list_invoice_summaries_by_account_id(
             pma_account, billing_period.year, billing_period.month
         )
-        raw_invoices = [inv for inv in invoice_summaries if _belongs_to_mpa(inv, mpa_account)]
-        invoice = self._build_organization_invoice(raw_invoices, authorization_currency)
+        raw_invoices = [inv for inv in invoice_summaries if belongs_to_mpa(inv, mpa_account)]
+        invoice = OrganizationInvoiceBuilder(raw_invoices, authorization_currency).build()
 
         for entity_name, entity in invoice.entities.items():
             logger.info(
@@ -140,78 +178,3 @@ class InvoiceGenerator:
             )
 
         return OrganizationInvoiceResult(raw_data=raw_invoices, invoice=invoice)
-
-    def _build_organization_invoice(
-        self, raw_invoices: list[dict], currency: str
-    ) -> OrganizationInvoice:
-        resolver = ExchangeRateResolver(raw_invoices)
-        entities = self._build_entities(raw_invoices, currency, resolver)
-
-        return OrganizationInvoice(
-            entities=entities,
-            base_total_amount=self._sum_amounts(raw_invoices, "BaseCurrencyAmount", "TotalAmount"),
-            base_total_amount_before_tax=self._sum_amounts(
-                raw_invoices, "BaseCurrencyAmount", "TotalAmountBeforeTax"
-            ),
-            payment_currency_total_amount=self._sum_amounts(
-                raw_invoices, "PaymentCurrencyAmount", "TotalAmount"
-            ),
-            payment_currency_total_amount_before_tax=self._sum_amounts(
-                raw_invoices, "PaymentCurrencyAmount", "TotalAmountBeforeTax"
-            ),
-            principal_invoice_amount=self._get_principal_amount(raw_invoices),
-        )
-
-    def _build_entities(
-        self, raw_invoices: list[dict], currency: str, resolver: ExchangeRateResolver
-    ) -> dict[str, InvoiceEntity]:
-        entities: dict[str, InvoiceEntity] = {}
-        for invoice in raw_invoices:
-            entity = invoice.get("Entity", {})
-            entity_key = f"{entity.get('InvoicingEntity', '')}:{entity.get('BillingEntity', 'AWS')}"
-            entities[entity_key] = self._build_invoice_entity(
-                invoice, entity, entities.get(entity_key), currency, resolver
-            )
-        return entities
-
-    def _build_invoice_entity(
-        self,
-        invoice: dict,
-        entity: dict,
-        existing: InvoiceEntity | None,
-        currency: str,
-        resolver: ExchangeRateResolver,
-    ) -> InvoiceEntity:
-        billing_entity = entity.get("BillingEntity", "AWS")
-        if existing:
-            new_id = invoice.get("InvoiceId", "")
-            merged_id = merge_invoice_ids(existing.invoice_id, new_id)
-            return InvoiceEntity(
-                invoice_id=merged_id,
-                base_currency_code=existing.base_currency_code,
-                payment_currency_code=existing.payment_currency_code,
-                exchange_rate=existing.exchange_rate,
-                billing_entity=billing_entity,
-                primary=_is_primary_invoice(invoice) or existing.primary,
-            )
-        exchange_rate = resolver.get_rate(entity.get("InvoicingEntity", ""), currency)
-        return InvoiceEntity(
-            invoice_id=invoice.get("InvoiceId", ""),
-            base_currency_code=invoice.get("BaseCurrencyAmount", {}).get("CurrencyCode", ""),
-            payment_currency_code=resolver.get_payment_currency(exchange_rate),
-            exchange_rate=exchange_rate,
-            billing_entity=billing_entity,
-            primary=_is_primary_invoice(invoice),
-        )
-
-    def _get_principal_amount(self, raw_invoices: list[dict]) -> Decimal | None:
-        for invoice in raw_invoices:
-            if _is_primary_invoice(invoice):
-                return Decimal(invoice.get("BaseCurrencyAmount", {}).get("TotalAmount", 0))
-        return None
-
-    def _sum_amounts(self, invoices: list[dict], currency_key: str, amount_key: str) -> Decimal:
-        return sum(
-            (Decimal(inv.get(currency_key, {}).get(amount_key, 0)) for inv in invoices),
-            DEC_ZERO,
-        )

--- a/swo_aws_extension/billing/generators/invoice_utils.py
+++ b/swo_aws_extension/billing/generators/invoice_utils.py
@@ -1,0 +1,61 @@
+from decimal import Decimal
+
+SPP_DISCOUNT_DESCRIPTION = "Discount (AWS SPP Discount)"
+MAX_INVOICE_ID_LENGTH = 20
+_INVOICE_ID_SUFFIX_LENGTH = 4
+_OVERFLOW_MARKER = ".."
+_SUFFIX_PREFIX = "-"
+_SEPARATOR = ","
+
+
+def merge_invoice_ids(existing_id: str, new_id: str) -> str:
+    """Merge invoice IDs keeping only the unique suffix (last 4 chars) of each.
+
+    Each suffix is prefixed with ``-`` to signal truncation.
+    The result must fit within MAX_INVOICE_ID_LENGTH characters.
+    When it overflows, an ellipsis marker replaces the newest suffix.
+    """
+    if not new_id:
+        return existing_id
+    new_suffix = _SUFFIX_PREFIX + new_id[-_INVOICE_ID_SUFFIX_LENGTH:]
+    if _SEPARATOR not in existing_id:
+        existing_id = _SUFFIX_PREFIX + existing_id[-_INVOICE_ID_SUFFIX_LENGTH:]
+    candidate = _SEPARATOR.join((existing_id, new_suffix))
+    if len(candidate) <= MAX_INVOICE_ID_LENGTH:
+        return candidate
+    truncated = _SEPARATOR.join((existing_id, _OVERFLOW_MARKER))
+    if len(truncated) <= MAX_INVOICE_ID_LENGTH:
+        return truncated
+    return existing_id
+
+
+def belongs_to_mpa(invoice: dict, mpa_account: str) -> bool:
+    """Check whether the invoice belongs to the given MPA account."""
+    bill_source_accounts = invoice.get("BillSourceAccounts")
+    if bill_source_accounts is not None:
+        return mpa_account in bill_source_accounts
+    return invoice.get("AccountId") == mpa_account
+
+
+def is_primary_invoice(invoice: dict) -> bool:
+    """Check whether the invoice contains an AWS SPP discount breakdown."""
+    breakdowns = (
+        invoice
+        .get("BaseCurrencyAmount", {})
+        .get("AmountBreakdown", {})
+        .get("Discounts", {})
+        .get("Breakdown", [])
+    )
+    return any(breakdown.get("Description") == SPP_DISCOUNT_DESCRIPTION for breakdown in breakdowns)
+
+
+def get_invoice_rate(invoice: dict) -> Decimal:
+    """Extract the payment-currency exchange rate from a raw invoice."""
+    return Decimal(
+        invoice.get("PaymentCurrencyAmount", {}).get("CurrencyExchangeDetails", {}).get("Rate", 0)
+    )
+
+
+def invoice_amount(invoice: dict, currency_key: str, amount_key: str) -> Decimal:
+    """Read a Decimal amount from a nested currency section of a raw invoice."""
+    return Decimal(invoice.get(currency_key, {}).get(amount_key, 0))

--- a/swo_aws_extension/billing/models/invoice.py
+++ b/swo_aws_extension/billing/models/invoice.py
@@ -25,6 +25,7 @@ class OrganizationInvoice:
     base_total_amount_before_tax: Decimal = field(default_factory=lambda: Decimal(0))
     payment_currency_total_amount: Decimal = field(default_factory=lambda: Decimal(0))
     payment_currency_total_amount_before_tax: Decimal = field(default_factory=lambda: Decimal(0))
+    payment_currency_subtotal_amount: Decimal = field(default_factory=lambda: Decimal(0))
     principal_invoice_amount: Decimal | None = None
 
     @property

--- a/swo_aws_extension/billing/models/journal_result.py
+++ b/swo_aws_extension/billing/models/journal_result.py
@@ -26,6 +26,24 @@ class BillingReportRow:
 
 
 @dataclass
+class OrganizationSppSummaryRow:
+    """One row per agreement reconciling the journal total (SP) against the AWS invoice (PP)."""
+
+    authorization_id: str
+    pma: str
+    agreement_id: str
+    mpa: str
+    pp: Decimal
+    sp: Decimal
+    currency: str
+    exchange_rate: Decimal
+    spp_discount: Decimal
+    spp_discount_pct: Decimal
+    list_price: Decimal
+    markup: Decimal
+
+
+@dataclass
 class PlsMismatch:
     """Records a PLS mismatch between order parameter and usage report."""
 
@@ -54,6 +72,7 @@ class AgreementJournalResult:
     billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)
     invoice_ids: set[str] = field(default_factory=set)
+    spp_summary_row: OrganizationSppSummaryRow | None = None
 
 
 @dataclass
@@ -74,3 +93,4 @@ class AuthorizationJournalResult:
     billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)
     invoice_ids: set[str] = field(default_factory=set)
+    spp_summary_rows: list[OrganizationSppSummaryRow] = field(default_factory=list)

--- a/swo_aws_extension/swo/excel_report_builder.py
+++ b/swo_aws_extension/swo/excel_report_builder.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 
@@ -5,9 +6,22 @@ from openpyxl import Workbook
 from openpyxl.styles import Font
 from openpyxl.worksheet.worksheet import Worksheet
 
-type SheetDefinition = tuple[str, list[str], list[list[str]]]
+type CellValue = str | float | Percent
+type SheetDefinition = tuple[str, list[str], list[list[CellValue]]]
 
 _HEADER_FONT = Font(bold=True)
+_PERCENT_NUMBER_FORMAT = "0.###################%"
+
+
+@dataclass(frozen=True, slots=True)
+class Percent:
+    """A ratio (e.g. 0.1234) rendered with Excel's native percent number format."""
+
+    ratio: float
+
+
+def _resolve_cell_value(entry: CellValue) -> str | float:
+    return entry.ratio if isinstance(entry, Percent) else entry
 
 
 class ExcelReportBuilder:
@@ -17,7 +31,7 @@ class ExcelReportBuilder:
         self.headers = headers
         self.sheet_name = sheet_name
 
-    def build_from_rows(self, rows: list[list[str]]) -> bytes:
+    def build_from_rows(self, rows: list[list[CellValue]]) -> bytes:
         """Build an Excel workbook in memory and return its raw bytes."""
         wb = Workbook()
         ws = wb.active
@@ -43,13 +57,17 @@ class ExcelReportBuilder:
         self,
         ws: Worksheet,
         headers: list[str],
-        rows: list[list[str]],
+        rows: list[list[CellValue]],
     ) -> None:
         ws.append(headers)
         for cell in ws[1]:
             cell.font = _HEADER_FONT
         for row_data in rows:
-            ws.append(row_data)
+            ws.append([_resolve_cell_value(entry) for entry in row_data])
+            row_idx = ws.max_row
+            for col_idx, entry in enumerate(row_data, start=1):
+                if isinstance(entry, Percent):
+                    ws.cell(row=row_idx, column=col_idx).number_format = _PERCENT_NUMBER_FORMAT
         ws.auto_filter.ref = ws.dimensions
 
     def _save_to_bytes(self, wb: Workbook) -> bytes:

--- a/tests/billing/generators/test_agreement.py
+++ b/tests/billing/generators/test_agreement.py
@@ -93,6 +93,11 @@ def mock_pls_charge_manager_cls(mocker):
     return cls_mock
 
 
+@pytest.fixture(autouse=True)
+def mock_build_spp_summary_row(mocker):
+    return mocker.patch(f"{MODULE}.build_spp_summary_row")
+
+
 def _build_agreement(support_type="ResoldSupport"):
     return {
         "id": "AGR-1",
@@ -123,6 +128,7 @@ def test_run(
     mock_line_generator_cls,
     mock_extra_discounts_manager_cls,
     mock_pls_charge_manager_cls,
+    mock_build_spp_summary_row,
 ):
     mock_builder = mocker.MagicMock()
     mock_builder.build.return_value = []
@@ -168,12 +174,21 @@ def test_run(
     assert result.lines == [mock_journal_line, mock_discount_line, mock_pls_line]
     assert result.invoice_ids == {"INV-001", "INV-002"}
     mock_invoice_generator.run.assert_called_once()
-    mock_generator_instance.generate.assert_called_once()
     mock_pls_instance.process.assert_called_once()
-    call_args = mock_generator_instance.generate.call_args
-    assert call_args[0][0] == "ACC-1"
-    assert call_args[0][1] == mock_account_usage
-    assert isinstance(call_args[0][2], JournalDetails)
+    mock_generator_instance.generate.assert_called_once_with(
+        "ACC-1",
+        mock_account_usage,
+        mocker.ANY,
+        mocker.ANY,
+    )
+    assert isinstance(mock_generator_instance.generate.call_args[0][2], JournalDetails)
+    assert result.spp_summary_row is mock_build_spp_summary_row.return_value
+    mock_build_spp_summary_row.assert_called_once_with(
+        mocker.ANY,
+        result.lines,
+        result.billing_report_rows,
+        mock_invoice_generator.run.return_value.invoice,
+    )
 
 
 def test_run_without_pls(

--- a/tests/billing/generators/test_authorization.py
+++ b/tests/billing/generators/test_authorization.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from swo_aws_extension.aws.client import AWSClient
@@ -17,6 +19,7 @@ from swo_aws_extension.billing.models.journal_result import (
     AgreementJournalResult,
     AuthorizationJournalResult,
     BillingReportRow,
+    OrganizationSppSummaryRow,
     PlsMismatch,
 )
 from swo_aws_extension.billing.models.usage import OrganizationReport
@@ -183,6 +186,44 @@ def test_includes_report_in_result(
     assert result.reports_by_agreement == {"AGR-1": report}
     assert result.billing_report_rows == [mock_row]
     assert result.billing_report_rows_by_account == [mock_row_by_account]
+
+
+def test_includes_spp_summary_row_in_result(
+    mocker,
+    mock_context,
+    mock_get_agreements,
+    mock_agreement_generator_cls,
+    mock_usage_generator_cls,
+    mock_invoice_generator_cls,
+    mock_aws_client_cls,
+    billing_aws_client_provider,
+    authorization,
+):
+    spp_summary_row = OrganizationSppSummaryRow(
+        authorization_id="AUTH-1",
+        pma="PMA-123",
+        agreement_id="AGR-1",
+        mpa="MPA-1",
+        pp=Decimal("90.00"),
+        sp=Decimal("100.00"),
+        currency="USD",
+        exchange_rate=Decimal("1.0"),
+        spp_discount=Decimal("-10.00"),
+        spp_discount_pct=Decimal("0.10"),
+        list_price=Decimal("120.00"),
+        markup=Decimal("10.00") / Decimal("90.00"),
+    )
+    mock_get_agreements.return_value = [{"id": "AGR-1"}]
+    mock_agr_gen = mocker.MagicMock(spec=AgreementJournalGenerator)
+    mock_agr_gen.run.return_value = AgreementJournalResult(
+        lines=[], spp_summary_row=spp_summary_row
+    )
+    mock_agreement_generator_cls.return_value = mock_agr_gen
+    generator = AuthorizationJournalGenerator(mock_context)
+
+    result = generator.run(authorization, billing_aws_client_provider)
+
+    assert result.spp_summary_rows == [spp_summary_row]
 
 
 def test_includes_pls_mismatches_in_result(

--- a/tests/billing/generators/test_invoice.py
+++ b/tests/billing/generators/test_invoice.py
@@ -4,10 +4,11 @@ import pytest
 
 from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.billing.generators.invoice import (
-    MAX_INVOICE_ID_LENGTH,
     ExchangeRateResolver,
     InvoiceGenerator,
-    merge_invoice_ids,
+)
+from swo_aws_extension.billing.generators.invoice_utils import (
+    MAX_INVOICE_ID_LENGTH,
 )
 from swo_aws_extension.billing.models.invoice import (
     OrganizationInvoiceResult,
@@ -25,6 +26,7 @@ def build_invoice(
     payment_currency="EUR",
     payment_total="95.00",
     payment_total_before_tax="85.00",
+    payment_subtotal="105.00",
     exchange_rate="0.95",
     discounts=None,
     bill_source_accounts=None,
@@ -44,6 +46,7 @@ def build_invoice(
             "TotalAmount": payment_total,
             "TotalAmountBeforeTax": payment_total_before_tax,
             "CurrencyExchangeDetails": {"Rate": exchange_rate},
+            "AmountBreakdown": {"SubTotalAmount": payment_subtotal},
         },
     }
     if discounts:
@@ -138,6 +141,20 @@ def test_run_merges_entities_and_calculates_totals(generator, mock_aws_client, b
     assert result.invoice.payment_currency_total_amount_before_tax == Decimal("255.00")
 
 
+def test_run_sums_payment_currency_subtotal_amount_across_invoices(
+    generator, mock_aws_client, billing_period
+):
+    invoices = [
+        build_invoice(invoice_id="INV-1", payment_subtotal="100.00"),
+        build_invoice(invoice_id="INV-2", payment_subtotal="50.00"),
+    ]
+    mock_aws_client.list_invoice_summaries_by_account_id.return_value = invoices
+
+    result = generator.run("PMA-456", "MPA-123", billing_period, "EUR")
+
+    assert result.invoice.payment_currency_subtotal_amount == Decimal("150.00")
+
+
 def test_run_handles_principal_invoice_amount_with_spp_discount(
     generator, mock_aws_client, billing_period
 ):
@@ -174,47 +191,6 @@ def test_run_handles_empty_invoices(generator, mock_aws_client, billing_period):
     assert result.raw_data == []
     assert result.invoice.entities == {}
     assert result.invoice.base_total_amount == Decimal(0)
-
-
-@pytest.mark.parametrize(
-    ("entity", "currency", "expected"),
-    [
-        ("AWS Inc.", "EUR", Decimal("0.95")),
-        ("Unknown Entity", "EUR", Decimal("0.95")),
-        ("AWS Inc.", "GBP", Decimal(0)),
-    ],
-)
-def test_exchange_rate_resolver_get_rate(entity, currency, expected):
-    invoices = [
-        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.90"),
-        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.95"),
-        build_invoice(invoicing_entity="AWS EMEA", exchange_rate="0.92"),
-    ]
-    resolver = ExchangeRateResolver(invoices)
-
-    result = resolver.get_rate(entity, currency)
-
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ("rate", "expected_currency"),
-    [
-        (Decimal("0.92"), "EUR"),
-        (Decimal("0.99"), "USD"),
-    ],
-)
-def test_exchange_rate_resolver_get_payment_currency(rate, expected_currency):
-    invoices = [
-        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.90"),
-        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.95"),
-        build_invoice(invoicing_entity="AWS EMEA", exchange_rate="0.92"),
-    ]
-    resolver = ExchangeRateResolver(invoices)
-
-    result = resolver.get_payment_currency(rate)
-
-    assert result == expected_currency
 
 
 def test_run_filters_invoices_by_bill_source_accounts(generator, mock_aws_client, billing_period):
@@ -285,22 +261,6 @@ def test_run_falls_back_to_account_id_when_bill_source_accounts_absent(
     assert result.raw_data[0]["InvoiceId"] == "INV-001"
 
 
-@pytest.mark.parametrize(
-    ("existing_id", "new_id", "expected"),
-    [
-        ("2609293185", "", "2609293185"),
-        ("2609293185", "SGIN26-350441", "-3185,-0441"),
-        ("-3185,-0441", "EUINPL26-355205", "-3185,-0441,-5205"),
-        ("-3185,-0441,-5205", "NEXT26-000002", "-3185,-0441,-5205,.."),
-        ("-3185,-0441,-5205,..", "NEXT26-000003", "-3185,-0441,-5205,.."),
-    ],
-)
-def test_merge_invoice_ids(existing_id, new_id, expected):
-    result = merge_invoice_ids(existing_id, new_id)  # act
-
-    assert result == expected
-
-
 def test_merge_invoice_ids_result_never_exceeds_navision_limit(
     generator, mock_aws_client, billing_period
 ):
@@ -316,3 +276,44 @@ def test_merge_invoice_ids_result_never_exceeds_navision_limit(
     entity = result.invoice.entities["AWS Inc.:AWS"]
     assert len(entity.invoice_id) <= MAX_INVOICE_ID_LENGTH
     assert entity.invoice_id.endswith(",..")
+
+
+@pytest.mark.parametrize(
+    ("entity", "currency", "expected"),
+    [
+        ("AWS Inc.", "EUR", Decimal("0.95")),
+        ("Unknown Entity", "EUR", Decimal("0.95")),
+        ("AWS Inc.", "GBP", Decimal(0)),
+    ],
+)
+def test_exchange_rate_resolver_get_rate(entity, currency, expected):
+    invoices = [
+        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.90"),
+        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.95"),
+        build_invoice(invoicing_entity="AWS EMEA", exchange_rate="0.92"),
+    ]
+    resolver = ExchangeRateResolver(invoices)
+
+    result = resolver.get_rate(entity, currency)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("rate", "expected_currency"),
+    [
+        (Decimal("0.92"), "EUR"),
+        (Decimal("0.99"), "USD"),
+    ],
+)
+def test_exchange_rate_resolver_get_payment_currency(rate, expected_currency):
+    invoices = [
+        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.90"),
+        build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.95"),
+        build_invoice(invoicing_entity="AWS EMEA", exchange_rate="0.92"),
+    ]
+    resolver = ExchangeRateResolver(invoices)
+
+    result = resolver.get_payment_currency(rate)
+
+    assert result == expected_currency

--- a/tests/billing/generators/test_invoice_utils.py
+++ b/tests/billing/generators/test_invoice_utils.py
@@ -1,0 +1,114 @@
+from decimal import Decimal
+
+import pytest
+
+from swo_aws_extension.billing.generators.invoice_utils import (
+    belongs_to_mpa,
+    get_invoice_rate,
+    is_primary_invoice,
+    merge_invoice_ids,
+)
+
+
+def build_invoice(
+    account_id="MPA-123",
+    invoice_id="INV-001",
+    invoicing_entity="AWS Inc.",
+    base_currency="USD",
+    base_total="100.00",
+    base_total_before_tax="90.00",
+    payment_currency="EUR",
+    payment_total="95.00",
+    payment_total_before_tax="85.00",
+    payment_subtotal="105.00",
+    exchange_rate="0.95",
+    discounts=None,
+    bill_source_accounts=None,
+):
+    """Factory function to create invoice dictionaries for testing."""
+    invoice = {
+        "AccountId": account_id,
+        "InvoiceId": invoice_id,
+        "Entity": {"InvoicingEntity": invoicing_entity},
+        "BaseCurrencyAmount": {
+            "CurrencyCode": base_currency,
+            "TotalAmount": base_total,
+            "TotalAmountBeforeTax": base_total_before_tax,
+        },
+        "PaymentCurrencyAmount": {
+            "CurrencyCode": payment_currency,
+            "TotalAmount": payment_total,
+            "TotalAmountBeforeTax": payment_total_before_tax,
+            "CurrencyExchangeDetails": {"Rate": exchange_rate},
+            "AmountBreakdown": {"SubTotalAmount": payment_subtotal},
+        },
+    }
+    if discounts:
+        invoice["BaseCurrencyAmount"]["AmountBreakdown"] = {"Discounts": {"Breakdown": discounts}}
+    if bill_source_accounts is not None:
+        invoice["BillSourceAccounts"] = bill_source_accounts
+    return invoice
+
+
+def test_get_invoice_rate_reads_payment_currency_exchange_details():
+    invoice = build_invoice(exchange_rate="0.87")
+
+    result = get_invoice_rate(invoice)
+
+    assert result == Decimal("0.87")
+
+
+def test_get_invoice_rate_defaults_to_zero_when_missing():
+    invoice = {"PaymentCurrencyAmount": {"CurrencyCode": "EUR"}}
+
+    result = get_invoice_rate(invoice)
+
+    assert result == Decimal(0)
+
+
+@pytest.mark.parametrize(
+    ("invoice", "mpa_account", "expected"),
+    [
+        (build_invoice(account_id="MPA-123"), "MPA-123", True),
+        (build_invoice(account_id="OTHER-456"), "MPA-123", False),
+        (build_invoice(bill_source_accounts=["MPA-123", "MPA-789"]), "MPA-123", True),
+        (build_invoice(bill_source_accounts=["OTHER-456"]), "MPA-123", False),
+        (build_invoice(bill_source_accounts=[]), "MPA-123", False),
+    ],
+)
+def test_belongs_to_mpa(invoice, mpa_account, expected):
+    result = belongs_to_mpa(invoice, mpa_account)  # act
+
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    ("discounts", "expected"),
+    [
+        ([{"Description": "Discount (AWS SPP Discount)"}], True),
+        ([{"Description": "Some other discount"}], False),
+        (None, False),
+    ],
+)
+def test_is_primary_invoice(discounts, expected):
+    invoice = build_invoice(discounts=discounts)
+
+    result = is_primary_invoice(invoice)  # act
+
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    ("existing_id", "new_id", "expected"),
+    [
+        ("2609293185", "", "2609293185"),
+        ("2609293185", "SGIN26-350441", "-3185,-0441"),
+        ("-3185,-0441", "EUINPL26-355205", "-3185,-0441,-5205"),
+        ("-3185,-0441,-5205", "NEXT26-000002", "-3185,-0441,-5205,.."),
+        ("-3185,-0441,-5205,..", "NEXT26-000003", "-3185,-0441,-5205,.."),
+    ],
+)
+def test_merge_invoice_ids(existing_id, new_id, expected):
+    result = merge_invoice_ids(existing_id, new_id)  # act
+
+    assert result == expected

--- a/tests/billing/generators/test_spp_summary.py
+++ b/tests/billing/generators/test_spp_summary.py
@@ -1,0 +1,161 @@
+from decimal import Decimal
+
+from swo_aws_extension.billing.generators.billing_report_rows import (
+    ReportContext,
+    build_spp_summary_row,
+)
+from swo_aws_extension.billing.models.invoice import InvoiceEntity, OrganizationInvoice
+from swo_aws_extension.billing.models.journal_result import BillingReportRow
+
+
+def _line(mocker, amount, *, is_valid=True):
+    line = mocker.MagicMock()
+    line.price.pp_x1 = Decimal(amount)
+    line.is_valid.return_value = is_valid
+    return line
+
+
+def _context(currency="USD"):
+    return ReportContext("AUTH-1", "PMA-1", "AGR-1", "MPA-1", currency)
+
+
+def _report_row(spp_discount, exchange_rate="1.0"):
+    return BillingReportRow(
+        authorization_id="AUTH-1",
+        pma="PMA-1",
+        agreement_id="AGR-1",
+        mpa="MPA-1",
+        service_name="EC2",
+        pp=Decimal(0),
+        sp=Decimal(0),
+        currency="USD",
+        invoice_id="INV-1",
+        invoice_entity="INV-E1",
+        exchange_rate=Decimal(exchange_rate),
+        spp_discount=Decimal(spp_discount),
+        spp_discount_pct=Decimal(0),
+    )
+
+
+def _organization_invoice(
+    base_before_tax="0", payment_before_tax="0", entities=None, payment_subtotal="0"
+):
+    return OrganizationInvoice(
+        entities=entities or {},
+        base_total_amount_before_tax=Decimal(base_before_tax),
+        payment_currency_total_amount_before_tax=Decimal(payment_before_tax),
+        payment_currency_subtotal_amount=Decimal(payment_subtotal),
+    )
+
+
+def _invoice_entity(exchange_rate):
+    return InvoiceEntity(invoice_id="INV-1", exchange_rate=Decimal(exchange_rate))
+
+
+def test_build_spp_summary_row_sp_only_sums_valid_lines(mocker):
+    all_lines = [
+        _line(mocker, "100.00"),
+        _line(mocker, "50.00"),
+        _line(mocker, "999.00", is_valid=False),
+    ]
+
+    result = build_spp_summary_row(_context(), all_lines, [], _organization_invoice())
+
+    assert result.sp == Decimal("150.00")
+
+
+def test_build_spp_summary_row_pp_uses_base_currency_before_tax_for_usd(mocker):
+    organization_invoice = _organization_invoice(
+        base_before_tax="97.024883950", payment_before_tax="999.00"
+    )
+
+    result = build_spp_summary_row(_context("USD"), [], [], organization_invoice)
+
+    assert result.pp == Decimal("97.024883950")
+
+
+def test_build_spp_summary_row_pp_uses_payment_currency_before_tax_for_non_usd(mocker):
+    organization_invoice = _organization_invoice(
+        base_before_tax="999.00", payment_before_tax="90.532488395"
+    )
+
+    result = build_spp_summary_row(_context("EUR"), [], [], organization_invoice)
+
+    assert result.pp == Decimal("90.532488395")
+
+
+def test_build_spp_summary_row_discount_sums_per_service_report_rows(mocker):
+    billing_report_rows = [
+        _report_row("-0.07933332540"),
+        _report_row("-0.00491806710"),
+    ]
+
+    result = build_spp_summary_row(_context(), [], billing_report_rows, _organization_invoice())
+
+    assert result.spp_discount == Decimal("-0.07933332540") + Decimal("-0.00491806710")
+
+
+def test_build_spp_summary_row_exchange_rate_taken_from_invoice_entity(mocker):
+    organization_invoice = _organization_invoice(
+        entities={"ENT-1": _invoice_entity("0.8664846127")}
+    )
+
+    result = build_spp_summary_row(_context(), [], [], organization_invoice)
+
+    assert result.exchange_rate == Decimal("0.8664846127")
+
+
+def test_build_spp_summary_row_exchange_rate_falls_back_to_another_entity(mocker):
+    organization_invoice = _organization_invoice(
+        entities={
+            "ENT-NO-RATE": _invoice_entity("0"),
+            "ENT-WITH-RATE": _invoice_entity("0.8664846127"),
+        }
+    )
+
+    result = build_spp_summary_row(_context(), [], [], organization_invoice)
+
+    assert result.exchange_rate == Decimal("0.8664846127")
+
+
+def test_build_spp_summary_row_defaults_exchange_rate_when_no_entities(mocker):
+    result = build_spp_summary_row(_context(), [], [], _organization_invoice())
+
+    assert result.exchange_rate == Decimal("1.0")
+
+
+def test_build_spp_summary_row_list_price_taken_from_payment_currency_subtotal(mocker):
+    organization_invoice = _organization_invoice(payment_subtotal="123.456789")
+
+    result = build_spp_summary_row(_context(), [], [], organization_invoice)
+
+    assert result.list_price == Decimal("123.456789")
+
+
+def test_build_spp_summary_row_discount_pct_uses_full_precision(mocker):
+    organization_invoice = _organization_invoice(base_before_tax="90.00")
+    billing_report_rows = [_report_row("-10.00")]
+
+    result = build_spp_summary_row(_context(), [], billing_report_rows, organization_invoice)
+
+    assert result.spp_discount_pct == Decimal("10.00") / Decimal("90.00")
+
+
+def test_build_spp_summary_row_zero_pp_guards_percentage(mocker):
+    billing_report_rows = [_report_row("-10.00")]
+
+    result = build_spp_summary_row(_context(), [], billing_report_rows, _organization_invoice())
+
+    assert result.pp == Decimal(0)
+    assert result.spp_discount_pct == Decimal(0)
+    assert result.markup == Decimal(0)
+
+
+def test_build_spp_summary_row_markup_uses_full_precision(mocker):
+    all_lines = [_line(mocker, "100.00")]
+    organization_invoice = _organization_invoice(base_before_tax="90.00")
+
+    result = build_spp_summary_row(_context(), all_lines, [], organization_invoice)
+
+    expected_markup = (Decimal("100.00") - Decimal("90.00")) / Decimal("90.00")
+    assert result.markup == expected_markup

--- a/tests/billing/models/test_journal_result.py
+++ b/tests/billing/models/test_journal_result.py
@@ -1,6 +1,56 @@
+from decimal import Decimal
+
 import pytest
 
-from swo_aws_extension.billing.models.journal_result import PlsMismatch
+from swo_aws_extension.billing.models.journal_result import (
+    AgreementJournalResult,
+    AuthorizationJournalResult,
+    OrganizationSppSummaryRow,
+    PlsMismatch,
+)
+
+
+def _build_spp_summary_row():
+    return OrganizationSppSummaryRow(
+        authorization_id="AUTH-1",
+        pma="PMA-1",
+        agreement_id="AGR-1",
+        mpa="MPA-1",
+        pp=Decimal("90.0"),
+        sp=Decimal("100.0"),
+        currency="USD",
+        exchange_rate=Decimal("1.0"),
+        spp_discount=Decimal("-10.0"),
+        spp_discount_pct=Decimal("0.1111"),
+        list_price=Decimal("120.0"),
+        markup=Decimal("0.1111"),
+    )
+
+
+def test_organization_spp_summary_row_equality():
+    result = _build_spp_summary_row()
+
+    assert result == _build_spp_summary_row()
+
+
+def test_agreement_journal_result_defaults_spp_summary_row_to_none():
+    result = AgreementJournalResult()
+
+    assert result.spp_summary_row is None
+
+
+def test_agreement_journal_result_carries_spp_summary_row():
+    row = _build_spp_summary_row()
+
+    result = AgreementJournalResult(spp_summary_row=row)
+
+    assert result.spp_summary_row == row
+
+
+def test_authorization_journal_result_defaults_spp_summary_rows_to_empty_list():
+    result = AuthorizationJournalResult()
+
+    assert result.spp_summary_rows == []
 
 
 @pytest.mark.parametrize(

--- a/tests/billing/test_billing_journal_service.py
+++ b/tests/billing/test_billing_journal_service.py
@@ -20,6 +20,7 @@ from swo_aws_extension.billing.models.journal_result import (
     AuthorizationJournalResult,
     BillingReportRow,
     InvoiceAttachmentResult,
+    OrganizationSppSummaryRow,
     PlsMismatch,
 )
 from swo_aws_extension.billing.models.usage import OrganizationReport
@@ -153,7 +154,48 @@ def test_processes_authorizations_creates_billing_report(
     service.run()  # act
 
     mock_report_creator.create_and_notify_teams.assert_called_once_with(
-        str(mock_context.billing_period), [mock_row], []
+        str(mock_context.billing_period), [mock_row], [], []
+    )
+
+
+def test_processes_authorizations_passes_spp_summary_rows(
+    mocker, mock_context, mock_get_authorizations, mock_auth_generator_cls
+):
+    mock_context.dry_run = False
+    authorization = {"id": "AUTH-1"}
+    mock_get_authorizations.return_value = [authorization]
+    mock_line = mocker.MagicMock(spec=JournalLine)
+    mock_row = mocker.MagicMock(spec=BillingReportRow)
+    spp_summary_row = OrganizationSppSummaryRow(
+        authorization_id="AUTH-1",
+        pma="PMA-1",
+        agreement_id="AGR-1",
+        mpa="MPA-1",
+        pp=Decimal("90.0"),
+        sp=Decimal("100.0"),
+        currency="USD",
+        exchange_rate=Decimal("1.0"),
+        spp_discount=Decimal("-10.0"),
+        spp_discount_pct=Decimal("0.1111"),
+        list_price=Decimal("120.0"),
+        markup=Decimal("0.1111"),
+    )
+    mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
+    mock_auth_gen.run.return_value = AuthorizationJournalResult(
+        lines=[mock_line],
+        billing_report_rows=[mock_row],
+        spp_summary_rows=[spp_summary_row],
+    )
+    mock_auth_generator_cls.return_value = mock_auth_gen
+    mocker.patch(f"{MODULE}.JournalManager", autospec=True)
+    mock_report_creator_cls = mocker.patch(f"{MODULE}.BillingReportCreator", autospec=True)
+    mock_report_creator = mock_report_creator_cls.return_value
+    service = BillingJournalService(mock_context)
+
+    service.run()  # act
+
+    mock_report_creator.create_and_notify_teams.assert_called_once_with(
+        str(mock_context.billing_period), [mock_row], [], [spp_summary_row]
     )
 
 

--- a/tests/billing/test_billing_report_creator.py
+++ b/tests/billing/test_billing_report_creator.py
@@ -3,8 +3,12 @@ from decimal import Decimal
 import pytest
 
 from swo_aws_extension.billing.billing_report_creator import BillingReportCreator
-from swo_aws_extension.billing.models.journal_result import BillingReportRow
+from swo_aws_extension.billing.models.journal_result import (
+    BillingReportRow,
+    OrganizationSppSummaryRow,
+)
 from swo_aws_extension.config import Config
+from swo_aws_extension.swo.excel_report_builder import Percent
 from swo_aws_extension.swo.notifications.teams import TeamsNotificationManager
 
 MODULE = "swo_aws_extension.billing.billing_report_creator"
@@ -46,6 +50,24 @@ def sample_row():
         exchange_rate=Decimal("1.2"),
         spp_discount=Decimal("-1.0"),
         spp_discount_pct=Decimal("1.0") / Decimal("11.5"),
+    )
+
+
+@pytest.fixture
+def sample_spp_summary_row():
+    return OrganizationSppSummaryRow(
+        authorization_id="AUTH-1",
+        pma="PMA-1",
+        agreement_id="AGR-1",
+        mpa="MPA-1",
+        pp=Decimal("90.0"),
+        sp=Decimal("100.0"),
+        currency="USD",
+        exchange_rate=Decimal("1.0"),
+        spp_discount=Decimal("-10.0"),
+        spp_discount_pct=Decimal("1.0") / Decimal("9.0"),
+        list_price=Decimal("120.0"),
+        markup=Decimal("10.0") / Decimal("90.0"),
     )
 
 
@@ -91,7 +113,7 @@ def test_create_and_notify_teams_upload_failure(
     mock_notifier.send_error.assert_called_once()
 
 
-def test_create_and_notify_teams_converts_decimals_to_string(
+def test_create_and_notify_teams_converts_decimals_to_numeric(
     mock_config, mock_notifier, mock_blob_uploader_cls, mock_excel_builder_cls, sample_row
 ):
     mock_excel_builder = mock_excel_builder_cls.return_value
@@ -103,22 +125,22 @@ def test_create_and_notify_teams_converts_decimals_to_string(
 
     call_args = mock_excel_builder.build_multi_sheet.call_args[0][0]
     sheet1_name, _, sheet1_rows = call_args[0]
-    assert sheet1_name == "Billing Report"
     expected_row = [
         "AUTH-1",
         "PMA-1",
         "AGR-1",
         "MPA-1",
         "EC2",
-        "10.5",
-        "11.5",
+        10.5,
+        11.5,
         "USD",
         "INV-1",
         "INV-E1",
-        "1.2",
-        "-1.0",
-        "0,0870 (8.70%)",
+        1.2,
+        -1.0,
+        Percent(float(sample_row.spp_discount_pct)),
     ]
+    assert sheet1_name == "Billing Report"
     assert sheet1_rows == [expected_row]
 
 
@@ -150,6 +172,71 @@ def test_create_and_notify_teams_builds_by_account_sheet(
 
     call_args = mock_excel_builder.build_multi_sheet.call_args[0][0]
     sheet2_name, sheet2_headers, sheet2_rows = call_args[1]
+    expected_row = [
+        "AUTH-1",
+        "PMA-1",
+        "AGR-1",
+        "MPA-1",
+        "ACC-001",
+        "EC2",
+        10.5,
+        11.5,
+        "USD",
+        "INV-1",
+        "INV-E1",
+        1.2,
+        -1.0,
+        Percent(float(by_account_row.spp_discount_pct)),
+    ]
     assert sheet2_name == "By Linked Account"
     assert "Linked Account" in sheet2_headers
-    assert sheet2_rows[0][4] == "ACC-001"
+    assert sheet2_rows == [expected_row]
+
+
+def test_create_and_notify_teams_builds_spp_summary_sheet(
+    mock_config,
+    mock_notifier,
+    mock_blob_uploader_cls,
+    mock_excel_builder_cls,
+    sample_row,
+    sample_spp_summary_row,
+):
+    mock_excel_builder = mock_excel_builder_cls.return_value
+    mock_excel_builder.build_multi_sheet.return_value = b"excel_bytes"
+    mock_blob_uploader_cls.return_value.upload_and_get_sas_url.return_value = "https://url"
+    creator = BillingReportCreator(mock_config, mock_notifier)
+
+    creator.create_and_notify_teams("2024-01", [sample_row], None, [sample_spp_summary_row])  # act
+
+    call_args = mock_excel_builder.build_multi_sheet.call_args[0][0]
+    sheet3_name, sheet3_headers, sheet3_rows = call_args[2]
+    assert sheet3_name == "SPP Summary"
+    assert list(sheet3_headers) == [
+        "Authorization ID",
+        "PMA",
+        "Agreement ID",
+        "MPA",
+        "PP",
+        "SP",
+        "Currency",
+        "Exchange Rate",
+        "SPP Discount",
+        "SPP Discount %",
+        "List price",
+        "Markup",
+    ]
+    expected_row = [
+        "AUTH-1",
+        "PMA-1",
+        "AGR-1",
+        "MPA-1",
+        90.0,
+        100.0,
+        "USD",
+        1.0,
+        -10.0,
+        Percent(float(sample_spp_summary_row.spp_discount_pct)),
+        120.0,
+        Percent(float(sample_spp_summary_row.markup)),
+    ]
+    assert sheet3_rows == [expected_row]

--- a/tests/swo/test_excel_report_builder.py
+++ b/tests/swo/test_excel_report_builder.py
@@ -1,8 +1,11 @@
 from io import BytesIO
 
+import pytest
 from openpyxl import load_workbook
 
-from swo_aws_extension.swo.excel_report_builder import ExcelReportBuilder
+from swo_aws_extension.swo.excel_report_builder import ExcelReportBuilder, Percent
+
+MARKUP_RATIO = 0.012354234234
 
 
 def test_build_from_rows_creates_valid_excel():
@@ -54,6 +57,24 @@ def test_build_multi_sheet_creates_multiple_sheets():
     returns_ws = wb["Returns"]
     assert returns_ws.cell(row=1, column=1).value == "Item"
     assert returns_ws.cell(row=2, column=1).value == "Widget"
+
+
+def test_build_multi_sheet_applies_percent_format_to_percent_values():
+    builder = ExcelReportBuilder([], "Unused")
+    sheets = [
+        ("Summary", ["Name", "Markup"], [["Acme", Percent(MARKUP_RATIO)]]),
+    ]
+
+    result = builder.build_multi_sheet(sheets)
+
+    wb = load_workbook(filename=BytesIO(result))
+    ws = wb["Summary"]
+    markup_cell = ws.cell(row=2, column=2)
+    assert markup_cell.value == pytest.approx(MARKUP_RATIO)
+    assert isinstance(markup_cell.value, float)
+    assert markup_cell.number_format == "0.###################%"
+    name_cell = ws.cell(row=2, column=1)
+    assert name_cell.number_format == "General"
 
 
 def test_build_from_rows_keeps_existing_sheet_title(mocker):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add a new "SPP Summary" sheet to the billing Excel report: one row per
agreement reconciling the true journal total (SP) against the AWS
invoice's before-tax total (PP).

## Why

The existing report's SP was computed from raw AWS Cost Explorer usage
data, independent of the actual journal, so whenever the PLS charge or
extra-discount processors added lines the report no longer matched the
journal total. There was also no way to reconcile the markup applied
between what AWS invoices (PP) and what's billed to the customer (SP).

## Change

- New `OrganizationSppSummaryRow` model and `build_spp_summary_row()`
  builder in `billing_report_rows.py`.
- SP = sum of generated journal line amounts (including the PLS charge
  and extra-discount lines).
- PP = AWS invoice's before-tax total (`BaseCurrencyAmount.TotalAmountBeforeTax`
  for USD, `PaymentCurrencyAmount.TotalAmountBeforeTax` otherwise).
- SPP Discount = sum of the already-precise per-service Cost Explorer
  discount values used by the other two sheets, since the AWS invoice's
  own discount breakdown is only accurate to the cent and would
  misalign markup calculations.
- Exchange Rate picks the best available per-entity rate, falling back
  to another entity's rate the same way the journal's
  `ExchangeRateResolver` already does when one entity has none.
- Markup = `(SP - PP) / PP`, left unrounded so `PP` can be reconstructed
  exactly downstream as `SP / (1 + markup)`.
- Wired through `AgreementJournalGenerator` → `AuthorizationJournalGenerator`
  → `BillingJournalService` → `BillingReportCreator`, adding a third
  "SPP Summary" Excel sheet alongside the existing two.

## Testing

- `make check-all`: all checks pass, 1106 passed, 1 xpassed, 99% coverage.

Jira: MPT-23245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23245](https://softwareone.atlassian.net/browse/MPT-23245)

- Adds an **“SPP Summary”** worksheet to the billing Excel report with one row per agreement, reconciling journal SP (true journal total) against AWS invoice PP (before-tax total).
- Introduces `OrganizationSppSummaryRow` and `build_spp_summary_row(...)` to compute SP, PP (USD vs non-USD), best-available exchange rate (with fallback), precise SPP discount, Excel-native **SPP Discount %**, and an unrounded **Markup**.
- Wires SPP summary generation through the journal/billing flow and threads `spp_summary_rows` into `BillingReportCreator` to produce a **three-sheet** workbook (Billing Report, By Linked Account, SPP Summary).
- Enhances Excel export to support native percent values via a new `Percent` type, and updates billing sheet row building to use numeric Excel cells (floats/Percent) instead of formatted strings.
- Adds/updates tests covering `get_invoice_rate`, `build_spp_summary_row` computations, journal result wiring for `spp_summary_rows`, workbook multi-sheet output (including headers/row values), and percent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23245]: https://softwareone.atlassian.net/browse/MPT-23245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ