### PR TITLE
MPT-23379 enable boto3 standard retry mode for AWS clients

### DIFF
--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Callable
 
 import boto3
+from botocore.config import Config as BotoConfig
 
 from swo_aws_extension.aws.errors import (
     AWSError,
@@ -15,6 +16,9 @@ from swo_aws_extension.swo.openid.client import OpenIDClient
 
 MINIMUM_DAYS_MONTH = 28
 MAX_RESULTS_PER_PAGE = 20
+# Standard mode retries throttling, server (5xx) and connection errors with
+# exponential backoff and jitter, keeping the default total max attempts.
+BOTO3_CLIENT_CONFIG = BotoConfig(retries={"mode": "standard"})
 
 logger = logging.getLogger(__name__)
 
@@ -399,7 +403,7 @@ class AWSClient:
             raise AWSError("Parameter 'account_id' must be provided to assume the role.")
 
         role_arn = f"arn:aws:iam::{self.account_id}:role/{self.role_name}"
-        response = boto3.client("sts").assume_role_with_web_identity(
+        response = boto3.client("sts", config=BOTO3_CLIENT_CONFIG).assume_role_with_web_identity(
             RoleArn=role_arn,
             RoleSessionName="SWOExtensionOnboardingSession",
             WebIdentityToken=self._openid_client.fetch_access_token(self.config.aws_openid_scope),
@@ -421,6 +425,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
         )
 
     def _get_sts_client(self):
@@ -429,6 +434,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
         )
 
     def _get_cost_explorer_client(self):
@@ -443,6 +449,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )
 
@@ -458,6 +465,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )
 
@@ -473,6 +481,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
         )
 
     def _get_partner_central_client(self):
@@ -487,6 +496,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )
 
@@ -502,6 +512,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )
 

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -1,5 +1,6 @@
 import datetime as dt
 
+import boto3
 import pytest
 from botocore.exceptions import ClientError
 
@@ -724,6 +725,34 @@ def test_list_invoice_summaries_success(config, aws_client_factory, mock_get_pag
     assert len(result) == 1
     assert result[0]["InvoiceId"] == "INV-001"
     mock_get_paged_response.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "client_getter",
+    [
+        "_get_organization_client",
+        "_get_sts_client",
+        "_get_cost_explorer_client",
+        "_get_billing_client",
+        "_get_billing_conductor_client",
+        "_get_partner_central_client",
+        "_get_invoicing_client",
+    ],
+)
+def test_boto3_clients_use_standard_retry_mode(config, aws_client_factory, client_getter):
+    mock_aws_client, _ = aws_client_factory(config, "test_account_id", "test_role_name")
+
+    getattr(mock_aws_client, client_getter)()  # act
+
+    client_config = boto3.client.call_args.kwargs["config"]
+    assert client_config.retries == {"mode": "standard"}
+
+
+def test_assume_role_uses_standard_retry_mode(config, aws_client_factory):
+    aws_client_factory(config, "test_account_id", "test_role_name")  # act
+
+    assume_role_call = boto3.client.call_args_list[0]
+    assert assume_role_call.kwargs["config"].retries == {"mode": "standard"}
 
 
 def test_get_linked_accounts_with_usage(mocker):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Configured every boto3 client created by `AWSClient` with a shared botocore `Config` using the `standard` retry mode, keeping the default total max attempts:

- Added a module-level `BOTO3_CLIENT_CONFIG = BotoConfig(retries={"mode": "standard"})` in `swo_aws_extension/aws/client.py` (imported as `BotoConfig` to avoid clashing with the extension's own `Config` class).
- Passed `config=BOTO3_CLIENT_CONFIG` to all seven boto3 clients created by `AWSClient` (organizations, sts, cost explorer, billing, billingconductor, partnercentral-channel, invoicing).
- Added a unit test asserting the clients are created with the `standard` retry mode.

## Why

The boto3 default (`legacy`) retry mode only covers a limited set of errors and services. The `standard` mode retries throttling, server (5xx) and connection errors with exponential backoff and jitter, per the [boto3 retries guide](https://docs.aws.amazon.com/boto3/latest/guide/retries.html#available-configuration-options).

Jira: [MPT-23379](https://softwareone.atlassian.net/browse/MPT-23379)


[MPT-23379]: https://softwareone.atlassian.net/browse/MPT-23379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Configures all boto3/AWS clients created by `AWSClient` to use a shared botocore `Config` with `retries.mode=standard` (including the STS client used for `assume_role_with_web_identity`).
- Adds unit tests verifying that all targeted boto3 client constructions receive the shared standard retry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->