### PR TITLE
[BACKPORT] MPT-23481 AWS Billing: Add Invoices to Journals

### DIFF
--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -1,8 +1,11 @@
 import datetime as dt
 import logging
+import time
 from collections.abc import Callable
 
 import boto3
+import requests
+from botocore.config import Config as BotoConfig
 
 from swo_aws_extension.aws.errors import (
     AWSError,
@@ -15,6 +18,11 @@ from swo_aws_extension.swo.openid.client import OpenIDClient
 
 MINIMUM_DAYS_MONTH = 28
 MAX_RESULTS_PER_PAGE = 20
+INVOICE_PDF_MAX_ATTEMPTS = 3
+INVOICE_PDF_DOWNLOAD_TIMEOUT_SECONDS = 60
+# Standard mode retries throttling, server (5xx) and connection errors with
+# exponential backoff and jitter, keeping the default total max attempts.
+BOTO3_CLIENT_CONFIG = BotoConfig(retries={"mode": "standard"})
 
 logger = logging.getLogger(__name__)
 
@@ -348,12 +356,66 @@ class AWSClient:
         )
 
     @wrap_boto3_error
+    def get_invoice_pdf(self, invoice_id: str) -> dict:
+        """Return AWS invoice PDF metadata for an invoice.
+
+        ResourceNotFoundException (PDF not yet generated) is retried with
+        exponential backoff before giving up; other errors rely on boto3's
+        built-in retries.
+        """
+        invoicing_client = self._get_invoicing_client()
+        attempt = 1
+        while True:
+            try:
+                return invoicing_client.get_invoice_pdf(InvoiceId=invoice_id)
+            except invoicing_client.exceptions.ResourceNotFoundException:
+                # Raised while the PDF is not yet generated; boto3 never retries it,
+                # unlike throttling and 5xx errors, which boto3 retries itself.
+                if attempt >= INVOICE_PDF_MAX_ATTEMPTS:
+                    raise
+                time.sleep(2 ** (attempt - 1))
+                attempt += 1
+
+    @wrap_boto3_error
+    def download_invoice_pdf(self, invoice_id: str) -> bytes:
+        """Return the AWS invoice PDF document content for an invoice.
+
+        Resolves the pre-signed URL via GetInvoicePDF and downloads its content.
+        The URL is used immediately and never stored.
+        """
+        invoice_pdf = self.get_invoice_pdf(invoice_id).get("InvoicePDF", {})
+        document_url = invoice_pdf.get("DocumentUrl")
+        if not isinstance(document_url, str) or not document_url:
+            raise AWSError(f"Invoice PDF URL is missing for invoice {invoice_id}")
+
+        try:
+            return self._download_document(document_url)
+        except requests.RequestException as error:
+            # The pre-signed URL carries a temporary access signature; keep only the HTTP
+            # status (never the URL) and drop the original exception so the signature
+            # cannot reach the logs or the caller.
+            if error.response is None:
+                status = "unknown"
+            else:
+                code = error.response.status_code
+                reason = error.response.reason
+                status = f"{code} {reason}".strip()
+            raise AWSError(
+                f"Failed to download invoice PDF for {invoice_id} (HTTP status: {status})"
+            ) from None
+
+    def _download_document(self, document_url: str) -> bytes:
+        response = requests.get(document_url, timeout=INVOICE_PDF_DOWNLOAD_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.content
+
+    @wrap_boto3_error
     def _get_credentials(self):
         if not self.account_id:
             raise AWSError("Parameter 'account_id' must be provided to assume the role.")
 
         role_arn = f"arn:aws:iam::{self.account_id}:role/{self.role_name}"
-        response = boto3.client("sts").assume_role_with_web_identity(
+        response = boto3.client("sts", config=BOTO3_CLIENT_CONFIG).assume_role_with_web_identity(
             RoleArn=role_arn,
             RoleSessionName="SWOExtensionOnboardingSession",
             WebIdentityToken=self._openid_client.fetch_access_token(self.config.aws_openid_scope),
@@ -375,6 +437,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
         )
 
     def _get_sts_client(self):
@@ -383,6 +446,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
         )
 
     def _get_cost_explorer_client(self):
@@ -397,6 +461,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )
 
@@ -412,6 +477,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )
 
@@ -427,6 +493,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
         )
 
     def _get_partner_central_client(self):
@@ -441,6 +508,7 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )
 
@@ -456,5 +524,6 @@ class AWSClient:
             aws_access_key_id=self.credentials["AccessKeyId"],
             aws_secret_access_key=self.credentials["SecretAccessKey"],
             aws_session_token=self.credentials["SessionToken"],
+            config=BOTO3_CLIENT_CONFIG,
             region_name="us-east-1",
         )

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -234,6 +234,7 @@ COMMAND_INVALID_BILLING_DATE_FUTURE = "Invalid billing date. Future months are n
 
 BILLING_JOURNAL_SUCCESS_TITLE = "AWS Billing Journal Synchronization Success"
 BILLING_JOURNAL_ERROR_TITLE = "AWS Billing Journal Synchronization Error"
+BILLING_INVOICE_ATTACHMENT_WARNING_TITLE = "AWS Billing Invoice Attachment Warning"
 COST_EXPLORER_DATE_FORMAT = "%Y-%m-%d"
 
 EXCEL_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"

--- a/swo_aws_extension/flows/jobs/billing_journal/billing_invoice_attachment_creator.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/billing_invoice_attachment_creator.py
@@ -1,0 +1,58 @@
+from io import BytesIO
+
+import requests
+
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.aws.errors import AWSError
+from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
+    InvoiceAttachmentResult,
+)
+from swo_aws_extension.logger import get_logger
+from swo_aws_extension.swo.mpt.billing.billing_client import BillingClient
+from swo_aws_extension.swo.mpt.billing.models.hints import JournalAttachment
+
+logger = get_logger(__name__)
+
+
+class BillingInvoiceAttachmentCreator:
+    """Creates AWS invoice attachments for a billing journal."""
+
+    def __init__(self, aws_client: AWSClient, billing_api_client: BillingClient) -> None:
+        self._aws_client = aws_client
+        self._billing_api_client = billing_api_client
+
+    def create_for_journal(
+        self,
+        journal_id: str,
+        invoice_ids: set[str],
+    ) -> InvoiceAttachmentResult:
+        """Retrieve and attach AWS invoices to a journal."""
+        result = InvoiceAttachmentResult()
+        for invoice_id in sorted(invoice_ids):
+            try:
+                self._create_attachment(journal_id, invoice_id)
+            except (AWSError, requests.RequestException):
+                logger.exception(
+                    "Failed to attach AWS invoice %s to journal %s",
+                    invoice_id,
+                    journal_id,
+                )
+                result.failed_invoice_ids.add(invoice_id)
+                continue
+            result.uploaded_invoice_ids.add(invoice_id)
+        return result
+
+    def _create_attachment(self, journal_id: str, invoice_id: str) -> None:
+        invoice_file = BytesIO(self._aws_client.download_invoice_pdf(invoice_id))
+        filename = f"AWS-Invoice-{invoice_id}.pdf"
+        attachment = JournalAttachment(
+            name=filename,
+            description=f"AWS invoice {invoice_id}",
+        )
+        self._billing_api_client.journal.attachments(journal_id).upload(
+            filename=filename,
+            mimetype="application/pdf",
+            file=invoice_file,
+            attachment=attachment,
+        )
+        logger.info("Uploaded AWS invoice %s to journal %s", invoice_id, journal_id)

--- a/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/billing_journal_service.py
@@ -1,7 +1,15 @@
 from collections import defaultdict
+from collections.abc import Callable
 from decimal import Decimal
 
-from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
+from swo_aws_extension.config import Config
+from swo_aws_extension.constants import (
+    BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+    BILLING_JOURNAL_ERROR_TITLE,
+)
+from swo_aws_extension.flows.jobs.billing_journal.billing_invoice_attachment_creator import (
+    BillingInvoiceAttachmentCreator,
+)
 from swo_aws_extension.flows.jobs.billing_journal.billing_report_creator import (
     BillingReportCreator,
 )
@@ -13,6 +21,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.context import BillingJ
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AuthorizationJournalResult,
 )
+from swo_aws_extension.flows.jobs.billing_journal.providers import BillingAWSClientProvider
 from swo_aws_extension.logger import get_logger
 from swo_aws_extension.swo.mpt.authorization import get_authorizations
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
@@ -52,18 +61,31 @@ def _log_dry_run_results(
     ]
     if attachments:
         logger.info("%s - [DRY-RUN] Attachments: %s", authorization_id, attachments)
+    if generator_result.invoice_ids:
+        logger.info(
+            "%s - [DRY-RUN] Invoice IDs: %s",
+            authorization_id,
+            sorted(generator_result.invoice_ids),
+        )
 
 
 class BillingJournalService:
     """Generate billing journals for authorizations."""
 
-    def __init__(self, job_context: BillingJournalContext) -> None:
+    def __init__(
+        self,
+        job_context: BillingJournalContext,
+        billing_aws_client_provider_factory: Callable[
+            [Config, str], BillingAWSClientProvider
+        ] = BillingAWSClientProvider,
+    ) -> None:
         self._context = job_context
         self._mpt_client = job_context.mpt_client
         self._product_ids = job_context.product_ids
         self._authorizations = job_context.authorizations
         self._notifier = job_context.notifier
         self._generator = AuthorizationJournalGenerator(job_context)
+        self._billing_aws_client_provider_factory = billing_aws_client_provider_factory
 
     def run(self) -> None:
         """Entry point for generating billing journals for all selected authorizations."""
@@ -114,8 +136,16 @@ class BillingJournalService:
 
     def _process_authorization(self, authorization: dict) -> AuthorizationJournalResult | None:
         authorization_id = authorization.get("id", "")
+        billing_aws_client_provider = self._billing_aws_client_provider_factory(
+            self._context.config,
+            authorization.get("externalIds", {}).get("operations", ""),
+        )
 
-        generator_result = self._generate_journal_lines(authorization, authorization_id)
+        generator_result = self._generate_journal_lines(
+            authorization,
+            authorization_id,
+            billing_aws_client_provider,
+        )
         if not generator_result or not generator_result.lines:
             logger.info(
                 "No journal lines generated for authorization %s",
@@ -146,15 +176,23 @@ class BillingJournalService:
                 journal.id,
                 generator_result.reports_by_agreement,
             )
+        self._create_invoice_attachments(
+            journal.id,
+            generator_result.invoice_ids,
+            billing_aws_client_provider,
+        )
         journal_manager.notify_success(journal.id, len(generator_result.lines))
 
         return generator_result
 
     def _generate_journal_lines(
-        self, authorization: dict, authorization_id: str
+        self,
+        authorization: dict,
+        authorization_id: str,
+        billing_aws_client_provider: BillingAWSClientProvider,
     ) -> AuthorizationJournalResult | None:
         try:
-            return self._generator.run(authorization)
+            return self._generator.run(authorization, billing_aws_client_provider)
         except Exception:  # TODO: Catch specific exceptions and handle them accordingly
             logger.exception(
                 "Failed to generate billing journals for authorization %s",
@@ -165,6 +203,29 @@ class BillingJournalService:
                 f"Failed to generate billing journals for authorization {authorization_id}",
             )
             return None
+
+    def _create_invoice_attachments(
+        self,
+        journal_id: str,
+        invoice_ids: set[str],
+        billing_aws_client_provider: BillingAWSClientProvider,
+    ) -> None:
+        if not invoice_ids:
+            return
+
+        creator = BillingInvoiceAttachmentCreator(
+            billing_aws_client_provider(),
+            self._context.billing_api_client,
+        )
+        result = creator.create_for_journal(journal_id, invoice_ids)
+        if result.failed_invoice_ids:
+            failed_invoice_ids = ", ".join(sorted(result.failed_invoice_ids))
+            self._notifier.send_warning(
+                title=BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+                text=(
+                    f"Failed to attach AWS invoices to journal {journal_id}: {failed_invoice_ids}"
+                ),
+            )
 
     def _build_rql_query(self) -> RQLQuery:
         rql_query = RQLQuery(product__id__in=self._product_ids)

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/agreement.py
@@ -103,6 +103,7 @@ class AgreementJournalGenerator:
             usage_result,
             journal_details,
             invoice_result.invoice,
+            invoice_result.invoice_ids,
         )
         logger.info("Generated %d journal lines", len(agreement_result.lines))
         return agreement_result
@@ -113,6 +114,7 @@ class AgreementJournalGenerator:
         usage_result: OrganizationUsageResult,
         journal_details: JournalDetails,
         organization_invoice,
+        invoice_ids: set[str],
     ) -> AgreementJournalResult:
         pls_in_order = get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
         report_has_enterprise = usage_result.has_enterprise_support()
@@ -166,6 +168,7 @@ class AgreementJournalGenerator:
             billing_report_rows=report_builder.build(),
             billing_report_rows_by_account=report_builder.build_by_account(),
             pls_mismatches=pls_mismatches,
+            invoice_ids=invoice_ids,
         )
 
     def _generate_usage_lines(

--- a/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/generators/authorization.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from mpt_extension_sdk.mpt_http.mpt import get_agreements_by_query
 from mpt_extension_sdk.runtime.tracer import dynamic_trace_span
 
@@ -40,15 +42,20 @@ class AuthorizationJournalGenerator:
         self._billing_period = context.billing_period
         self._notifier = context.notifier
 
-    @with_log_context(lambda _, authorization, **kwargs: authorization.get("id"))
+    @with_log_context(lambda _, authorization, *args, **kwargs: authorization.get("id"))
     @dynamic_trace_span(
-        lambda _, authorization, **kwargs: f"Authorization {authorization.get('id')}",
+        lambda _, authorization, *args, **kwargs: f"Authorization {authorization.get('id')}",
     )
-    def run(self, authorization: dict) -> AuthorizationJournalResult:
+    def run(
+        self,
+        authorization: dict,
+        billing_aws_client_provider: Callable[[], AWSClient],
+    ) -> AuthorizationJournalResult:
         """Generate billing journal for the given authorization.
 
         Args:
             authorization: The authorization data to process.
+            billing_aws_client_provider: Provider for the billing AWS client.
 
         Returns:
             AuthorizationJournalResult containing lines and generated reports.
@@ -76,7 +83,7 @@ class AuthorizationJournalGenerator:
             aws_client=AWSClient(self._config, pma_account, self._config.management_role_name),
         )
 
-        aws_client = AWSClient(self._config, pma_account, self._config.billing_role_name)
+        aws_client = billing_aws_client_provider()
 
         return self._process_agreements(
             auth_context,
@@ -139,6 +146,7 @@ class AuthorizationJournalGenerator:
             )
         if agreement_result.pls_mismatches:
             result.pls_mismatches.extend(agreement_result.pls_mismatches)
+        result.invoice_ids.update(agreement_result.invoice_ids)
 
     def _apply_pma_usage_to_report(
         self,

--- a/swo_aws_extension/flows/jobs/billing_journal/models/invoice.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/invoice.py
@@ -50,3 +50,8 @@ class OrganizationInvoiceResult:
 
     raw_data: list[dict] = field(default_factory=list)
     invoice: OrganizationInvoice = field(default_factory=OrganizationInvoice)
+
+    @property
+    def invoice_ids(self) -> set[str]:
+        """The complete AWS invoice IDs present in the raw invoice summaries."""
+        return {summary["InvoiceId"] for summary in self.raw_data if summary.get("InvoiceId")}

--- a/swo_aws_extension/flows/jobs/billing_journal/models/journal_result.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/models/journal_result.py
@@ -53,6 +53,15 @@ class AgreementJournalResult:
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
     billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)
+    invoice_ids: set[str] = field(default_factory=set)
+
+
+@dataclass
+class InvoiceAttachmentResult:
+    """Result of attaching AWS invoice documents to a journal."""
+
+    uploaded_invoice_ids: set[str] = field(default_factory=set)
+    failed_invoice_ids: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -64,3 +73,4 @@ class AuthorizationJournalResult:
     billing_report_rows: list[BillingReportRow] = field(default_factory=list)
     billing_report_rows_by_account: list[BillingReportRow] = field(default_factory=list)
     pls_mismatches: list[PlsMismatch] = field(default_factory=list)
+    invoice_ids: set[str] = field(default_factory=set)

--- a/swo_aws_extension/flows/jobs/billing_journal/providers.py
+++ b/swo_aws_extension/flows/jobs/billing_journal/providers.py
@@ -1,0 +1,21 @@
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.config import Config
+
+
+class BillingAWSClientProvider:
+    """Lazily create and reuse the billing AWS client for one authorization."""
+
+    def __init__(self, config: Config, pma_account: str) -> None:
+        self._config = config
+        self._pma_account = pma_account
+        self._client: AWSClient | None = None
+
+    def __call__(self) -> AWSClient:
+        """Return the cached billing AWS client."""
+        if self._client is None:
+            self._client = AWSClient(
+                self._config,
+                self._pma_account,
+                self._config.billing_role_name,
+            )
+        return self._client

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -1,6 +1,9 @@
 import datetime as dt
+from http import HTTPStatus
 
+import boto3
 import pytest
+import responses
 from botocore.exceptions import ClientError
 
 from swo_aws_extension.aws.client import MAX_RESULTS_PER_PAGE, get_paged_response
@@ -15,6 +18,18 @@ from swo_aws_extension.flows.jobs.billing_journal.models.billing_period import B
 # see more: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations/client/terminate_responsibility_transfer.html#
 class InvalidInputException(ClientError):  # noqa: N818
     """Dummy exception for testing purposes."""
+
+
+class ResourceNotFoundException(ClientError):  # noqa: N818
+    """Dummy exception for testing purposes."""
+
+
+@pytest.fixture
+def resource_not_found_error():
+    return ResourceNotFoundException(
+        {"Error": {"Code": "ResourceNotFoundException"}},
+        "GetInvoicePDF",
+    )
 
 
 @pytest.fixture
@@ -720,3 +735,133 @@ def test_list_invoice_summaries_success(config, aws_client_factory, mock_get_pag
     assert len(result) == 1
     assert result[0]["InvoiceId"] == "INV-001"
     mock_get_paged_response.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "client_getter",
+    [
+        "_get_organization_client",
+        "_get_sts_client",
+        "_get_cost_explorer_client",
+        "_get_billing_client",
+        "_get_billing_conductor_client",
+        "_get_partner_central_client",
+        "_get_invoicing_client",
+    ],
+)
+def test_boto3_clients_use_standard_retry_mode(config, aws_client_factory, client_getter):
+    mock_aws_client, _ = aws_client_factory(config, "test_account_id", "test_role_name")
+
+    getattr(mock_aws_client, client_getter)()  # act
+
+    client_config = boto3.client.call_args.kwargs["config"]
+    assert client_config.retries == {"mode": "standard"}
+
+
+def test_assume_role_uses_standard_retry_mode(config, aws_client_factory):
+    aws_client_factory(config, "test_account_id", "test_role_name")  # act
+
+    assume_role_call = boto3.client.call_args_list[0]
+    assert assume_role_call.kwargs["config"].retries == {"mode": "standard"}
+
+
+def test_get_invoice_pdf_success(config, aws_client_factory):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    response = {"InvoicePDF": {"DocumentUrl": "https://example.test/invoice.pdf"}}
+    mock_client.get_invoice_pdf.return_value = response
+
+    result = mock_aws_client.get_invoice_pdf("INV-001")
+
+    assert result == response
+    mock_client.get_invoice_pdf.assert_called_once_with(InvoiceId="INV-001")
+
+
+def test_get_invoice_pdf_retries_not_found(
+    mocker, config, aws_client_factory, resource_not_found_error
+):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+    response = {"InvoicePDF": {"DocumentUrl": "https://example.test/invoice.pdf"}}
+    mock_client.get_invoice_pdf.side_effect = [
+        resource_not_found_error,
+        resource_not_found_error,
+        response,
+    ]
+    mock_sleep = mocker.patch("swo_aws_extension.aws.client.time.sleep", autospec=True)
+
+    result = mock_aws_client.get_invoice_pdf("INV-001")
+
+    assert result == response
+    assert mock_client.get_invoice_pdf.call_count == 3
+    assert mock_sleep.call_args_list == [mocker.call(1), mocker.call(2)]
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["AccessDeniedException", "ThrottlingException", "InternalServerException"],
+)
+def test_get_invoice_pdf_skips_other_errors(mocker, config, aws_client_factory, error_code):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+    mock_client.get_invoice_pdf.side_effect = ClientError(
+        {"Error": {"Code": error_code}},
+        "GetInvoicePDF",
+    )
+    mock_sleep = mocker.patch("swo_aws_extension.aws.client.time.sleep", autospec=True)
+
+    with pytest.raises(AWSError, match=error_code):
+        mock_aws_client.get_invoice_pdf("INV-001")
+
+    mock_client.get_invoice_pdf.assert_called_once_with(InvoiceId="INV-001")
+    mock_sleep.assert_not_called()
+
+
+def test_get_invoice_pdf_stops_after_three_tries(
+    mocker, config, aws_client_factory, resource_not_found_error
+):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.exceptions.ResourceNotFoundException = ResourceNotFoundException
+    mock_client.get_invoice_pdf.side_effect = resource_not_found_error
+    mock_sleep = mocker.patch("swo_aws_extension.aws.client.time.sleep", autospec=True)
+
+    with pytest.raises(AWSError, match="ResourceNotFoundException"):
+        mock_aws_client.get_invoice_pdf("INV-001")
+
+    assert mock_client.get_invoice_pdf.call_count == 3
+    assert mock_sleep.call_args_list == [mocker.call(1), mocker.call(2)]
+
+
+def test_download_invoice_pdf_returns_content(config, aws_client_factory, requests_mocker):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    document_url = "https://example.test/invoice.pdf"
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {"DocumentUrl": document_url}}
+    requests_mocker.add(responses.GET, document_url, body=b"invoice-pdf", status=HTTPStatus.OK)
+
+    result = mock_aws_client.download_invoice_pdf("INV-001")
+
+    assert result == b"invoice-pdf"
+    mock_client.get_invoice_pdf.assert_called_once_with(InvoiceId="INV-001")
+
+
+def test_download_invoice_pdf_missing_url_raises(config, aws_client_factory):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {}}
+
+    with pytest.raises(AWSError, match="Invoice PDF URL is missing"):
+        mock_aws_client.download_invoice_pdf("INV-001")
+
+
+def test_download_invoice_pdf_error_redacts_url(config, aws_client_factory, requests_mocker):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    document_url = "https://example.test/invoice.pdf?X-Amz-Signature=super-secret-signature"
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {"DocumentUrl": document_url}}
+    requests_mocker.add(responses.GET, document_url, status=HTTPStatus.FORBIDDEN)
+
+    with pytest.raises(AWSError) as exc_info:
+        mock_aws_client.download_invoice_pdf("INV-001")
+
+    assert "super-secret-signature" not in str(exc_info.value)
+    assert "X-Amz-Signature" not in str(exc_info.value)
+    assert "403 Forbidden" in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True

--- a/tests/flows/jobs/billing_journal/generators/test_agreement.py
+++ b/tests/flows/jobs/billing_journal/generators/test_agreement.py
@@ -141,6 +141,12 @@ def test_run(
     mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
     mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
         invoice=OrganizationInvoice(),
+        raw_data=[
+            {"InvoiceId": "INV-001"},
+            {"InvoiceId": "INV-001"},
+            {"InvoiceId": "INV-002"},
+            {"InvoicingEntity": "AWS Inc."},
+        ],
     )
     generator = AgreementJournalGenerator(
         _build_auth_context(mock_aws_client),
@@ -152,6 +158,7 @@ def test_run(
     result = generator.run(agreement)
 
     assert result.lines == [mock_journal_line, mock_discount_line, mock_pls_line]
+    assert result.invoice_ids == {"INV-001", "INV-002"}
     mock_invoice_generator.run.assert_called_once()
     mock_generator_instance.generate.assert_called_once()
     mock_discounts_instance.process.assert_called_once()

--- a/tests/flows/jobs/billing_journal/generators/test_authorization.py
+++ b/tests/flows/jobs/billing_journal/generators/test_authorization.py
@@ -62,6 +62,11 @@ def mock_aws_client_cls(mocker):
 
 
 @pytest.fixture
+def billing_aws_client_provider(mocker):
+    return mocker.Mock(return_value=mocker.create_autospec(AWSClient, instance=True))
+
+
+@pytest.fixture
 def mock_generate_billing_report_rows(mocker):
     mock_builder = mocker.MagicMock()
     mock_builder.build.return_value = []
@@ -77,12 +82,13 @@ def test_no_agreements_returns_empty_list(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mock_get_agreements.return_value = []
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result == AuthorizationJournalResult()
     mock_agreement_generator_cls.assert_not_called()
@@ -96,19 +102,28 @@ def test_processes_agreements(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mock_get_agreements.return_value = [{"id": "AGR-1"}, {"id": "AGR-2"}]
     mock_journal_line = mocker.MagicMock(spec=JournalLine)
     mock_agr_gen = mocker.MagicMock(spec=AgreementJournalGenerator)
-    mock_agr_gen.run.return_value = AgreementJournalResult(lines=[mock_journal_line])
+    mock_agr_gen.run.side_effect = [
+        AgreementJournalResult(lines=[mock_journal_line], invoice_ids={"INV-001"}),
+        AgreementJournalResult(lines=[mock_journal_line], invoice_ids={"INV-001", "INV-002"}),
+    ]
     mock_agreement_generator_cls.return_value = mock_agr_gen
+    billing_aws_client = billing_aws_client_provider.return_value
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert mock_agr_gen.run.call_count == 2
     assert result.lines == [mock_journal_line, mock_journal_line]
+    assert result.invoice_ids == {"INV-001", "INV-002"}
+    billing_aws_client_provider.assert_called_once_with()
+    mock_usage_generator_cls.assert_called_once_with(billing_aws_client)
+    mock_invoice_generator_cls.assert_called_once_with(billing_aws_client)
 
 
 def test_exception_sends_error(
@@ -119,6 +134,7 @@ def test_exception_sends_error(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mock_get_agreements.return_value = [{"id": "AGR-1"}]
@@ -127,7 +143,7 @@ def test_exception_sends_error(
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result == AuthorizationJournalResult()
     expected_message = "Failed to generate billing journal for AGR-1: Test Error"
@@ -144,6 +160,7 @@ def test_includes_report_in_result(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     report = OrganizationReport(organization_data={"usage": [{"key": "val"}]})
@@ -161,7 +178,7 @@ def test_includes_report_in_result(
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result.reports_by_agreement == {"AGR-1": report}
     assert result.billing_report_rows == [mock_row]
@@ -176,6 +193,7 @@ def test_includes_pls_mismatches_in_result(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     authorization,
 ):
     mismatch = PlsMismatch(agreement_id="AGR-1", pls_in_order=True, report_has_enterprise=False)
@@ -188,7 +206,7 @@ def test_includes_pls_mismatches_in_result(
     mock_agreement_generator_cls.return_value = mock_agr_gen
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result.pls_mismatches == [mismatch]
 
@@ -201,6 +219,7 @@ def test_pma_usage_included_in_report_rows(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     mock_generate_billing_report_rows,
     authorization,
 ):
@@ -220,7 +239,7 @@ def test_pma_usage_included_in_report_rows(
     mock_generate_billing_report_rows.build.return_value = [mock_row]
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     mock_invoice_gen.run.assert_any_call("MPA-123", "MPA-123", mock_context.billing_period, "USD")
     mock_usage_gen.run_for_pma.assert_called_once_with(
@@ -241,6 +260,7 @@ def test_pma_usage_error_does_not_crash(
     mock_usage_generator_cls,
     mock_invoice_generator_cls,
     mock_aws_client_cls,
+    billing_aws_client_provider,
     mock_generate_billing_report_rows,
     authorization,
 ):
@@ -256,7 +276,7 @@ def test_pma_usage_error_does_not_crash(
     mock_invoice_gen.run.side_effect = AWSError("PMA invoice fetch failed")
     generator = AuthorizationJournalGenerator(mock_context)
 
-    result = generator.run(authorization)
+    result = generator.run(authorization, billing_aws_client_provider)
 
     assert result.billing_report_rows == []
     mock_generate_billing_report_rows.assert_not_called()

--- a/tests/flows/jobs/billing_journal/models/test_invoice.py
+++ b/tests/flows/jobs/billing_journal/models/test_invoice.py
@@ -5,6 +5,7 @@ import pytest
 from swo_aws_extension.flows.jobs.billing_journal.models.invoice import (
     InvoiceEntity,
     OrganizationInvoice,
+    OrganizationInvoiceResult,
 )
 
 PRIMARY_ENTITY_NAME = "AWS EMEA SARL"
@@ -100,3 +101,22 @@ def test_primary_invoice_id_returns_default_when_no_entities():
     result = invoice.primary_invoice_id
 
     assert result == "invoice_id"
+
+
+def test_invoice_ids_deduplicates_and_skips_missing_ids():
+    result = OrganizationInvoiceResult(
+        raw_data=[
+            {"InvoiceId": PRIMARY_INVOICE_ID},
+            {"InvoiceId": PRIMARY_INVOICE_ID},
+            {"InvoiceId": SECONDARY_INVOICE_ID},
+            {"InvoicingEntity": SECONDARY_ENTITY_NAME},
+        ],
+    )
+
+    assert result.invoice_ids == {PRIMARY_INVOICE_ID, SECONDARY_INVOICE_ID}
+
+
+def test_invoice_ids_returns_empty_when_no_raw_data():
+    result = OrganizationInvoiceResult()
+
+    assert result.invoice_ids == set()

--- a/tests/flows/jobs/billing_journal/test_billing_invoice_attachment_creator.py
+++ b/tests/flows/jobs/billing_journal/test_billing_invoice_attachment_creator.py
@@ -1,0 +1,88 @@
+from io import BytesIO
+
+import pytest
+from requests import HTTPError
+
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.aws.errors import AWSError
+from swo_aws_extension.flows.jobs.billing_journal.billing_invoice_attachment_creator import (
+    BillingInvoiceAttachmentCreator,
+)
+
+
+@pytest.fixture
+def aws_client(mocker):
+    return mocker.create_autospec(AWSClient, instance=True)
+
+
+@pytest.fixture
+def billing_api_client(mocker):
+    # BillingClient.journal is set in __init__ and its attachments(id).upload chain is
+    # resolved dynamically, so it cannot be autospecced; a plain mock is required here.
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def creator(aws_client, billing_api_client):
+    return BillingInvoiceAttachmentCreator(aws_client, billing_api_client)
+
+
+def test_create_for_journal_uploads_invoice_pdf(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.return_value = b"invoice-pdf"
+
+    result = creator.create_for_journal("JRN-1", {"INV-001"})
+
+    assert (result.uploaded_invoice_ids, result.failed_invoice_ids) == ({"INV-001"}, set())
+    aws_client.download_invoice_pdf.assert_called_once_with("INV-001")
+    billing_api_client.journal.attachments.assert_called_once_with("JRN-1")
+    upload = billing_api_client.journal.attachments.return_value.upload
+    upload.assert_called_once()
+    upload_kwargs = upload.call_args.kwargs
+    assert upload_kwargs["filename"] == "AWS-Invoice-INV-001.pdf"
+    assert upload_kwargs["mimetype"] == "application/pdf"
+    assert isinstance(upload_kwargs["file"], BytesIO)
+    assert upload_kwargs["file"].getvalue() == b"invoice-pdf"
+
+
+def test_create_for_journal_continues_after_failure(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.side_effect = [AWSError("AWS failure"), b"invoice-pdf"]
+    upload = billing_api_client.journal.attachments.return_value.upload
+
+    result = creator.create_for_journal("JRN-1", {"INV-001", "INV-002"})
+
+    assert result.failed_invoice_ids == {"INV-001"}
+    assert result.uploaded_invoice_ids == {"INV-002"}
+    assert aws_client.download_invoice_pdf.call_count == 2
+    billing_api_client.journal.attachments.assert_called_once_with("JRN-1")
+    upload.assert_called_once()
+    assert upload.call_args.kwargs["filename"] == "AWS-Invoice-INV-002.pdf"
+
+
+def test_create_for_journal_records_upload_failure(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.return_value = b"invoice-pdf"
+    upload = billing_api_client.journal.attachments.return_value.upload
+    upload.side_effect = HTTPError("Upload failed")
+
+    result = creator.create_for_journal("JRN-1", {"INV-001"})
+
+    assert result.failed_invoice_ids == {"INV-001"}
+    assert result.uploaded_invoice_ids == set()
+
+
+def test_create_for_journal_records_download_failure(creator, aws_client, billing_api_client):
+    aws_client.download_invoice_pdf.side_effect = AWSError("Invoice PDF URL is missing")
+    upload = billing_api_client.journal.attachments.return_value.upload
+
+    result = creator.create_for_journal("JRN-1", {"INV-001"})
+
+    assert result.failed_invoice_ids == {"INV-001"}
+    assert result.uploaded_invoice_ids == set()
+    upload.assert_not_called()
+
+
+def test_create_for_journal_with_no_invoices_does_nothing(creator, aws_client):
+    result = creator.create_for_journal("JRN-1", set())
+
+    assert result.uploaded_invoice_ids == set()
+    assert result.failed_invoice_ids == set()
+    aws_client.download_invoice_pdf.assert_not_called()

--- a/tests/flows/jobs/billing_journal/test_billing_journal_service.py
+++ b/tests/flows/jobs/billing_journal/test_billing_journal_service.py
@@ -2,7 +2,13 @@ from decimal import Decimal
 
 import pytest
 
-from swo_aws_extension.constants import BILLING_JOURNAL_ERROR_TITLE
+from swo_aws_extension.constants import (
+    BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+    BILLING_JOURNAL_ERROR_TITLE,
+)
+from swo_aws_extension.flows.jobs.billing_journal.billing_invoice_attachment_creator import (
+    BillingInvoiceAttachmentCreator,
+)
 from swo_aws_extension.flows.jobs.billing_journal.billing_journal_service import (
     BillingJournalService,
 )
@@ -17,6 +23,7 @@ from swo_aws_extension.flows.jobs.billing_journal.models.journal_line import (
 from swo_aws_extension.flows.jobs.billing_journal.models.journal_result import (
     AuthorizationJournalResult,
     BillingReportRow,
+    InvoiceAttachmentResult,
     PlsMismatch,
 )
 from swo_aws_extension.flows.jobs.billing_journal.models.usage import OrganizationReport
@@ -61,7 +68,7 @@ def test_processes_authorizations(
 
     service.run()  # act
 
-    mock_auth_gen.run.assert_called_once_with(authorization)
+    mock_auth_gen.run.assert_called_once_with(authorization, mocker.ANY)
 
 
 def test_exception_sends_error(
@@ -208,6 +215,56 @@ def test_uploads_attachments_when_reports_present(
     mock_journal_manager.notify_success.assert_called_once_with("JRN-1", 1)
 
 
+def test_uploads_invoice_attachments_and_sends_warning_for_failures(
+    mocker, mock_context, mock_get_authorizations, mock_auth_generator_cls
+):
+    mock_context.dry_run = False
+    authorization = {"id": "AUTH-1", "externalIds": {"operations": "PMA-123"}}
+    mock_get_authorizations.return_value = [authorization]
+    mock_auth_gen = mocker.MagicMock(spec=AuthorizationJournalGenerator)
+    mock_line = mocker.MagicMock(spec=JournalLine)
+    invoice_ids = {"INV-001", "INV-002"}
+    mock_auth_gen.run.return_value = AuthorizationJournalResult(
+        lines=[mock_line],
+        invoice_ids=invoice_ids,
+    )
+    mock_auth_generator_cls.return_value = mock_auth_gen
+    mock_journal_manager_cls = mocker.patch(f"{MODULE}.JournalManager", autospec=True)
+    mock_journal_manager = mock_journal_manager_cls.return_value
+    mock_journal_manager.get_pending_journal.return_value = mocker.MagicMock(id="JRN-1")
+    mock_aws_client_cls = mocker.patch(
+        "swo_aws_extension.flows.jobs.billing_journal.providers.AWSClient", autospec=True
+    )
+    mock_invoice_creator_cls = mocker.patch(
+        f"{MODULE}.BillingInvoiceAttachmentCreator", autospec=True
+    )
+    mock_invoice_creator = mocker.MagicMock(spec=BillingInvoiceAttachmentCreator)
+    mock_invoice_creator.create_for_journal.return_value = InvoiceAttachmentResult(
+        uploaded_invoice_ids={"INV-001"},
+        failed_invoice_ids={"INV-002"},
+    )
+    mock_invoice_creator_cls.return_value = mock_invoice_creator
+    service = BillingJournalService(mock_context)
+
+    service.run()  # act
+
+    mock_aws_client_cls.assert_called_once_with(
+        mock_context.config,
+        "PMA-123",
+        mock_context.config.billing_role_name,
+    )
+    mock_invoice_creator_cls.assert_called_once_with(
+        mock_aws_client_cls.return_value,
+        mock_context.billing_api_client,
+    )
+    mock_invoice_creator.create_for_journal.assert_called_once_with("JRN-1", invoice_ids)
+    mock_context.notifier.send_warning.assert_called_once_with(
+        title=BILLING_INVOICE_ATTACHMENT_WARNING_TITLE,
+        text="Failed to attach AWS invoices to journal JRN-1: INV-002",
+    )
+    mock_journal_manager.notify_success.assert_called_once_with("JRN-1", 1)
+
+
 def test_dry_run_skips_upload(
     mocker, mock_context, mock_get_authorizations, mock_auth_generator_cls
 ):
@@ -226,11 +283,15 @@ def test_dry_run_skips_upload(
     )
     mock_auth_generator_cls.return_value = mock_auth_gen
     mock_journal_manager_cls = mocker.patch(f"{MODULE}.JournalManager", autospec=True)
+    mock_invoice_creator_cls = mocker.patch(
+        f"{MODULE}.BillingInvoiceAttachmentCreator", autospec=True
+    )
     service = BillingJournalService(mock_context)
 
     service.run()  # act
 
     mock_journal_manager_cls.assert_not_called()
+    mock_invoice_creator_cls.assert_not_called()
 
 
 def test_dry_run_skips_upload_with_empty_reports(

--- a/tests/flows/jobs/billing_journal/test_providers.py
+++ b/tests/flows/jobs/billing_journal/test_providers.py
@@ -1,0 +1,34 @@
+import pytest
+
+from swo_aws_extension.flows.jobs.billing_journal.providers import BillingAWSClientProvider
+
+MODULE = "swo_aws_extension.flows.jobs.billing_journal.providers"
+
+
+@pytest.fixture
+def mock_aws_client_cls(mocker):
+    return mocker.patch(f"{MODULE}.AWSClient", autospec=True)
+
+
+def test_does_not_create_client_until_called(config, mock_aws_client_cls):
+    BillingAWSClientProvider(config, "PMA-123")  # act
+
+    mock_aws_client_cls.assert_not_called()
+
+
+def test_creates_billing_client_when_called(config, mock_aws_client_cls):
+    provider = BillingAWSClientProvider(config, "PMA-123")
+
+    client = provider()  # act
+
+    assert client is mock_aws_client_cls.return_value
+    mock_aws_client_cls.assert_called_once_with(config, "PMA-123", config.billing_role_name)
+
+
+def test_reuses_the_same_client(config, mock_aws_client_cls):
+    provider = BillingAWSClientProvider(config, "PMA-123")
+
+    clients = [provider(), provider()]  # act
+
+    assert clients[0] is clients[1]
+    mock_aws_client_cls.assert_called_once()


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Backport of the "AWS Billing: Add Invoices to Journals" feature to `release/5`. Jira: [MPT-23481](https://softwareone.atlassian.net/browse/MPT-23481).

**This is a manual port, not a cherry-pick.** On `main` the feature lives in `swo_aws_extension/billing/`, but `release/5` still keeps the billing code under `swo_aws_extension/flows/jobs/billing_journal/` and uses different ruff conventions, so the merged commits could not be cherry-picked and the change was re-implemented against release/5's structure.

## What was ported (from the merged main PRs)

- **MPT-23379** — boto3 `standard` retry mode on every `AWSClient` boto3 client.
- **MPT-23324** — complete AWS invoice IDs collected from the raw summaries and propagated through the journal generation results (`OrganizationInvoiceResult.invoice_ids`, `AgreementJournalResult`/`AuthorizationJournalResult.invoice_ids`), logged during `--dry-run`.
- **MPT-23325** — `AWSClient.get_invoice_pdf` (retries `ResourceNotFoundException`) and `download_invoice_pdf` (downloads the pre-signed URL, re-raises a redacted `AWSError` that never leaks the signed URL).
- **MPT-23326** — `BillingAWSClientProvider` + `BillingInvoiceAttachmentCreator`, wired into `BillingJournalService`: after uploading lines and reports, invoices are attached as `AWS-Invoice-{id}.pdf`; partial failures raise a Teams warning while the journal is still reported successful; nothing runs during `--dry-run`.

## Validation

Full test suite green (1052 passed); ruff + flake8 clean.

Note: enabling the feature at runtime still depends on the `invoicing:GetInvoicePDF` IAM permission (MPT-23327), an external dependency.


[MPT-23481]: https://softwareone.atlassian.net/browse/MPT-23481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Backports AWS invoice attachment support to the release/5 billing workflow.
- Adds standard boto3 retry configuration and resilient invoice PDF retrieval/download with redacted errors.
- Propagates invoice IDs through journal generation and attaches PDFs as `AWS-Invoice-{id}.pdf`.
- Reports partial attachment failures through Teams warnings while preserving journal success.
- Skips invoice processing during dry runs.
- Adds comprehensive tests; 1,052 tests pass with ruff and flake8 clean.
- Requires the `invoicing:GetInvoicePDF` IAM permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->