### PR TITLE
MPT-23326 add invoice PDF download and billing AWS client provider

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ The runtime is organised as a pipeline-driven fulfilment flow:
 | `swo_aws_extension/flows/jobs/` | Background jobs: reports, FinOps entitlement sync, MPT subscription sync for linked AWS accounts |
 | `swo_aws_extension/billing/` | Billing journal generation, line processors, generators, and models |
 | `swo_aws_extension/processor/` | Chain-of-responsibility processors for querying AWS roles, handshakes, transfers |
-| `swo_aws_extension/aws/` | `AWSClient` (boto3 AssumeRole, account/billing/CUR operations, Cost Explorer with dimension attributes) |
+| `swo_aws_extension/aws/` | `AWSClient` (boto3 AssumeRole, account/billing/CUR operations, Cost Explorer with dimension attributes, Invoicing summaries and invoice document retrieval) |
 | `swo_aws_extension/swo/` | External-service clients (CCP, CRM, FinOps, CCO, Cloud Orchestrator, MPT, Key Vault, Blob, notifications, OpenID) |
 | `swo_aws_extension/airtable/` | FinOps entitlements Airtable sync |
 | `swo_aws_extension/management/` | Django management commands run by the worker |

--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import Callable
 
 import boto3
+import requests
 from botocore.config import Config as BotoConfig
 
 from swo_aws_extension.aws.errors import (
@@ -18,6 +19,7 @@ from swo_aws_extension.swo.openid.client import OpenIDClient
 MINIMUM_DAYS_MONTH = 28
 MAX_RESULTS_PER_PAGE = 20
 INVOICE_PDF_MAX_ATTEMPTS = 3
+INVOICE_PDF_DOWNLOAD_TIMEOUT_SECONDS = 60
 # Standard mode retries throttling, server (5xx) and connection errors with
 # exponential backoff and jitter, keeping the default total max attempts.
 BOTO3_CLIENT_CONFIG = BotoConfig(retries={"mode": "standard"})
@@ -397,6 +399,39 @@ class AWSClient:
                     raise
                 time.sleep(2 ** (attempt - 1))
                 attempt += 1
+
+    @wrap_boto3_error
+    def download_invoice_pdf(self, invoice_id: str) -> bytes:
+        """Return the AWS invoice PDF document content for an invoice.
+
+        Resolves the pre-signed URL via GetInvoicePDF and downloads its content.
+        The URL is used immediately and never stored.
+        """
+        invoice_pdf = self.get_invoice_pdf(invoice_id).get("InvoicePDF", {})
+        document_url = invoice_pdf.get("DocumentUrl")
+        if not isinstance(document_url, str) or not document_url:
+            raise AWSError(f"Invoice PDF URL is missing for invoice {invoice_id}")
+
+        try:
+            return self._download_document(document_url)
+        except requests.RequestException as error:
+            # The pre-signed URL carries a temporary access signature; keep only the HTTP
+            # status (never the URL) and drop the original exception so the signature
+            # cannot reach the logs or the caller.
+            if error.response is None:
+                status = "unknown"
+            else:
+                code = error.response.status_code
+                reason = error.response.reason
+                status = f"{code} {reason}".strip()
+            raise AWSError(
+                f"Failed to download invoice PDF for {invoice_id} (HTTP status: {status})"
+            ) from None
+
+    def _download_document(self, document_url: str) -> bytes:
+        response = requests.get(document_url, timeout=INVOICE_PDF_DOWNLOAD_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.content
 
     def _build_cost_and_usage_params(
         self,

--- a/swo_aws_extension/billing/billing_journal_service.py
+++ b/swo_aws_extension/billing/billing_journal_service.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Callable
 from decimal import Decimal
 
 from swo_aws_extension.billing.billing_report_creator import (
@@ -12,6 +13,8 @@ from swo_aws_extension.billing.models.context import BillingJournalContext
 from swo_aws_extension.billing.models.journal_result import (
     AuthorizationJournalResult,
 )
+from swo_aws_extension.billing.providers import BillingAWSClientProvider
+from swo_aws_extension.config import Config
 from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
 from swo_aws_extension.logger import get_logger
 from swo_aws_extension.swo.mpt.authorization import get_authorizations
@@ -63,13 +66,20 @@ def _log_dry_run_results(
 class BillingJournalService:
     """Generate billing journals for authorizations."""
 
-    def __init__(self, job_context: BillingJournalContext) -> None:
+    def __init__(
+        self,
+        job_context: BillingJournalContext,
+        billing_aws_client_provider_factory: Callable[
+            [Config, str], BillingAWSClientProvider
+        ] = BillingAWSClientProvider,
+    ) -> None:
         self._context = job_context
         self._mpt_client = job_context.mpt_client
         self._product_ids = job_context.product_ids
         self._authorizations = job_context.authorizations
         self._notifier = job_context.notifier
         self._generator = AuthorizationJournalGenerator(job_context)
+        self._billing_aws_client_provider_factory = billing_aws_client_provider_factory
 
     def run(self) -> None:
         """Entry point for generating billing journals for all selected authorizations."""
@@ -120,8 +130,16 @@ class BillingJournalService:
 
     def _process_authorization(self, authorization: dict) -> AuthorizationJournalResult | None:
         authorization_id = authorization.get("id", "")
+        billing_aws_client_provider = self._billing_aws_client_provider_factory(
+            self._context.config,
+            authorization.get("externalIds", {}).get("operations", ""),
+        )
 
-        generator_result = self._generate_journal_lines(authorization, authorization_id)
+        generator_result = self._generate_journal_lines(
+            authorization,
+            authorization_id,
+            billing_aws_client_provider,
+        )
         if not generator_result or not generator_result.lines:
             logger.info(
                 "No journal lines generated for authorization %s",
@@ -157,10 +175,13 @@ class BillingJournalService:
         return generator_result
 
     def _generate_journal_lines(
-        self, authorization: dict, authorization_id: str
+        self,
+        authorization: dict,
+        authorization_id: str,
+        billing_aws_client_provider: BillingAWSClientProvider,
     ) -> AuthorizationJournalResult | None:
         try:
-            return self._generator.run(authorization)
+            return self._generator.run(authorization, billing_aws_client_provider)
         except Exception:  # TODO: Catch specific exceptions and handle them accordingly
             logger.exception(
                 "Failed to generate billing journals for authorization %s",

--- a/swo_aws_extension/billing/generators/authorization.py
+++ b/swo_aws_extension/billing/generators/authorization.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from mpt_extension_sdk.mpt_http.mpt import get_agreements_by_query
 from mpt_extension_sdk.runtime.tracer import dynamic_trace_span
 
@@ -40,15 +42,20 @@ class AuthorizationJournalGenerator:
         self._billing_period = context.billing_period
         self._notifier = context.notifier
 
-    @with_log_context(lambda _, authorization, **kwargs: authorization.get("id"))
+    @with_log_context(lambda _, authorization, *args, **kwargs: authorization.get("id"))
     @dynamic_trace_span(
-        lambda _, authorization, **kwargs: f"Authorization {authorization.get('id')}",
+        lambda _, authorization, *args, **kwargs: f"Authorization {authorization.get('id')}",
     )
-    def run(self, authorization: dict) -> AuthorizationJournalResult:
+    def run(
+        self,
+        authorization: dict,
+        billing_aws_client_provider: Callable[[], AWSClient],
+    ) -> AuthorizationJournalResult:
         """Generate billing journal for the given authorization.
 
         Args:
             authorization: The authorization data to process.
+            billing_aws_client_provider: Provider for the billing AWS client.
 
         Returns:
             AuthorizationJournalResult containing lines and generated reports.
@@ -76,7 +83,7 @@ class AuthorizationJournalGenerator:
             aws_client=AWSClient(self._config, pma_account, self._config.management_role_name),
         )
 
-        aws_client = AWSClient(self._config, pma_account, self._config.billing_role_name)
+        aws_client = billing_aws_client_provider()
 
         return self._process_agreements(
             auth_context,

--- a/swo_aws_extension/billing/providers.py
+++ b/swo_aws_extension/billing/providers.py
@@ -1,0 +1,21 @@
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.config import Config
+
+
+class BillingAWSClientProvider:
+    """Lazily create and reuse the billing AWS client for one authorization."""
+
+    def __init__(self, config: Config, pma_account: str) -> None:
+        self._config = config
+        self._pma_account = pma_account
+        self._client: AWSClient | None = None
+
+    def __call__(self) -> AWSClient:
+        """Return the cached billing AWS client."""
+        if self._client is None:
+            self._client = AWSClient(
+                self._config,
+                self._pma_account,
+                self._config.billing_role_name,
+            )
+        return self._client

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -1,7 +1,9 @@
 import datetime as dt
+from http import HTTPStatus
 
 import boto3
 import pytest
+import responses
 from botocore.exceptions import ClientError
 
 from swo_aws_extension.aws.client import (
@@ -831,6 +833,42 @@ def test_get_invoice_pdf_stops_after_three_tries(
 
     assert mock_client.get_invoice_pdf.call_count == 3
     assert mock_sleep.call_args_list == [mocker.call(1), mocker.call(2)]
+
+
+def test_download_invoice_pdf_returns_content(config, aws_client_factory, requests_mocker):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    document_url = "https://example.test/invoice.pdf"
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {"DocumentUrl": document_url}}
+    requests_mocker.add(responses.GET, document_url, body=b"invoice-pdf", status=HTTPStatus.OK)
+
+    result = mock_aws_client.download_invoice_pdf("INV-001")
+
+    assert result == b"invoice-pdf"
+    mock_client.get_invoice_pdf.assert_called_once_with(InvoiceId="INV-001")
+
+
+def test_download_invoice_pdf_missing_url_raises(config, aws_client_factory):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {}}
+
+    with pytest.raises(AWSError, match="Invoice PDF URL is missing"):
+        mock_aws_client.download_invoice_pdf("INV-001")
+
+
+def test_download_invoice_pdf_error_redacts_url(config, aws_client_factory, requests_mocker):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    document_url = "https://example.test/invoice.pdf?X-Amz-Signature=super-secret-signature"
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {"DocumentUrl": document_url}}
+    requests_mocker.add(responses.GET, document_url, status=HTTPStatus.FORBIDDEN)
+
+    with pytest.raises(AWSError) as exc_info:
+        mock_aws_client.download_invoice_pdf("INV-001")
+
+    assert "super-secret-signature" not in str(exc_info.value)
+    assert "X-Amz-Signature" not in str(exc_info.value)
+    assert "403 Forbidden" in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True
 
 
 def test_get_linked_accounts_with_usage(mocker):

--- a/tests/billing/generators/test_authorization.py
+++ b/tests/billing/generators/test_authorization.py
@@ -62,6 +62,11 @@ def mock_aws_client_cls(mocker):
 
 
 @pytest.fixture
+def billing_aws_client_provider(mocker):
+    return mocker.Mock(return_value=mocker.create_autospec(AWSClient, instance=True))
+
+
+@pytest.fixture
 def mock_generate_billing_report_rows(mocker):
     mock_builder = mocker.MagicMock()
     mock_builder.build.return_value = []
@@ -77,12 +82,13 @@ def test_no_agreements_returns_empty_list(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mock_get_agreements.return_value = []
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result == AuthorizationJournalResult()
     mock_agreement_generator_cls.assert_not_called()
@@ -96,6 +102,7 @@ def test_processes_agreements(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mock_get_agreements.return_value = [{"id": "AGR-1"}, {"id": "AGR-2"}]
@@ -106,13 +113,17 @@ def test_processes_agreements(
         AgreementJournalResult(lines=[mock_journal_line], invoice_ids={"INV-001", "INV-002"}),
     ]
     mock_agreement_generator_cls.return_value = mock_agr_gen
+    billing_aws_client = billing_aws_client_provider.return_value
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert mock_agr_gen.run.call_count == 2
     assert result.lines == [mock_journal_line, mock_journal_line]
     assert result.invoice_ids == {"INV-001", "INV-002"}
+    billing_aws_client_provider.assert_called_once_with()
+    mock_usage_generator_cls.assert_called_once_with(billing_aws_client)
+    mock_invoice_generator_cls.assert_called_once_with(billing_aws_client)
 
 
 def test_exception_sends_error(
@@ -123,6 +134,7 @@ def test_exception_sends_error(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mock_get_agreements.return_value = [{"id": "AGR-1"}]
@@ -131,7 +143,7 @@ def test_exception_sends_error(
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result == AuthorizationJournalResult()
     expected_message = "Failed to generate billing journal for AGR-1: Test Error"
@@ -148,6 +160,7 @@ def test_includes_report_in_result(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     report = OrganizationReport(organization_data={"usage": [{"key": "val"}]})
@@ -165,7 +178,7 @@ def test_includes_report_in_result(
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result.reports_by_agreement == {"AGR-1": report}
     assert result.billing_report_rows == [mock_row]
@@ -180,6 +193,7 @@ def test_includes_pls_mismatches_in_result(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mismatch = PlsMismatch(agreement_id="AGR-1", pls_in_order=True, report_has_enterprise=False)
@@ -192,7 +206,7 @@ def test_includes_pls_mismatches_in_result(
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result.pls_mismatches == [mismatch]
 
@@ -205,6 +219,7 @@ def test_pma_usage_included_in_report_rows(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     mock_generate_billing_report_rows,
     authorization,
 ):
@@ -224,7 +239,7 @@ def test_pma_usage_included_in_report_rows(
     mock_generate_billing_report_rows.build.return_value = [mock_row]
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     mock_invoice_gen.run.assert_any_call("MPA-123", "MPA-123", mock_context.billing_period, "USD")
     mock_usage_gen.run_for_pma.assert_called_once_with(
@@ -245,6 +260,7 @@ def test_pma_usage_error_does_not_crash(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     mock_generate_billing_report_rows,
     authorization,
 ):
@@ -260,7 +276,7 @@ def test_pma_usage_error_does_not_crash(
     mock_invoice_gen.run.side_effect = AWSError("PMA invoice fetch failed")
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result.billing_report_rows == []
     mock_generate_billing_report_rows.assert_not_called()

--- a/tests/billing/test_billing_journal_service.py
+++ b/tests/billing/test_billing_journal_service.py
@@ -19,6 +19,7 @@ from swo_aws_extension.billing.models.journal_result import (
     PlsMismatch,
 )
 from swo_aws_extension.billing.models.usage import OrganizationReport
+from swo_aws_extension.billing.providers import BillingAWSClientProvider
 from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
 
@@ -52,16 +53,21 @@ def test_processes_authorizations(
     mocker, mock_context, mock_get_authorizations, mock_auth_generator_cls
 ):
     mock_context.dry_run = False
-    authorization = {"id": "AUTH-1"}
+    authorization = {
+        "id": "AUTH-1",
+        "externalIds": {"operations": "MPA-123"},
+    }
     mock_get_authorizations.return_value = [authorization]
     mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
     mock_auth_gen.run.return_value = AuthorizationJournalResult()
     mock_auth_generator_cls.return_value = mock_auth_gen
-    service = BillingJournalService(mock_context)
+    provider_factory = mocker.create_autospec(BillingAWSClientProvider)
+    service = BillingJournalService(mock_context, provider_factory)
 
     service.run()  # act
 
-    mock_auth_gen.run.assert_called_once_with(authorization)
+    provider_factory.assert_called_once_with(mock_context.config, "MPA-123")
+    mock_auth_gen.run.assert_called_once_with(authorization, provider_factory.return_value)
 
 
 def test_exception_sends_error(

--- a/tests/billing/test_providers.py
+++ b/tests/billing/test_providers.py
@@ -1,0 +1,32 @@
+import pytest
+
+from swo_aws_extension.billing.providers import BillingAWSClientProvider
+
+
+@pytest.fixture
+def mock_aws_client_cls(mocker):
+    return mocker.patch("swo_aws_extension.billing.providers.AWSClient", autospec=True)
+
+
+def test_does_not_create_client_until_called(config, mock_aws_client_cls):
+    BillingAWSClientProvider(config, "PMA-123")  # act
+
+    mock_aws_client_cls.assert_not_called()
+
+
+def test_creates_billing_client_when_called(config, mock_aws_client_cls):
+    provider = BillingAWSClientProvider(config, "PMA-123")
+
+    client = provider()  # act
+
+    assert client is mock_aws_client_cls.return_value
+    mock_aws_client_cls.assert_called_once_with(config, "PMA-123", config.billing_role_name)
+
+
+def test_reuses_the_same_client(config, mock_aws_client_cls):
+    provider = BillingAWSClientProvider(config, "PMA-123")
+
+    clients = [provider(), provider()]  # act
+
+    assert clients[0] is clients[1]
+    mock_aws_client_cls.assert_called_once()


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

First of two PRs for [MPT-23326](https://softwareone.atlassian.net/browse/MPT-23326) (attach AWS invoice documents to billing journals). This one adds the reusable building blocks; the creator and its integration into the billing flow follow in a stacked PR.

- **`AWSClient.download_invoice_pdf(invoice_id)`**: resolves the pre-signed URL via the AWS Invoicing `GetInvoicePDF` API and downloads the invoice document content, returning the bytes. The URL is used immediately and never stored. HTTP transport is mocked in tests via the `requests_mocker` fixture.
- **`BillingAWSClientProvider`**: lazily creates and reuses the billing `AWSClient` for one authorization, so journal generation and invoice retrieval share a single assumed-role client.
- Updated `docs/architecture.md` to note the `AWSClient` invoicing capability.

These components are consumed by `BillingInvoiceAttachmentCreator` and `BillingJournalService` in the follow-up PR.

Jira: [MPT-23326](https://softwareone.atlassian.net/browse/MPT-23326)


[MPT-23326]: https://softwareone.atlassian.net/browse/MPT-23326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23326]: https://softwareone.atlassian.net/browse/MPT-23326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23326](https://softwareone.atlassian.net/browse/MPT-23326)

- Adds `AWSClient.download_invoice_pdf(invoice_id)`, which resolves a pre-signed invoice URL via `GetInvoicePDF` and downloads the PDF bytes with a timeout, redacting signed-URL details from raised `AWSError`s on HTTP failures.
- Introduces `BillingAWSClientProvider` to lazily construct and cache a billing `AWSClient` per authorization.
- Wires the provider through `BillingJournalService` and `AuthorizationJournalGenerator` (updating `run(...)` signatures) so journal generation reuses the same billing client.
- Updates `docs/architecture.md` to document AWS invoicing summary and invoice document retrieval responsibilities.
- Adds/updates tests covering invoice PDF download success/missing URL/forbidden redaction, and provider laziness/caching, plus corresponding generator and billing journal service test updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->