### PR TITLE
MPT-23324 propagate complete AWS invoice IDs through journal results

### DIFF
--- a/swo_aws_extension/billing/billing_journal_service.py
+++ b/swo_aws_extension/billing/billing_journal_service.py
@@ -52,6 +52,12 @@ def _log_dry_run_results(
     ]
     if attachments:
         logger.info("%s - [DRY-RUN] Attachments: %s", authorization_id, attachments)
+    if generator_result.invoice_ids:
+        logger.info(
+            "%s - [DRY-RUN] Invoice IDs: %s",
+            authorization_id,
+            sorted(generator_result.invoice_ids),
+        )
 
 
 class BillingJournalService:

--- a/swo_aws_extension/billing/generators/agreement.py
+++ b/swo_aws_extension/billing/generators/agreement.py
@@ -111,6 +111,7 @@ class AgreementJournalGenerator:
             usage_result,
             journal_details,
             invoice_result.invoice,
+            invoice_result.invoice_ids,
         )
         logger.info("Generated %d journal lines", len(agreement_result.lines))
         return agreement_result
@@ -121,6 +122,7 @@ class AgreementJournalGenerator:
         usage_result: OrganizationUsageResult,
         journal_details: JournalDetails,
         organization_invoice,
+        invoice_ids: set[str],
     ) -> AgreementJournalResult:
         pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
         report_has_enterprise = usage_result.has_enterprise_support()
@@ -161,6 +163,7 @@ class AgreementJournalGenerator:
             billing_report_rows=report_builder.build(),
             billing_report_rows_by_account=report_builder.build_by_account(),
             pls_mismatches=pls_mismatches,
+            invoice_ids=invoice_ids,
         )
 
     def _generate_usage_lines(

--- a/swo_aws_extension/billing/generators/authorization.py
+++ b/swo_aws_extension/billing/generators/authorization.py
@@ -139,6 +139,7 @@ class AuthorizationJournalGenerator:
             )
         if agreement_result.pls_mismatches:
             result.pls_mismatches.extend(agreement_result.pls_mismatches)
+        result.invoice_ids.update(agreement_result.invoice_ids)
 
     def _apply_pma_usage_to_report(
         self,

--- a/swo_aws_extension/billing/models/invoice.py
+++ b/swo_aws_extension/billing/models/invoice.py
@@ -50,3 +50,8 @@ class OrganizationInvoiceResult:
 
     raw_data: list[dict] = field(default_factory=list)
     invoice: OrganizationInvoice = field(default_factory=OrganizationInvoice)
+
+    @property
+    def invoice_ids(self) -> set[str]:
+        """The complete AWS invoice IDs present in the raw invoice summaries."""
+        return {summary["InvoiceId"] for summary in self.raw_data if summary.get("InvoiceId")}

--- a/swo_aws_extension/billing/models/journal_result.py
+++ b/swo_aws_extension/billing/models/journal_result.py
@@ -53,6 +53,7 @@ class AgreementJournalResult:
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
     billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)
+    invoice_ids: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -64,3 +65,4 @@ class AuthorizationJournalResult:
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
     billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)
+    invoice_ids: set[str] = field(default_factory=set)

--- a/tests/billing/generators/test_agreement.py
+++ b/tests/billing/generators/test_agreement.py
@@ -149,6 +149,12 @@ def test_run(
     mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
     mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
         invoice=OrganizationInvoice(),
+        raw_data=[
+            {"InvoiceId": "INV-001"},
+            {"InvoiceId": "INV-001"},
+            {"InvoiceId": "INV-002"},
+            {"InvoicingEntity": "AWS Inc."},
+        ],
     )
     generator = AgreementJournalGenerator(
         _build_auth_context(mock_aws_client),
@@ -160,6 +166,7 @@ def test_run(
     result = generator.run(agreement)
 
     assert result.lines == [mock_journal_line, mock_discount_line, mock_pls_line]
+    assert result.invoice_ids == {"INV-001", "INV-002"}
     mock_invoice_generator.run.assert_called_once()
     mock_generator_instance.generate.assert_called_once()
     mock_pls_instance.process.assert_called_once()

--- a/tests/billing/generators/test_authorization.py
+++ b/tests/billing/generators/test_authorization.py
@@ -101,7 +101,10 @@ def test_processes_agreements(
     mock_get_agreements.return_value = [{"id": "AGR-1"}, {"id": "AGR-2"}]
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_agr_gen = mocker.MagicMock(spec=AgreementJournalGenerator)
-    mock_agr_gen.run.return_value = AgreementJournalResult(lines=[mock_journal_line])
+    mock_agr_gen.run.side_effect = [
+        AgreementJournalResult(lines=[mock_journal_line], invoice_ids={"INV-001"}),
+        AgreementJournalResult(lines=[mock_journal_line], invoice_ids={"INV-001", "INV-002"}),
+    ]
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
 
@@ -109,6 +112,7 @@ def test_processes_agreements(
 
     assert mock_agr_gen.run.call_count == 2
     assert result.lines == [mock_journal_line, mock_journal_line]
+    assert result.invoice_ids == {"INV-001", "INV-002"}
 
 
 def test_exception_sends_error(

--- a/tests/billing/models/test_invoice.py
+++ b/tests/billing/models/test_invoice.py
@@ -5,6 +5,7 @@ import pytest
 from swo_aws_extension.billing.models.invoice import (
     InvoiceEntity,
     OrganizationInvoice,
+    OrganizationInvoiceResult,
 )
 
 PRIMARY_ENTITY_NAME = "AWS EMEA SARL"
@@ -100,3 +101,22 @@ def test_primary_invoice_id_returns_default_when_no_entities():
     result = invoice.primary_invoice_id
 
     assert result == "invoice_id"
+
+
+def test_invoice_ids_deduplicates_and_skips_missing_ids():
+    result = OrganizationInvoiceResult(
+        raw_data=[
+            {"InvoiceId": PRIMARY_INVOICE_ID},
+            {"InvoiceId": PRIMARY_INVOICE_ID},
+            {"InvoiceId": SECONDARY_INVOICE_ID},
+            {"InvoicingEntity": SECONDARY_ENTITY_NAME},
+        ],
+    )
+
+    assert result.invoice_ids == {PRIMARY_INVOICE_ID, SECONDARY_INVOICE_ID}
+
+
+def test_invoice_ids_returns_empty_when_no_raw_data():
+    result = OrganizationInvoiceResult()
+
+    assert result.invoice_ids == set()

--- a/tests/billing/test_billing_journal_service.py
+++ b/tests/billing/test_billing_journal_service.py
@@ -223,6 +223,7 @@ def test_dry_run_skips_upload(
     mock_auth_gen.run.return_value = AuthorizationJournalResult(
         lines=[mock_line],
         reports_by_agreement={"AGR-1": report},
+        invoice_ids={"INV-001"},
     )
     mock_auth_generator_cls.return_value = mock_auth_gen
     mock_journal_manager_cls = mocker.patch(f"{MODULE}.JournalManager", autospec=True)


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

First slice of [MPT-23323](https://softwareone.atlassian.net/browse/MPT-23323) (attach AWS invoice PDF documents to billing journals), covering the invoice ID identification and propagation described in the [TDR](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/7688683583):

- Added an `invoice_ids` property to `OrganizationInvoiceResult` that extracts the complete AWS invoice IDs from the raw (MPA-filtered) invoice summaries, skipping entries without an `InvoiceId`.
- Added an `invoice_ids: set[str]` field to `AgreementJournalResult` and `AuthorizationJournalResult`; the authorization generator aggregates the IDs from every agreement, deduplicated by construction.
- `_log_dry_run_results` logs the collected invoice IDs during `--dry-run` for verification.

The complete invoice IDs are required by the AWS `GetInvoicePDF` API; the abbreviated invoice reference used in journal lines (NAV 20-character limit) cannot be used for document retrieval. No behaviour changes outside dry-run logging: journal lines, reports and attachments remain unchanged.

Jira: [MPT-23324](https://softwareone.atlassian.net/browse/MPT-23324)


[MPT-23323]: https://softwareone.atlassian.net/browse/MPT-23323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23324]: https://softwareone.atlassian.net/browse/MPT-23324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23324](https://softwareone.atlassian.net/browse/MPT-23324)

- Propagate complete AWS invoice IDs through organization invoice, agreement journal, and authorization journal results.
- Add `invoice_ids` sets to `AgreementJournalResult` and `AuthorizationJournalResult`, deduplicating across agreements.
- Extract `invoice_ids` from `OrganizationInvoiceResult.raw_data`, skipping entries without `InvoiceId`.
- Log collected invoice IDs during `--dry-run` (without changing journal lines, reports, or attachments).
- Extend tests to cover invoice ID extraction, deduplication/aggregation, and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->