### PR TITLE
MPT-23411 Adopt ruff 0.15.22 conventions and drop RUF105/RUF201 ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,36 +191,34 @@ select = [
   "SIM", # flake8-simpify
   "SLF", # flake8-self
   "SLOT", # flake8-slots
-  "T100", # flake8-debugger
+  "debugger", # flake8-debugger
   "TRY", # tryceratops
   "UP", # pyupgrade
   "W", # pycodestyle
   "YTT", # flake8-2020
 ]
 ignore = [
-  "A005", # allow to shadow stdlib and builtin module names
-  "B904", # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
-  "COM812", # trailing comma, conflicts with `ruff format`
+  "stdlib-module-shadowing", # allow to shadow stdlib and builtin module names
+  "raise-without-from-inside-except", # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
+  "missing-trailing-comma", # trailing comma, conflicts with `ruff format`
   # Different doc rules that we don't really care about:
-  "D100",
-  "D104",
-  "D105", # docstring for magic methods
-  "D106",
-  "D107",
-  "D203",
-  "D212",
-  "D401",
-  "D404",
-  "D405",
-  "ISC001", # implicit string concat conflicts with `ruff format`
-  "ISC003", # prefer explicit string concat over implicit concat
+  "undocumented-public-module",
+  "undocumented-public-package",
+  "undocumented-magic-method", # docstring for magic methods
+  "undocumented-public-nested-class",
+  "undocumented-public-init",
+  "incorrect-blank-line-before-class",
+  "multi-line-summary-first-line",
+  "non-imperative-mood",
+  "docstring-starts-with-this",
+  "non-capitalized-section-name",
+  "single-line-implicit-string-concatenation", # implicit string concat conflicts with `ruff format`
+  "explicit-string-concatenation", # prefer explicit string concat over implicit concat
   "PLR09", # we have our own complexity rules
-  "PLR2004", # do not report magic numbers
-  "PLR6301", # do not require classmethod / staticmethod when self not used
-  "PT011", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
-  "RUF105", # `# noqa` vs `# ruff:ignore` migration (new rule in ruff 0.15.22)
-  "RUF201", # rule codes in selectors (new rule in ruff 0.15.22)
-  "TRY003", # long exception messages from `tryceratops`
+  "magic-value-comparison", # do not report magic numbers
+  "no-self-use", # do not require classmethod / staticmethod when self not used
+  "pytest-raises-too-broad", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
+  "raise-vanilla-args", # long exception messages from `tryceratops`
 ]
 external = [ "AAA", "WPS" ]
 
@@ -240,14 +238,14 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
-  "D101", # missing docstring in public class
-  "D102", # missing docstring in public methods
-  "D103", # missing docstring in public function
-  "S101", # asserts
-  "S105", # hardcoded passwords
-  "S404", # subprocess calls are for tests
-  "S603", # do not require `shell=True`
-  "S607", # partial executable paths
+  "undocumented-public-class", # missing docstring in public class
+  "undocumented-public-method", # missing docstring in public methods
+  "undocumented-public-function", # missing docstring in public function
+  "assert", # asserts
+  "hardcoded-password-string", # hardcoded passwords
+  "suspicious-subprocess-import", # subprocess calls are for tests
+  "subprocess-without-shell-equals-true", # do not require `shell=True`
+  "start-process-with-partial-path", # partial executable paths
 ]
 
 [tool.ruff.lint.isort]

--- a/swo_aws_extension/aws/errors.py
+++ b/swo_aws_extension/aws/errors.py
@@ -54,7 +54,7 @@ class InvalidDateInTerminateResponsibilityError(AWSError):
         super().__init__(message)
 
 
-def wrap_http_error(func: Callable[FuncParams, RetType]) -> Callable[FuncParams, RetType]:  # noqa: UP047
+def wrap_http_error(func: Callable[FuncParams, RetType]) -> Callable[FuncParams, RetType]:  # ruff:ignore[non-pep695-generic-function]
     """Wraps http error to internal."""
 
     @wraps(func)
@@ -78,7 +78,7 @@ def wrap_http_error(func: Callable[FuncParams, RetType]) -> Callable[FuncParams,
     return _wrapper
 
 
-def wrap_boto3_error(func: Callable[FuncParams, RetType]) -> Callable[FuncParams, RetType]:  # noqa: UP047
+def wrap_boto3_error(func: Callable[FuncParams, RetType]) -> Callable[FuncParams, RetType]:  # ruff:ignore[non-pep695-generic-function]
     """Wraps boto3 error to internal extension errors."""
 
     @wraps(func)

--- a/swo_aws_extension/config.py
+++ b/swo_aws_extension/config.py
@@ -279,7 +279,7 @@ _CONFIG = None
 
 def get_config() -> Config:
     """Get configuration."""
-    global _CONFIG  # noqa: PLW0603 WPS420
+    global _CONFIG  # ruff:ignore[global-statement]  # noqa: WPS420
     if not _CONFIG:
         _CONFIG = Config()
     return _CONFIG

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -3,10 +3,10 @@ from enum import IntEnum, StrEnum
 
 MPT_DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:00Z"
 
-ACCESS_TOKEN_NOT_FOUND_IN_RESPONSE = "Access token not found in the response"  # noqa: S105
-CCP_SECRET_NOT_FOUND_IN_KEY_VAULT = "CCP secret not found in key vault"  # noqa: S105
-FAILED_TO_GET_SECRET = "Failed to get secret"  # noqa: S105
-FAILED_TO_SAVE_SECRET_TO_KEY_VAULT = "Failed to save secret to key vault"  # noqa: S105
+ACCESS_TOKEN_NOT_FOUND_IN_RESPONSE = "Access token not found in the response"  # ruff:ignore[hardcoded-password-string]
+CCP_SECRET_NOT_FOUND_IN_KEY_VAULT = "CCP secret not found in key vault"  # ruff:ignore[hardcoded-password-string]
+FAILED_TO_GET_SECRET = "Failed to get secret"  # ruff:ignore[hardcoded-password-string]
+FAILED_TO_SAVE_SECRET_TO_KEY_VAULT = "Failed to save secret to key vault"  # ruff:ignore[hardcoded-password-string]
 
 CRM_EXTERNAL_EMAIL = "marketplace@softwareone.com"
 CRM_EXTERNAL_USERNAME = "mpt@marketplace.com"

--- a/swo_aws_extension/default.py
+++ b/swo_aws_extension/default.py
@@ -15,9 +15,11 @@ import os
 from pathlib import Path
 
 from azure.monitor.opentelemetry.exporter import AzureMonitorLogExporter
-from opentelemetry._logs import set_logger_provider  # noqa: PLC2701
-from opentelemetry.sdk._logs import LoggerProvider  # noqa: PLC2701
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor  # noqa: PLC2701
+from opentelemetry._logs import set_logger_provider  # ruff:ignore[import-private-name]
+from opentelemetry.sdk._logs import LoggerProvider  # ruff:ignore[import-private-name]
+from opentelemetry.sdk._logs.export import (  # ruff:ignore[import-private-name]
+    BatchLogRecordProcessor,
+)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/swo_aws_extension/flows/steps/setup_context.py
+++ b/swo_aws_extension/flows/steps/setup_context.py
@@ -2,7 +2,10 @@ import logging
 from typing import override
 
 from mpt_extension_sdk.mpt_http.base import MPTClient
-from mpt_extension_sdk.mpt_http.mpt import _paginated, update_order  # noqa: PLC2701
+from mpt_extension_sdk.mpt_http.mpt import (
+    _paginated,  # ruff:ignore[import-private-name]
+    update_order,
+)
 
 from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.aws.errors import AWSError

--- a/swo_aws_extension/initializer.py
+++ b/swo_aws_extension/initializer.py
@@ -19,8 +19,8 @@ def initialize(options, group=DEFAULT_APP_CONFIG_GROUP, name=DEFAULT_APP_CONFIG_
         name=name,
     )
 
-    import django  # noqa: PLC0415
-    from django.conf import settings  # noqa: PLC0415
+    import django  # ruff:ignore[import-outside-top-level]
+    from django.conf import settings  # ruff:ignore[import-outside-top-level]
 
     if settings.USE_APPLICATIONINSIGHTS:
         BotocoreInstrumentor().instrument()

--- a/swo_aws_extension/swo/mpt/authorization.py
+++ b/swo_aws_extension/swo/mpt/authorization.py
@@ -1,5 +1,5 @@
 from mpt_extension_sdk.mpt_http.base import MPTClient
-from mpt_extension_sdk.mpt_http.mpt import _paginated  # noqa: PLC2701
+from mpt_extension_sdk.mpt_http.mpt import _paginated  # ruff:ignore[import-private-name]
 
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
 

--- a/swo_aws_extension/swo/mpt/billing/journal_client.py
+++ b/swo_aws_extension/swo/mpt/billing/journal_client.py
@@ -217,12 +217,12 @@ class JournalClient:
         response.raise_for_status()
         return response.json()
 
-    @lru_cache(maxsize=10)  # noqa: B019
+    @lru_cache(maxsize=10)  # ruff:ignore[cached-instance-method]
     def attachments(self, journal_id: str) -> AttachmentsClient:
         """Get attachments client."""
         return AttachmentsClient(self._client, journal_id)
 
-    @lru_cache(maxsize=10)  # noqa: B019
+    @lru_cache(maxsize=10)  # ruff:ignore[cached-instance-method]
     def charges(self, journal_id: str) -> ChargesClient:
         """Get charges client."""
         return ChargesClient(self._client, journal_id)

--- a/swo_aws_extension/swo/mpt/order.py
+++ b/swo_aws_extension/swo/mpt/order.py
@@ -1,5 +1,5 @@
 from mpt_extension_sdk.mpt_http.base import MPTClient
-from mpt_extension_sdk.mpt_http.mpt import _paginated  # noqa: PLC2701
+from mpt_extension_sdk.mpt_http.mpt import _paginated  # ruff:ignore[import-private-name]
 
 
 # TODO: SDK candidate and should use dependency injection for mpt_client

--- a/swo_aws_extension/swo/rql/query_builder.py
+++ b/swo_aws_extension/swo/rql/query_builder.py
@@ -58,7 +58,7 @@ def rql_encode(op: str, value: str | list) -> str:
     raise TypeError(f"the `{op}` operator doesn't support the {type(value)} type.")
 
 
-def _encode_scalar(value: str | bool | int | float | Decimal | dt.date | dt.datetime) -> str:  # noqa: FBT001
+def _encode_scalar(value: str | bool | int | float | Decimal | dt.date | dt.datetime) -> str:  # ruff:ignore[boolean-type-hint-positional-argument]
     if isinstance(value, str):
         return value
     if isinstance(value, bool):
@@ -350,7 +350,7 @@ class RQLQuery:
         self.expr = f"eq({self._field},{expr}())"
         return self
 
-    def _to_string(self, query):  # noqa: C901
+    def _to_string(self, query):  # ruff:ignore[complex-structure]
         tokens = []
         if query.expr:
             if query.negated:

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -20,11 +20,11 @@ from swo_aws_extension.models import BillingPeriod
 
 # InvalidInputException is the name given by AWS boto3 to the error we are testing:
 # see more: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations/client/terminate_responsibility_transfer.html#
-class InvalidInputException(ClientError):  # noqa: N818
+class InvalidInputException(ClientError):  # ruff:ignore[error-suffix-on-exception-name]
     """Dummy exception for testing purposes."""
 
 
-class ResourceNotFoundException(ClientError):  # noqa: N818
+class ResourceNotFoundException(ClientError):  # ruff:ignore[error-suffix-on-exception-name]
     """Dummy exception for testing purposes."""
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -878,7 +878,7 @@ def mock_token():
 @pytest.fixture
 def mpt_client(settings):
     settings.MPT_API_BASE_URL = "https://localhost"
-    from mpt_extension_sdk.core.utils import setup_client  # noqa: PLC0415
+    from mpt_extension_sdk.core.utils import setup_client  # ruff:ignore[import-outside-top-level]
 
     return setup_client()
 

--- a/tests/swo/cco/test_client.py
+++ b/tests/swo/cco/test_client.py
@@ -7,7 +7,7 @@ import responses
 
 from swo_aws_extension.swo.cco.client import (
     CcoClient,
-    _CcoClientFactory,  # noqa: PLC2701
+    _CcoClientFactory,  # ruff:ignore[import-private-name]
     get_cco_client,
 )
 from swo_aws_extension.swo.cco.errors import CcoError, CcoHttpError, CcoNotFoundError
@@ -27,7 +27,7 @@ class _LockThatSetsInstance:
         self._instance = instance
 
     def __enter__(self):
-        _CcoClientFactory._instance = self._instance  # noqa: SLF001
+        _CcoClientFactory._instance = self._instance  # ruff:ignore[private-member-access]
         return self
 
     def __exit__(self, *args):

--- a/tests/swo/mpt/httpquery/test_httpquery.py
+++ b/tests/swo/mpt/httpquery/test_httpquery.py
@@ -17,16 +17,16 @@ def test_init():
 
     result = HttpQuery(mock_client, url, query)
 
-    assert result._client == mock_client  # noqa: SLF001
-    assert result._url == url  # noqa: SLF001
-    assert result._query == query  # noqa: SLF001
+    assert result._client == mock_client  # ruff:ignore[private-member-access]
+    assert result._url == url  # ruff:ignore[private-member-access]
+    assert result._query == query  # ruff:ignore[private-member-access]
 
 
 def test_has_more_pages_no_page():
     mock_client = MagicMock()
     hq = HttpQuery(mock_client, "https://fake-url")
 
-    result = hq._has_more_pages(None)  # noqa: SLF001
+    result = hq._has_more_pages(None)  # ruff:ignore[private-member-access]
 
     assert result is True
 
@@ -36,7 +36,7 @@ def test_has_more_pages_with_more():
     hq = HttpQuery(mock_client, "https://fake-url")
     page = {"$meta": {"pagination": {"total": 20, "limit": 10, "offset": 0}}}
 
-    result = hq._has_more_pages(page)  # noqa: SLF001
+    result = hq._has_more_pages(page)  # ruff:ignore[private-member-access]
 
     assert result is True
 
@@ -46,7 +46,7 @@ def test_has_more_pages_with_no_more():
     hq = HttpQuery(mock_client, "https://fake-url")
     page = {"$meta": {"pagination": {"total": 20, "limit": 10, "offset": 10}}}
 
-    result = hq._has_more_pages(page)  # noqa: SLF001
+    result = hq._has_more_pages(page)  # ruff:ignore[private-member-access]
 
     assert result is False
 
@@ -98,9 +98,9 @@ def test_query_combines_existing_and_new_rql():
     result = hq.query(new_rql)
 
     assert isinstance(result, HttpQuery)
-    assert result._query == f"{base_query}&{new_rql}"  # noqa: SLF001
-    assert result._url == "https://fake-url"  # noqa: SLF001
-    assert result._client == mock_client  # noqa: SLF001
+    assert result._query == f"{base_query}&{new_rql}"  # ruff:ignore[private-member-access]
+    assert result._url == "https://fake-url"  # ruff:ignore[private-member-access]
+    assert result._client == mock_client  # ruff:ignore[private-member-access]
 
 
 def test_query_uses_new_rql_if_none_exists():
@@ -111,7 +111,7 @@ def test_query_uses_new_rql_if_none_exists():
     result = hq.query(new_rql)
 
     assert isinstance(result, HttpQuery)
-    assert result._query == new_rql  # noqa: SLF001
+    assert result._query == new_rql  # ruff:ignore[private-member-access]
 
 
 def test_query_ignores_none_rql():
@@ -122,7 +122,7 @@ def test_query_ignores_none_rql():
     result = hq.query(None)
 
     assert isinstance(result, HttpQuery)
-    assert result._query == base_query  # noqa: SLF001
+    assert result._query == base_query  # ruff:ignore[private-member-access]
 
 
 def test_query_none_on_none():
@@ -132,7 +132,7 @@ def test_query_none_on_none():
     result = hq.query(None)
 
     assert isinstance(result, HttpQuery)
-    assert result._query is None  # noqa: SLF001
+    assert result._query is None  # ruff:ignore[private-member-access]
 
 
 def test_call_no_query():
@@ -143,7 +143,7 @@ def test_call_no_query():
     mock_client.get.return_value = mock_response
     hq = HttpQuery(mock_client, "https://fake-url")
 
-    result = hq._call()  # noqa: SLF001
+    result = hq._call()  # ruff:ignore[private-member-access]
 
     mock_client.get.assert_called_once_with("https://fake-url")
     mock_response.raise_for_status.assert_called_once()
@@ -158,7 +158,7 @@ def test_call_with_self_query():
     mock_client.get.return_value = mock_response
     hq = HttpQuery(mock_client, "https://fake-url", "a=1")
 
-    result = hq._call()  # noqa: SLF001
+    result = hq._call()  # ruff:ignore[private-member-access]
 
     mock_client.get.assert_called_once_with("https://fake-url?a=1")
     assert result == {"data": [2]}
@@ -172,7 +172,7 @@ def test_call_with_query_arg():
     mock_client.get.return_value = mock_response
     hq = HttpQuery(mock_client, "https://fake-url")
 
-    result = hq._call("b=2")  # noqa: SLF001
+    result = hq._call("b=2")  # ruff:ignore[private-member-access]
 
     mock_client.get.assert_called_once_with("https://fake-url?b=2")
     assert result == {"data": [3]}
@@ -186,7 +186,7 @@ def test_call_with_both_queries():
     mock_client.get.return_value = mock_response
     hq = HttpQuery(mock_client, "https://fake-url", "a=1")
 
-    result = hq._call("b=2")  # noqa: SLF001
+    result = hq._call("b=2")  # ruff:ignore[private-member-access]
 
     mock_client.get.assert_called_once_with("https://fake-url?a=1&b=2")
     assert result == {"data": [4]}

--- a/tests/swo/notifications/test_email.py
+++ b/tests/swo/notifications/test_email.py
@@ -14,7 +14,7 @@ def test_email_notification_manager_init(mocker, config):
     mock_boto3_client.assert_called_once_with(
         "ses",
         aws_access_key_id="access_key",
-        aws_secret_access_key="secret_key",  # noqa: S106
+        aws_secret_access_key="secret_key",  # ruff:ignore[hardcoded-password-func-arg]
         region_name="us-east-1",
     )
     assert manager.sender == "sender@example.com"

--- a/tests/swo/rql/test_query_builder.py
+++ b/tests/swo/rql/test_query_builder.py
@@ -255,8 +255,8 @@ def test_and_merge():
 @pytest.mark.parametrize("op", ["eq", "ne", "gt", "ge", "le", "lt"])
 def test_dotted_path_comp(op):
     assert str(getattr(RQLQuery().asset.id, op)("value")) == f"{op}(asset.id,'value')"
-    assert str(getattr(RQLQuery().asset.id, op)(True)) == f"{op}(asset.id,'true')"  # noqa: FBT003
-    assert str(getattr(RQLQuery().asset.id, op)(False)) == f"{op}(asset.id,'false')"  # noqa: FBT003
+    assert str(getattr(RQLQuery().asset.id, op)(True)) == f"{op}(asset.id,'true')"  # ruff:ignore[boolean-positional-value-in-call]
+    assert str(getattr(RQLQuery().asset.id, op)(False)) == f"{op}(asset.id,'false')"  # ruff:ignore[boolean-positional-value-in-call]
     assert str(getattr(RQLQuery().asset.id, op)(10)) == f"{op}(asset.id,'10')"
     assert str(getattr(RQLQuery().asset.id, op)(10.678937)) == f"{op}(asset.id,'10.678937')"
 

--- a/tests/swo/test_auth.py
+++ b/tests/swo/test_auth.py
@@ -25,7 +25,7 @@ def test_get_auth_token_success(requests_mocker):
     result = get_auth_token(
         endpoint=OAUTH_URL,
         client_id="test_client_id",
-        client_secret="test_secret",  # noqa: S106
+        client_secret="test_secret",  # ruff:ignore[hardcoded-password-func-arg]
         scope="test_scope",
     )
 
@@ -45,7 +45,7 @@ def test_get_auth_token_with_audience(requests_mocker):
     result = get_auth_token(
         endpoint=OAUTH_URL,
         client_id="test_client_id",
-        client_secret="test_secret",  # noqa: S106
+        client_secret="test_secret",  # ruff:ignore[hardcoded-password-func-arg]
         scope="test_scope",
         audience="test_audience",
     )
@@ -65,7 +65,7 @@ def test_get_auth_token_http_error(requests_mocker):
         get_auth_token(
             endpoint=OAUTH_URL,
             client_id="invalid_client",
-            client_secret="invalid_secret",  # noqa: S106
+            client_secret="invalid_secret",  # ruff:ignore[hardcoded-password-func-arg]
             scope="test_scope",
         )
 
@@ -82,6 +82,6 @@ def test_get_auth_token_server_error(requests_mocker):
         get_auth_token(
             endpoint=OAUTH_URL,
             client_id="test_client_id",
-            client_secret="test_secret",  # noqa: S106
+            client_secret="test_secret",  # ruff:ignore[hardcoded-password-func-arg]
             scope="test_scope",
         )

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -57,7 +57,7 @@ def make_mock_settings(app_config_name, logging_handler="console", *, use_app_in
 
 def test_initializer_sets_env(monkeypatch):
     monkeypatch.delenv("MPT_INITIALIZER", raising=False)
-    from swo_aws_extension import initializer  # noqa: PLC0415
+    from swo_aws_extension import initializer  # ruff:ignore[import-outside-top-level]
 
     importlib.reload(initializer)  # act
 
@@ -80,7 +80,7 @@ def test_initialize_basic(monkeypatch, mocker):
     )
     monkeypatch.setattr("rich.reconfigure", lambda **kwargs: None)
     options = {"color": True, "debug": True}
-    from swo_aws_extension import initializer  # noqa: PLC0415
+    from swo_aws_extension import initializer  # ruff:ignore[import-outside-top-level]
 
     initializer.initialize(options)  # act
 
@@ -140,7 +140,7 @@ def test_initialize_with_app_insights(monkeypatch, mocker, mock_app_insights_ins
     )
     mock_botocore = mocker.patch("swo_aws_extension.initializer.BotocoreInstrumentor")
     options = {"color": False, "debug": False}
-    from swo_aws_extension import initializer  # noqa: PLC0415
+    from swo_aws_extension import initializer  # ruff:ignore[import-outside-top-level]
 
     initializer.initialize(options)  # act
 

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -45,7 +45,7 @@ def test_with_log_context_clears_context_on_exception(
     service = _FailingService()
 
     with pytest.raises(ValueError, match="fail"):
-        result = service.run({"id": "ENT-456"})  # noqa: F841
+        result = service.run({"id": "ENT-456"})  # ruff:ignore[unused-variable]
 
     mock_set_log_context.assert_called_once_with("ENT-456")
     mock_clear_log_context.assert_called_once_with("ENT-456")


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Removes the temporary `RUF105`/`RUF201` entries from `[tool.ruff.lint].ignore` (added to unblock the ruff `0.15.22` bump) and migrates the code to the conventions those preview rules enforce.

Part of epic MPT-23408 / story MPT-23409.

## Changes

- **RUF201** (rule-codes-in-selectors): rule codes → rule names in `lint.select` / `lint.ignore` / `per-file-ignores` (auto-fixed via `ruff check --fix`).
- **RUF105** (noqa-comments): `# noqa: X` → `# ruff:ignore[X]`. Three suppressions the autofix could not migrate cleanly were restored by hand:
  - `config.py`: `global _CONFIG` mixed `PLW0603` with flake8 `WPS420` → `# ruff:ignore[global-statement]  # noqa: WPS420`.
  - `default.py`, `flows/steps/setup_context.py`: private-name imports (`PLC2701`) that the autofix wrapped to multiline while dropping the `# noqa` → restored as `# ruff:ignore[import-private-name]`.

No behavioural change.

## Validation

`make check-all` fully green — ruff format/check, flake8 (WPS/private-name suppressions intact), `uv lock --check`, **1103 tests passed** (1 xpassed).

Jira: MPT-23411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updates Ruff configuration and suppressions to Ruff 0.15.22 conventions.
- Replaces rule codes with descriptive rule names in selectors and per-file ignores.
- Migrates inline `noqa` directives to `ruff:ignore[...]`, preserving required mixed-rule and private-import suppressions.
- No behavioral changes; all checks passed, including 1,103 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->