### PR TITLE
MPT-23325 add AWSClient.get_invoice_pdf with resource-not-found retry

### DIFF
--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import logging
+import time
 from collections.abc import Callable
 
 import boto3
@@ -16,6 +17,7 @@ from swo_aws_extension.swo.openid.client import OpenIDClient
 
 MINIMUM_DAYS_MONTH = 28
 MAX_RESULTS_PER_PAGE = 20
+INVOICE_PDF_MAX_ATTEMPTS = 3
 # Standard mode retries throttling, server (5xx) and connection errors with
 # exponential backoff and jitter, keeping the default total max attempts.
 BOTO3_CLIENT_CONFIG = BotoConfig(retries={"mode": "standard"})
@@ -374,6 +376,27 @@ class AWSClient:
                 "Filter": {"BillingPeriod": {"Month": month, "Year": year}},
             },
         )
+
+    @wrap_boto3_error
+    def get_invoice_pdf(self, invoice_id: str) -> dict:
+        """Return AWS invoice PDF metadata for an invoice.
+
+        ResourceNotFoundException (PDF not yet generated) is retried with
+        exponential backoff before giving up; other errors rely on boto3's
+        built-in retries.
+        """
+        invoicing_client = self._get_invoicing_client()
+        attempt = 1
+        while True:
+            try:
+                return invoicing_client.get_invoice_pdf(InvoiceId=invoice_id)
+            except invoicing_client.exceptions.ResourceNotFoundException:
+                # Raised while the PDF is not yet generated; boto3 never retries it,
+                # unlike throttling and 5xx errors, which boto3 retries itself.
+                if attempt >= INVOICE_PDF_MAX_ATTEMPTS:
+                    raise
+                time.sleep(2 ** (attempt - 1))
+                attempt += 1
 
     def _build_cost_and_usage_params(
         self,

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -22,6 +22,18 @@ class InvalidInputException(ClientError):  # noqa: N818
     """Dummy exception for testing purposes."""
 
 
+class ResourceNotFoundException(ClientError):  # noqa: N818
+    """Dummy exception for testing purposes."""
+
+
+@pytest.fixture
+def resource_not_found_error():
+    return ResourceNotFoundException(
+        {"Error": {"Code": "ResourceNotFoundException"}},
+        "GetInvoicePDF",
+    )
+
+
 @pytest.fixture
 def mock_get_paged_response(mocker):
     return mocker.patch("swo_aws_extension.aws.client.get_paged_response", spec=True)
@@ -753,6 +765,72 @@ def test_assume_role_uses_standard_retry_mode(config, aws_client_factory):
 
     assume_role_call = boto3.client.call_args_list[0]
     assert assume_role_call.kwargs["config"].retries == {"mode": "standard"}
+
+
+def test_get_invoice_pdf_success(config, aws_client_factory):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    response = {"InvoicePDF": {"DocumentUrl": "https://example.test/invoice.pdf"}}
+    mock_client.get_invoice_pdf.return_value = response
+
+    result = mock_aws_client.get_invoice_pdf("INV-001")
+
+    assert result == response
+    mock_client.get_invoice_pdf.assert_called_once_with(InvoiceId="INV-001")
+
+
+def test_get_invoice_pdf_retries_not_found(
+    mocker, config, aws_client_factory, resource_not_found_error
+):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+    response = {"InvoicePDF": {"DocumentUrl": "https://example.test/invoice.pdf"}}
+    mock_client.get_invoice_pdf.side_effect = [
+        resource_not_found_error,
+        resource_not_found_error,
+        response,
+    ]
+    mock_sleep = mocker.patch("swo_aws_extension.aws.client.time.sleep", autospec=True)
+
+    result = mock_aws_client.get_invoice_pdf("INV-001")
+
+    assert result == response
+    assert mock_client.get_invoice_pdf.call_count == 3
+    assert mock_sleep.call_args_list == [mocker.call(1), mocker.call(2)]
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["AccessDeniedException", "ThrottlingException", "InternalServerException"],
+)
+def test_get_invoice_pdf_skips_other_errors(mocker, config, aws_client_factory, error_code):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+    mock_client.get_invoice_pdf.side_effect = ClientError(
+        {"Error": {"Code": error_code}},
+        "GetInvoicePDF",
+    )
+    mock_sleep = mocker.patch("swo_aws_extension.aws.client.time.sleep", autospec=True)
+
+    with pytest.raises(AWSError, match=error_code):
+        mock_aws_client.get_invoice_pdf("INV-001")
+
+    mock_client.get_invoice_pdf.assert_called_once_with(InvoiceId="INV-001")
+    mock_sleep.assert_not_called()
+
+
+def test_get_invoice_pdf_stops_after_three_tries(
+    mocker, config, aws_client_factory, resource_not_found_error
+):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+    mock_client.get_invoice_pdf.side_effect = resource_not_found_error
+    mock_sleep = mocker.patch("swo_aws_extension.aws.client.time.sleep", autospec=True)
+
+    with pytest.raises(AWSError, match="ResourceNotFoundException"):
+        mock_aws_client.get_invoice_pdf("INV-001")
+
+    assert mock_client.get_invoice_pdf.call_count == 3
+    assert mock_sleep.call_args_list == [mocker.call(1), mocker.call(2)]
 
 
 def test_get_linked_accounts_with_usage(mocker):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Second slice of [MPT-23323](https://softwareone.atlassian.net/browse/MPT-23323) (attach AWS invoice PDF documents to billing journals), covering the invoice document retrieval operation described in the [TDR](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/7688683583):

- Added `AWSClient.get_invoice_pdf(invoice_id)` calling the AWS Invoicing [`GetInvoicePDF`](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_invoicing_GetInvoicePDF.html) API, which returns the pre-signed URL for downloading the invoice PDF document.
- `ResourceNotFoundException` (invoice PDF not yet generated) is retried up to 3 attempts with exponential backoff (1s, 2s) — it is the only error boto3 never retries. Other errors (throttling, 5xx, access denied) rely on boto3's built-in retries and propagate through the existing `wrap_boto3_error` pattern.

Note: calling this operation requires the `invoicing:GetInvoicePDF` IAM permission on the AWS billing role ([MPT-23327](https://softwareone.atlassian.net/browse/MPT-23327), external dependency). The operation is not wired into the billing flow yet — that lands with [MPT-23326](https://softwareone.atlassian.net/browse/MPT-23326).

Jira: [MPT-23325](https://softwareone.atlassian.net/browse/MPT-23325)


[MPT-23323]: https://softwareone.atlassian.net/browse/MPT-23323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23327]: https://softwareone.atlassian.net/browse/MPT-23327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23325](https://softwareone.atlassian.net/browse/MPT-23325)

- Adds `AWSClient.get_invoice_pdf(invoice_id)` to call AWS Invoicing `GetInvoicePDF` and return the pre-signed invoice PDF download URL/metadata
- Retries `ResourceNotFoundException` up to 3 attempts with exponential backoff (1s, then 2s); other errors use existing boto3 retry behavior and are wrapped via `wrap_boto3_error`
- Adds tests covering successful response passthrough, `ResourceNotFoundException` retry/sleep behavior, immediate failure (no retries/sleeps) for other error codes, and the stop-after-three-attempts condition
- Requires `invoicing:GetInvoicePDF` IAM permission; not yet integrated into the billing flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->