### PR TITLE
MPT-23326 attach AWS invoice documents to billing journals

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ The runtime is organised as a pipeline-driven fulfilment flow:
 | `swo_aws_extension/` | Extension config, runtime `config.py`, order `parameters.py`, `constants.py` |
 | `swo_aws_extension/flows/` | Fulfilment orchestration, pipelines, steps, validation, order context |
 | `swo_aws_extension/flows/jobs/` | Background jobs: reports, FinOps entitlement sync, MPT subscription sync for linked AWS accounts |
-| `swo_aws_extension/billing/` | Billing journal generation, line processors, generators, and models |
+| `swo_aws_extension/billing/` | Billing journal generation, line processors, generators, models, and AWS invoice document attachment |
 | `swo_aws_extension/processor/` | Chain-of-responsibility processors for querying AWS roles, handshakes, transfers |
 | `swo_aws_extension/aws/` | `AWSClient` (boto3 AssumeRole, account/billing/CUR operations, Cost Explorer with dimension attributes, Invoicing summaries and invoice document retrieval) |
 | `swo_aws_extension/swo/` | External-service clients (CCP, CRM, FinOps, CCO, Cloud Orchestrator, MPT, Key Vault, Blob, notifications, OpenID) |

--- a/swo_aws_extension/billing/billing_invoice_attachment_creator.py
+++ b/swo_aws_extension/billing/billing_invoice_attachment_creator.py
@@ -1,0 +1,56 @@
+from io import BytesIO
+
+import requests
+
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.aws.errors import AWSError
+from swo_aws_extension.billing.models.journal_result import InvoiceAttachmentResult
+from swo_aws_extension.logger import get_logger
+from swo_aws_extension.swo.mpt.billing.billing_client import BillingClient
+from swo_aws_extension.swo.mpt.billing.models.hints import JournalAttachment
+
+logger = get_logger(__name__)
+
+
+class BillingInvoiceAttachmentCreator:
+    """Creates AWS invoice attachments for a billing journal."""
+
+    def __init__(self, aws_client: AWSClient, billing_api_client: BillingClient) -> None:
+        self._aws_client = aws_client
+        self._billing_api_client = billing_api_client
+
+    def create_for_journal(
+        self,
+        journal_id: str,
+        invoice_ids: set[str],
+    ) -> InvoiceAttachmentResult:
+        """Retrieve and attach AWS invoices to a journal."""
+        result = InvoiceAttachmentResult()
+        for invoice_id in sorted(invoice_ids):
+            try:
+                self._create_attachment(journal_id, invoice_id)
+            except (AWSError, requests.RequestException):
+                logger.exception(
+                    "Failed to attach AWS invoice %s to journal %s",
+                    invoice_id,
+                    journal_id,
+                )
+                result.failed_invoice_ids.add(invoice_id)
+                continue
+            result.uploaded_invoice_ids.add(invoice_id)
+        return result
+
+    def _create_attachment(self, journal_id: str, invoice_id: str) -> None:
+        invoice_file = BytesIO(self._aws_client.download_invoice_pdf(invoice_id))
+        filename = f"AWS-Invoice-{invoice_id}.pdf"
+        attachment = JournalAttachment(
+            name=filename,
+            description=f"AWS invoice {invoice_id}",
+        )
+        self._billing_api_client.journal.attachments(journal_id).upload(
+            filename=filename,
+            mimetype="application/pdf",
+            file=invoice_file,
+            attachment=attachment,
+        )
+        logger.info("Uploaded AWS invoice %s to journal %s", invoice_id, journal_id)

--- a/swo_aws_extension/billing/billing_journal_service.py
+++ b/swo_aws_extension/billing/billing_journal_service.py
@@ -2,6 +2,9 @@ from collections import defaultdict
 from collections.abc import Callable
 from decimal import Decimal
 
+from swo_aws_extension.billing.billing_invoice_attachment_creator import (
+    BillingInvoiceAttachmentCreator,
+)
 from swo_aws_extension.billing.billing_report_creator import (
     BillingReportCreator,
 )
@@ -15,7 +18,10 @@ from swo_aws_extension.billing.models.journal_result import (
 )
 from swo_aws_extension.billing.providers import BillingAWSClientProvider
 from swo_aws_extension.config import Config
-from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
+from swo_aws_extension.constants import (
+    BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+    BILLING_JOURNAL_ERROR_TITLE,
+)
 from swo_aws_extension.logger import get_logger
 from swo_aws_extension.swo.mpt.authorization import get_authorizations
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
@@ -170,6 +176,11 @@ class BillingJournalService:
                 journal.id,
                 generator_result.reports_by_agreement,
             )
+        self._create_invoice_attachments(
+            journal.id,
+            generator_result.invoice_ids,
+            billing_aws_client_provider,
+        )
         journal_manager.notify_success(journal.id, len(generator_result.lines))
 
         return generator_result
@@ -192,6 +203,29 @@ class BillingJournalService:
                 f"Failed to generate billing journals for authorization {authorization_id}",
             )
             return None
+
+    def _create_invoice_attachments(
+        self,
+        journal_id: str,
+        invoice_ids: set[str],
+        billing_aws_client_provider: BillingAWSClientProvider,
+    ) -> None:
+        if not invoice_ids:
+            return
+
+        creator = BillingInvoiceAttachmentCreator(
+            billing_aws_client_provider(),
+            self._context.billing_api_client,
+        )
+        result = creator.create_for_journal(journal_id, invoice_ids)
+        if result.failed_invoice_ids:
+            failed_invoice_ids = ", ".join(sorted(result.failed_invoice_ids))
+            self._notifier.send_warning(
+                title=BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+                text=(
+                    f"Failed to attach AWS invoices to journal {journal_id}: {failed_invoice_ids}"
+                ),
+            )
 
     def _build_rql_query(self) -> RQLQuery:
         rql_query = RQLQuery(product__id__in=self._product_ids)

--- a/swo_aws_extension/billing/models/journal_result.py
+++ b/swo_aws_extension/billing/models/journal_result.py
@@ -57,6 +57,14 @@ class AgreementJournalResult:
 
 
 @dataclass
+class InvoiceAttachmentResult:
+    """Result of attaching AWS invoice documents to a journal."""
+
+    uploaded_invoice_ids: set[str] = field(default_factory=set)
+    failed_invoice_ids: set[str] = field(default_factory=set)
+
+
+@dataclass
 class AuthorizationJournalResult:
     """Result of generating an authorization journal."""
 

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -236,6 +236,7 @@ COMMAND_INVALID_BILLING_DATE_FUTURE = "Invalid billing date. Future months are n
 
 BILLING_JOURNAL_SUCCESS_TITLE = "AWS Billing Journal Synchronization Success"
 BILLING_JOURNAL_ERROR_TITLE = "AWS Billing Journal Synchronization Error"
+BILLING_INVOICE_ATTACHMENT_WARNING_TITLE = "AWS Billing Invoice Attachment Warning"
 COST_EXPLORER_DATE_FORMAT = "%Y-%m-%d"
 
 EXCEL_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"

--- a/tests/billing/test_billing_invoice_attachment_creator.py
+++ b/tests/billing/test_billing_invoice_attachment_creator.py
@@ -1,0 +1,88 @@
+from io import BytesIO
+
+import pytest
+from requests import HTTPError
+
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.aws.errors import AWSError
+from swo_aws_extension.billing.billing_invoice_attachment_creator import (
+    BillingInvoiceAttachmentCreator,
+)
+
+
+@pytest.fixture
+def aws_client(mocker):
+    return mocker.create_autospec(AWSClient, instance=True)
+
+
+@pytest.fixture
+def billing_api_client(mocker):
+    # BillingClient.journal is set in __init__ and its attachments(id).upload chain is
+    # resolved dynamically, so it cannot be autospecced; a plain mock is required here.
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def creator(aws_client, billing_api_client):
+    return BillingInvoiceAttachmentCreator(aws_client, billing_api_client)
+
+
+def test_create_for_journal_uploads_invoice_pdf(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.return_value = b"invoice-pdf"
+
+    result = creator.create_for_journal("JRN-1", {"INV-001"})
+
+    assert (result.uploaded_invoice_ids, result.failed_invoice_ids) == ({"INV-001"}, set())
+    aws_client.download_invoice_pdf.assert_called_once_with("INV-001")
+    billing_api_client.journal.attachments.assert_called_once_with("JRN-1")
+    upload = billing_api_client.journal.attachments.return_value.upload
+    upload.assert_called_once()
+    upload_kwargs = upload.call_args.kwargs
+    assert upload_kwargs["filename"] == "AWS-Invoice-INV-001.pdf"
+    assert upload_kwargs["mimetype"] == "application/pdf"
+    assert isinstance(upload_kwargs["file"], BytesIO)
+    assert upload_kwargs["file"].getvalue() == b"invoice-pdf"
+
+
+def test_create_for_journal_continues_after_failure(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.side_effect = [AWSError("AWS failure"), b"invoice-pdf"]
+    upload = billing_api_client.journal.attachments.return_value.upload
+
+    result = creator.create_for_journal("JRN-1", {"INV-001", "INV-002"})
+
+    assert result.failed_invoice_ids == {"INV-001"}
+    assert result.uploaded_invoice_ids == {"INV-002"}
+    assert aws_client.download_invoice_pdf.call_count == 2
+    billing_api_client.journal.attachments.assert_called_once_with("JRN-1")
+    upload.assert_called_once()
+    assert upload.call_args.kwargs["filename"] == "AWS-Invoice-INV-002.pdf"
+
+
+def test_create_for_journal_records_upload_failure(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.return_value = b"invoice-pdf"
+    upload = billing_api_client.journal.attachments.return_value.upload
+    upload.side_effect = HTTPError("Upload failed")
+
+    result = creator.create_for_journal("JRN-1", {"INV-001"})
+
+    assert result.failed_invoice_ids == {"INV-001"}
+    assert result.uploaded_invoice_ids == set()
+
+
+def test_create_for_journal_records_download_failure(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.side_effect = AWSError("Invoice PDF URL is missing")
+    upload = billing_api_client.journal.attachments.return_value.upload
+
+    result = creator.create_for_journal("JRN-1", {"INV-001"})
+
+    assert result.failed_invoice_ids == {"INV-001"}
+    assert result.uploaded_invoice_ids == set()
+    upload.assert_not_called()
+
+
+def test_create_for_journal_with_no_invoices_does_nothing(creator, aws_client):
+    result = creator.create_for_journal("JRN-1", set())
+
+    assert result.uploaded_invoice_ids == set()
+    assert result.failed_invoice_ids == set()
+    aws_client.download_invoice_pdf.assert_not_called()

--- a/tests/billing/test_billing_journal_service.py
+++ b/tests/billing/test_billing_journal_service.py
@@ -2,6 +2,9 @@ from decimal import Decimal
 
 import pytest
 
+from swo_aws_extension.billing.billing_invoice_attachment_creator import (
+    BillingInvoiceAttachmentCreator,
+)
 from swo_aws_extension.billing.billing_journal_service import (
     BillingJournalService,
 )
@@ -16,11 +19,15 @@ from swo_aws_extension.billing.models.journal_line import (
 from swo_aws_extension.billing.models.journal_result import (
     AuthorizationJournalResult,
     BillingReportRow,
+    InvoiceAttachmentResult,
     PlsMismatch,
 )
 from swo_aws_extension.billing.models.usage import OrganizationReport
 from swo_aws_extension.billing.providers import BillingAWSClientProvider
-from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
+from swo_aws_extension.constants import (
+    BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+    BILLING_JOURNAL_ERROR_TITLE,
+)
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
 
 MODULE = "swo_aws_extension.billing.billing_journal_service"
@@ -214,6 +221,61 @@ def test_uploads_attachments_when_reports_present(
     mock_journal_manager.notify_success.assert_called_once_with("JRN-1", 1)
 
 
+def test_uploads_invoice_attachments_and_sends_warning_for_failures(
+    mocker, mock_context, mock_get_authorizations, mock_auth_generator_cls
+):
+    mock_context.dry_run = False
+    authorization = {
+        "id": "AUTH-1",
+        "externalIds": {"operations": "PMA-123"},
+    }
+    mock_get_authorizations.return_value = [authorization]
+    mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
+    mock_line = mocker.MagicMock(spec=JournalLine)
+    invoice_ids = {"INV-001", "INV-002"}
+    mock_auth_gen.run.return_value = AuthorizationJournalResult(
+        lines=[mock_line],
+        invoice_ids=invoice_ids,
+    )
+    mock_auth_generator_cls.return_value = mock_auth_gen
+    mock_journal_manager_cls = mocker.patch(f"{MODULE}.JournalManager", autospec=True)
+    mock_journal_manager = mock_journal_manager_cls.return_value
+    mock_journal_manager.get_pending_journal.return_value = mocker.MagicMock(id="JRN-1")
+    mock_aws_client_cls = mocker.patch(
+        "swo_aws_extension.billing.providers.AWSClient", autospec=True
+    )
+    mock_invoice_creator_cls = mocker.patch(
+        f"{MODULE}.BillingInvoiceAttachmentCreator", autospec=True
+    )
+    mock_invoice_creator = mocker.MagicMock(spec=BillingInvoiceAttachmentCreator)
+    mock_invoice_creator.create_for_journal.return_value = InvoiceAttachmentResult(
+        uploaded_invoice_ids={"INV-001"},
+        failed_invoice_ids={"INV-002"},
+    )
+    mock_invoice_creator_cls.return_value = mock_invoice_creator
+    service = BillingJournalService(mock_context)
+
+    service.run()  # act
+
+    mock_aws_client_cls.assert_called_once_with(
+        mock_context.config,
+        "PMA-123",
+        mock_context.config.billing_role_name,
+    )
+    billing_aws_client_provider = mock_auth_gen.run.call_args.args[1]
+    assert billing_aws_client_provider() is mock_aws_client_cls.return_value
+    mock_invoice_creator_cls.assert_called_once_with(
+        mock_aws_client_cls.return_value,
+        mock_context.billing_api_client,
+    )
+    mock_invoice_creator.create_for_journal.assert_called_once_with("JRN-1", invoice_ids)
+    mock_context.notifier.send_warning.assert_called_once_with(
+        title=BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+        text="Failed to attach AWS invoices to journal JRN-1: INV-002",
+    )
+    mock_journal_manager.notify_success.assert_called_once_with("JRN-1", 1)
+
+
 def test_dry_run_skips_upload(
     mocker, mock_context, mock_get_authorizations, mock_auth_generator_cls
 ):
@@ -233,11 +295,15 @@ def test_dry_run_skips_upload(
     )
     mock_auth_generator_cls.return_value = mock_auth_gen
     mock_journal_manager_cls = mocker.patch(f"{MODULE}.JournalManager", autospec=True)
+    mock_invoice_creator_cls = mocker.patch(
+        f"{MODULE}.BillingInvoiceAttachmentCreator", autospec=True
+    )
     service = BillingJournalService(mock_context)
 
     service.run()  # act
 
     mock_journal_manager_cls.assert_not_called()
+    mock_invoice_creator_cls.assert_not_called()
 
 
 def test_dry_run_skips_upload_with_empty_reports(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Second of two PRs for [MPT-23326](https://softwareone.atlassian.net/browse/MPT-23326). **Stacked on #410** (`download_invoice_pdf` + `BillingAWSClientProvider`); review/merge that one first. This PR adds the attachment creation and wires it into the billing flow.

- **`BillingInvoiceAttachmentCreator`**: for each collected invoice ID, downloads the PDF via `AWSClient.download_invoice_pdf` and uploads it as an `AWS-Invoice-{invoice-id}.pdf` journal attachment. Invoices are processed independently; failures are recorded in an `InvoiceAttachmentResult` (uploaded vs failed) instead of aborting the batch.
- **`BillingJournalService` integration**: after uploading the journal lines and JSON reports, it attaches the invoice documents (reusing the authorization's `BillingAWSClientProvider`), then sends a Teams warning listing any failed invoice IDs. The journal is still reported as successful.
- No invoice processing during `--dry-run` (the collected invoice IDs are only logged).

Jira: [MPT-23326](https://softwareone.atlassian.net/browse/MPT-23326)


[MPT-23326]: https://softwareone.atlassian.net/browse/MPT-23326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23326]: https://softwareone.atlassian.net/browse/MPT-23326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23326](https://softwareone.atlassian.net/browse/MPT-23326)

- Add `BillingInvoiceAttachmentCreator` to download collected AWS invoice PDFs and upload them to billing journals as `AWS-Invoice-{invoice-id}.pdf` attachments.
- Introduce `InvoiceAttachmentResult` to track `uploaded_invoice_ids` vs `failed_invoice_ids`, continuing per-invoice on errors.
- Update `BillingJournalService` to run invoice attachment processing after uploading journal lines and JSON reports, reusing the authorization’s `BillingAWSClientProvider`.
- Send a Teams warning listing failed invoice IDs while keeping the journal processing successful overall.
- Skip invoice attachment processing during `--dry-run` (only log collected invoice IDs).
- Add unit and service-level tests covering download/upload behavior, per-invoice failure handling, Teams warning behavior, and dry-run skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->