### PR TITLE
MPT-23613 apply reconciled markup to journal PP before upload

### DIFF
--- a/swo_aws_extension/billing/generators/additional_line_processors/extra_discounts.py
+++ b/swo_aws_extension/billing/generators/additional_line_processors/extra_discounts.py
@@ -53,7 +53,7 @@ class BaseExtraDiscountProcessor(AdditionalLineProcessor):
             logger.info("Principal invoice amount is zero, skipping extra discounts processing.")
             return []
 
-        if not self._is_applicable(agreement):
+        if not self._is_applicable(agreement, usage_result):
             return []
 
         discount_percentage = self._get_discount_percentage(agreement)
@@ -72,7 +72,7 @@ class BaseExtraDiscountProcessor(AdditionalLineProcessor):
         ]
 
     @abstractmethod
-    def _is_applicable(self, agreement: dict) -> bool:
+    def _is_applicable(self, agreement: dict, usage_result: OrganizationUsageResult) -> bool:
         """Check if this specific discount is applicable based on agreement parameters."""
 
     @abstractmethod
@@ -96,7 +96,7 @@ class ServiceDiscountProcessor(BaseExtraDiscountProcessor):
         super().__init__(service_name="SWO additional Usage discount")
 
     @override
-    def _is_applicable(self, agreement: dict) -> bool:
+    def _is_applicable(self, agreement: dict, usage_result: OrganizationUsageResult) -> bool:
         return get_channel_handshake_approval_status(agreement) == ChannelHandshakeDeployed.YES
 
     @override
@@ -173,7 +173,7 @@ class SupportDiscountProcessor(BaseExtraDiscountProcessor):
         super().__init__(service_name="SWO additional Support discount")
 
     @override
-    def _is_applicable(self, agreement: dict) -> bool:
+    def _is_applicable(self, agreement: dict, usage_result: OrganizationUsageResult) -> bool:
         if get_channel_handshake_approval_status(agreement) != ChannelHandshakeDeployed.YES:
             return False
         return get_support_type(agreement) == SupportTypesEnum.AWS_RESOLD_SUPPORT
@@ -221,10 +221,12 @@ class PlSDiscountProcessor(BaseExtraDiscountProcessor):
         self._charge_percentage = charge_percentage
 
     @override
-    def _is_applicable(self, agreement: dict) -> bool:
+    def _is_applicable(self, agreement: dict, usage_result: OrganizationUsageResult) -> bool:
         if get_channel_handshake_approval_status(agreement) != ChannelHandshakeDeployed.YES:
             return False
-        return get_support_type(agreement) == SupportTypesEnum.PARTNER_LED_SUPPORT
+        if get_support_type(agreement) != SupportTypesEnum.PARTNER_LED_SUPPORT:
+            return False
+        return usage_result.has_enterprise_support()
 
     @override
     def _get_discount_percentage(self, agreement: dict) -> Decimal:

--- a/swo_aws_extension/billing/generators/agreement.py
+++ b/swo_aws_extension/billing/generators/agreement.py
@@ -26,6 +26,7 @@ from swo_aws_extension.billing.models.journal_line import JournalDetails, Journa
 from swo_aws_extension.billing.models.journal_result import AgreementJournalResult, PlsMismatch
 from swo_aws_extension.billing.models.usage import OrganizationUsageResult
 from swo_aws_extension.constants import (
+    DEC_ZERO,
     ResponsibilityTransferStatus,
     SplitBillingPolicyEnum,
     SupportTypesEnum,
@@ -39,6 +40,47 @@ from swo_aws_extension.parameters import (
 from swo_aws_extension.utils.decorators import with_log_context
 
 logger = get_logger(__name__)
+
+
+def calculate_markup(
+    all_lines: list[JournalLine],
+    organization_invoice,
+    context: ReportContext,
+):
+    """Compute the dynamic markup reconciling the journal total (sp) against the invoice (pp).
+
+    This must run once the journal lines for the agreement exist and before they are
+    rewritten by ``apply_markup_to_lines``, since it reads their current (usage-based)
+    price. The resulting value feeds both the report row and the journal rewrite.
+    """
+    sp = sum((line.price.pp_x1 for line in all_lines if line.is_valid()), DEC_ZERO)
+    pp = (
+        organization_invoice.base_total_amount_before_tax
+        if context.currency == "USD"
+        else organization_invoice.payment_currency_total_amount_before_tax
+    )
+    return (sp - pp) / pp if pp else DEC_ZERO
+
+
+def apply_markup_to_lines(lines: list[JournalLine], markup) -> None:
+    """Rewrite each valid line's price as the invoice-derived purchase price.
+
+    Lines are priced up front as the usage-based sales amount (sp). The
+    billing platform doesn't support per-service dynamic markups, so instead
+    we upload the purchase price (pp) per line and set this same agreement-
+    level markup on the platform; it then recomputes sp = pp * (1 + markup)
+    itself. Dividing every line by (1 + markup) rewrites the total from sp
+    down to pp while preserving each line's relative share, so the platform's
+    own calculation reconstructs the original sp exactly.
+    """
+    divisor = 1 + markup
+    if divisor <= DEC_ZERO:
+        return
+    for line in lines:
+        if not line.is_valid():
+            continue
+        line.price.pp_x1 = round(line.price.pp_x1 / divisor, 6)
+        line.price.unit_pp = round(line.price.unit_pp / divisor, 6)
 
 
 class AgreementJournalGenerator:
@@ -152,25 +194,39 @@ class AgreementJournalGenerator:
                 )
             )
 
-        report_builder = BillingReportRowsBuilder(
-            ReportContext.from_contexts(self._auth_context, journal_details),
-            usage_result,
+        result = self._build_agreement_journal_result(
+            all_lines,
+            journal_details,
             organization_invoice,
+            usage_result,
         )
+        result.invoice_ids = invoice_ids
+        result.pls_mismatches = pls_mismatches
+        return result
+
+    def _build_agreement_journal_result(
+        self,
+        all_lines: list[JournalLine],
+        journal_details: JournalDetails,
+        organization_invoice,
+        usage_result: OrganizationUsageResult,
+    ) -> AgreementJournalResult:
+        context = ReportContext.from_contexts(self._auth_context, journal_details)
+        report_builder = BillingReportRowsBuilder(context, usage_result, organization_invoice)
+        billing_report_rows = report_builder.build()
+
+        markup = calculate_markup(all_lines, organization_invoice, context)
+        spp_summary_row = build_spp_summary_row(
+            context, all_lines, billing_report_rows, organization_invoice, markup
+        )
+        apply_markup_to_lines(all_lines, markup)
 
         return AgreementJournalResult(
             lines=all_lines,
             report=usage_result.reports,
-            billing_report_rows=report_builder.build(),
+            billing_report_rows=billing_report_rows,
             billing_report_rows_by_account=report_builder.build_by_account(),
-            pls_mismatches=pls_mismatches,
-            invoice_ids=invoice_ids,
-            spp_summary_row=build_spp_summary_row(
-                ReportContext.from_contexts(self._auth_context, journal_details),
-                all_lines,
-                report_builder.build(),
-                organization_invoice,
-            ),
+            spp_summary_row=spp_summary_row,
         )
 
     def _generate_usage_lines(

--- a/swo_aws_extension/billing/generators/billing_report_rows.py
+++ b/swo_aws_extension/billing/generators/billing_report_rows.py
@@ -158,6 +158,7 @@ def build_spp_summary_row(
     all_lines: list[JournalLine],
     billing_report_rows: list[BillingReportRow],
     organization_invoice: OrganizationInvoice,
+    markup: Decimal,
 ) -> OrganizationSppSummaryRow:
     """Build one organization-level row reconciling the journal total (SP) against PP."""
     sp = sum((line.price.pp_x1 for line in all_lines if line.is_valid()), DEC_ZERO)
@@ -181,7 +182,7 @@ def build_spp_summary_row(
         spp_discount=spp_discount,
         spp_discount_pct=abs(spp_discount) / pp if pp else DEC_ZERO,
         list_price=organization_invoice.payment_currency_subtotal_amount,
-        markup=(sp - pp) / pp if pp else DEC_ZERO,
+        markup=markup,
     )
 
 

--- a/tests/billing/generators/additional_line_processors/test_extra_discounts.py
+++ b/tests/billing/generators/additional_line_processors/test_extra_discounts.py
@@ -361,6 +361,7 @@ def test_pls_discount_processor(
     usage_result.usage_by_account["ACC-1"].metrics.extend([
         create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
         create_metric("RDS", AWSRecordTypeEnum.USAGE, "50.00"),
+        create_metric("AWS Support (Enterprise)", AWSRecordTypeEnum.SUPPORT, "0.00"),
     ])
     processor = PlSDiscountProcessor(Decimal("5.0"))
 
@@ -370,6 +371,29 @@ def test_pls_discount_processor(
     assert result[0].price.unit_pp == Decimal("-30.000000")
     assert result[0].description.value1 == "SWO additional PLS Support discount"
     assert result[0].external_ids.vendor == "MPA-1"
+
+
+def test_pls_discount_processor_skips_when_no_enterprise_support_in_usage(
+    agreement,
+    usage_result,
+    journal_details,
+    organization_invoice,
+):
+    agreement["parameters"]["ordering"].append(
+        {"externalId": "supportType", "value": SupportTypesEnum.PARTNER_LED_SUPPORT},
+    )
+    agreement["parameters"]["fulfillment"].append(
+        {"externalId": "plsDiscount", "value": "20.0"},
+    )
+    usage_result.usage_by_account["ACC-1"].metrics.extend([
+        create_metric("EC2", AWSRecordTypeEnum.USAGE, "100.00"),
+        create_metric("RDS", AWSRecordTypeEnum.USAGE, "50.00"),
+    ])
+    processor = PlSDiscountProcessor(Decimal("5.0"))
+
+    result = processor.process(agreement, usage_result, journal_details, organization_invoice)
+
+    assert not result
 
 
 @pytest.mark.parametrize(

--- a/tests/billing/generators/test_agreement.py
+++ b/tests/billing/generators/test_agreement.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from decimal import Decimal
 
 import pytest
 
@@ -11,6 +12,12 @@ from swo_aws_extension.billing.generators.additional_line_processors.saving_plan
 )
 from swo_aws_extension.billing.generators.agreement import (
     AgreementJournalGenerator,
+    apply_markup_to_lines,
+    calculate_markup,
+)
+from swo_aws_extension.billing.generators.billing_report_rows import (
+    ReportContext,
+    build_spp_summary_row,
 )
 from swo_aws_extension.billing.generators.invoice import InvoiceGenerator
 from swo_aws_extension.billing.generators.journal_line import (
@@ -25,8 +32,10 @@ from swo_aws_extension.billing.models.invoice import (
     OrganizationInvoiceResult,
 )
 from swo_aws_extension.billing.models.journal_line import (
+    InvoiceDetails,
     JournalDetails,
     JournalLine,
+    Price,
 )
 from swo_aws_extension.billing.models.usage import (
     AccountUsage,
@@ -95,7 +104,16 @@ def mock_pls_charge_manager_cls(mocker):
 
 @pytest.fixture(autouse=True)
 def mock_build_spp_summary_row(mocker):
-    return mocker.patch(f"{MODULE}.build_spp_summary_row")
+    mock = mocker.patch(f"{MODULE}.build_spp_summary_row")
+    mock.return_value.markup = Decimal(0)
+    return mock
+
+
+def _mock_journal_line(mocker):
+    line = mocker.MagicMock(spec=JournalLine)
+    line.price = Price(Decimal("10.0"), Decimal("10.0"))
+    line.is_valid.return_value = True
+    return line
 
 
 def _build_agreement(support_type="ResoldSupport"):
@@ -135,9 +153,9 @@ def test_run(
     mock_builder.build_by_account.return_value = []
     mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="PartnerLedSupport")
-    mock_journal_line = mocker.MagicMock(spec=JournalLine)
-    mock_discount_line = mocker.MagicMock(spec=JournalLine)
-    mock_pls_line = mocker.MagicMock(spec=JournalLine)
+    mock_journal_line = _mock_journal_line(mocker)
+    mock_discount_line = _mock_journal_line(mocker)
+    mock_pls_line = _mock_journal_line(mocker)
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
     mock_line_generator_cls.return_value = mock_generator_instance
@@ -188,6 +206,7 @@ def test_run(
         result.lines,
         result.billing_report_rows,
         mock_invoice_generator.run.return_value.invoice,
+        mocker.ANY,
     )
 
 
@@ -205,7 +224,7 @@ def test_run_without_pls(
     mock_builder.build_by_account.return_value = []
     mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="DeveloperSupport")
-    mock_journal_line = mocker.MagicMock(spec=JournalLine)
+    mock_journal_line = _mock_journal_line(mocker)
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
     mock_line_generator_cls.return_value = mock_generator_instance
@@ -446,8 +465,8 @@ def test_pls_mismatch_param_resold_but_enterprise_in_report(
     mock_builder.build_by_account.return_value = []
     mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     agreement = _build_agreement(support_type="ResoldSupport")
-    mock_journal_line = mocker.MagicMock(spec=JournalLine)
-    mock_pls_line = mocker.MagicMock(spec=JournalLine)
+    mock_journal_line = _mock_journal_line(mocker)
+    mock_pls_line = _mock_journal_line(mocker)
     mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
     mock_generator_instance.generate.return_value = [mock_journal_line]
     mock_line_generator_cls.return_value = mock_generator_instance
@@ -495,7 +514,7 @@ def test_run_with_split_billing_enabled(
     mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
     mock_sp_processor = mocker.patch(f"{MODULE}.SavingPlansDistributionProcessor", autospec=True)
     mock_sp_instance = mocker.MagicMock(spec=SavingPlansDistributionProcessor)
-    mock_sp_line = mocker.MagicMock(spec=JournalLine)
+    mock_sp_line = _mock_journal_line(mocker)
     mock_sp_instance.process.return_value = [mock_sp_line]
     mock_sp_processor.return_value = mock_sp_instance
     agreement = {
@@ -534,3 +553,225 @@ def test_run_with_split_billing_enabled(
 
     mock_sp_instance.process.assert_called_once()
     assert mock_sp_line in result.lines
+
+
+def _build_real_line(amount, *, error=None):
+    journal_details = JournalDetails("AGR-1", "MPA", "2025-10-01", "2025-10-31")
+    invoice_details = InvoiceDetails(
+        service_name="EC2",
+        amount=amount,
+        account_id="ACC-1",
+        invoice_entity="ENT-1",
+        start_date="2025-10-01",
+        end_date="2025-10-31",
+        error=error,
+    )
+    return JournalLine.build(
+        item_external_id="ITEM-1", journal_details=journal_details, invoice_details=invoice_details
+    )
+
+
+def test_run_applies_markup_to_valid_line_prices(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    mock_line_generator_cls,
+    mock_extra_discounts_manager_cls,
+    mock_pls_charge_manager_cls,
+    mock_build_spp_summary_row,
+):
+    mock_build_spp_summary_row.side_effect = build_spp_summary_row
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
+    agreement = _build_agreement(support_type="DeveloperSupport")
+    real_line = _build_real_line(Decimal("100.00"))
+    mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
+    mock_generator_instance.generate.return_value = [real_line]
+    mock_line_generator_cls.return_value = mock_generator_instance
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
+    mock_usage_result.reports = OrganizationReport()
+    mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_result.has_enterprise_support.return_value = False
+    mock_usage_generator.run.return_value = mock_usage_result
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
+        invoice=OrganizationInvoice(base_total_amount_before_tax=Decimal("50.00")),
+    )
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)  # act
+
+    # sp = 100.00 (the only valid line), pp = 50.00 -> markup = 1.0 -> divisor = 2.0
+    assert result.spp_summary_row.markup == Decimal("1.0")
+    assert result.lines[0].price.pp_x1 == Decimal("50.00")
+    assert result.lines[0].price.unit_pp == Decimal("50.00")
+
+
+def test_run_skips_rescale_when_markup_divisor_not_positive(
+    mocker,
+    mock_context,
+    mock_aws_client,
+    mock_get_responsibility_transfer_id,
+    mock_line_generator_cls,
+    mock_extra_discounts_manager_cls,
+    mock_pls_charge_manager_cls,
+    mock_build_spp_summary_row,
+):
+    mock_build_spp_summary_row.side_effect = build_spp_summary_row
+    mock_builder = mocker.MagicMock()
+    mock_builder.build.return_value = []
+    mock_builder.build_by_account.return_value = []
+    mocker.patch(f"{MODULE}.BillingReportRowsBuilder", return_value=mock_builder)
+    agreement = _build_agreement(support_type="DeveloperSupport")
+    real_line = _build_real_line(Decimal("0.00"))
+    mock_generator_instance = mocker.MagicMock(spec=JournalLineGenerator)
+    mock_generator_instance.generate.return_value = [real_line]
+    mock_line_generator_cls.return_value = mock_generator_instance
+    mock_usage_generator = mocker.MagicMock(spec=CostExplorerUsageGenerator)
+    mock_usage_result = mocker.MagicMock(spec=OrganizationUsageResult)
+    mock_usage_result.reports = OrganizationReport()
+    mock_usage_result.usage_by_account = {"ACC-1": mocker.MagicMock(spec=AccountUsage)}
+    mock_usage_result.has_enterprise_support.return_value = False
+    mock_usage_generator.run.return_value = mock_usage_result
+    mock_invoice_generator = mocker.MagicMock(spec=InvoiceGenerator)
+    mock_invoice_generator.run.return_value = OrganizationInvoiceResult(
+        invoice=OrganizationInvoice(base_total_amount_before_tax=Decimal("50.00")),
+    )
+    generator = AgreementJournalGenerator(
+        _build_auth_context(mock_aws_client),
+        mock_context,
+        mock_usage_generator,
+        mock_invoice_generator,
+    )
+
+    result = generator.run(agreement)  # act
+
+    # sp = 0.00, pp = 50.00 -> markup = -1.0 -> divisor = 0 -> rescale is skipped
+    assert result.spp_summary_row.markup == Decimal("-1.0")
+    assert result.lines[0].price.pp_x1 == Decimal("0.00")
+
+
+def _markup_context(currency="USD"):
+    return ReportContext("AUTH-1", "PMA-1", "AGR-1", "MPA-1", currency)
+
+
+def _markup_organization_invoice(base_before_tax="0", payment_before_tax="0"):
+    return OrganizationInvoice(
+        base_total_amount_before_tax=Decimal(base_before_tax),
+        payment_currency_total_amount_before_tax=Decimal(payment_before_tax),
+    )
+
+
+def _markup_line(mocker, amount, *, is_valid=True):
+    line = mocker.MagicMock()
+    line.price.pp_x1 = Decimal(amount)
+    line.is_valid.return_value = is_valid
+    return line
+
+
+def _markup_journal_line(amount, *, error=None):
+    journal_details = JournalDetails("AGR-1", "MPA-1", "2025-10-01", "2025-10-31")
+    invoice_details = InvoiceDetails(
+        service_name="EC2",
+        amount=amount,
+        account_id="ACC-1",
+        invoice_entity="ENT-1",
+        start_date="2025-10-01",
+        end_date="2025-10-31",
+        error=error,
+    )
+    return JournalLine.build(
+        item_external_id="ITEM-1", journal_details=journal_details, invoice_details=invoice_details
+    )
+
+
+def test_calculate_markup_uses_full_precision(mocker):
+    all_lines = [_markup_line(mocker, "100.00")]
+    organization_invoice = _markup_organization_invoice(base_before_tax="90.00")
+
+    result = calculate_markup(all_lines, organization_invoice, _markup_context())  # act
+
+    expected_markup = (Decimal("100.00") - Decimal("90.00")) / Decimal("90.00")
+    assert result == expected_markup
+
+
+def test_calculate_markup_uses_payment_currency_before_tax_for_non_usd(mocker):
+    all_lines = [_markup_line(mocker, "100.00")]
+    organization_invoice = _markup_organization_invoice(
+        base_before_tax="999.00", payment_before_tax="50.00"
+    )
+
+    result = calculate_markup(all_lines, organization_invoice, _markup_context("EUR"))  # act
+
+    expected_markup = (Decimal("100.00") - Decimal("50.00")) / Decimal("50.00")
+    assert result == expected_markup
+
+
+def test_calculate_markup_defaults_to_zero_when_pp_is_zero(mocker):
+    all_lines = [_markup_line(mocker, "100.00")]
+
+    result = calculate_markup(all_lines, _markup_organization_invoice(), _markup_context())  # act
+
+    assert result == Decimal(0)
+
+
+def test_calculate_markup_only_sums_valid_lines(mocker):
+    all_lines = [
+        _markup_line(mocker, "100.00"),
+        _markup_line(mocker, "999.00", is_valid=False),
+    ]
+    organization_invoice = _markup_organization_invoice(base_before_tax="90.00")
+
+    result = calculate_markup(all_lines, organization_invoice, _markup_context())  # act
+
+    expected_markup = (Decimal("100.00") - Decimal("90.00")) / Decimal("90.00")
+    assert result == expected_markup
+
+
+def test_apply_markup_to_lines_rescales_valid_lines():
+    line = _markup_journal_line(Decimal("100.00"))
+
+    apply_markup_to_lines([line], Decimal("1.0"))  # act
+
+    assert line.price.pp_x1 == Decimal("50.00")
+    assert line.price.unit_pp == Decimal("50.00")
+
+
+def test_apply_markup_to_lines_skips_invalid_lines():
+    line = _markup_journal_line(Decimal("100.00"), error="Some error")
+
+    apply_markup_to_lines([line], Decimal("1.0"))  # act
+
+    assert line.price.pp_x1 == Decimal("100.00")
+    assert line.price.unit_pp == Decimal("100.00")
+
+
+def test_apply_markup_to_lines_skips_rescale_when_divisor_not_positive():
+    line = _markup_journal_line(Decimal("100.00"))
+
+    apply_markup_to_lines([line], Decimal(-1))  # act
+
+    assert line.price.pp_x1 == Decimal("100.00")
+    assert line.price.unit_pp == Decimal("100.00")
+
+
+def test_apply_markup_to_lines_rounds_to_six_decimal_places():
+    original_amount = Decimal("0.097533806")
+    divisor = Decimal("1.0107594")
+    line = _markup_journal_line(original_amount)
+
+    apply_markup_to_lines([line], Decimal("0.0107594"))  # act
+
+    expected = round(original_amount / divisor, 6)
+    assert line.price.pp_x1 == expected
+    assert line.price.pp_x1.as_tuple().exponent >= -6
+    assert line.price.unit_pp.as_tuple().exponent >= -6

--- a/tests/billing/generators/test_spp_summary.py
+++ b/tests/billing/generators/test_spp_summary.py
@@ -7,6 +7,8 @@ from swo_aws_extension.billing.generators.billing_report_rows import (
 from swo_aws_extension.billing.models.invoice import InvoiceEntity, OrganizationInvoice
 from swo_aws_extension.billing.models.journal_result import BillingReportRow
 
+DEFAULT_MARKUP = Decimal(0)
+
 
 def _line(mocker, amount, *, is_valid=True):
     line = mocker.MagicMock()
@@ -59,7 +61,9 @@ def test_build_spp_summary_row_sp_only_sums_valid_lines(mocker):
         _line(mocker, "999.00", is_valid=False),
     ]
 
-    result = build_spp_summary_row(_context(), all_lines, [], _organization_invoice())
+    result = build_spp_summary_row(
+        _context(), all_lines, [], _organization_invoice(), DEFAULT_MARKUP
+    )
 
     assert result.sp == Decimal("150.00")
 
@@ -69,7 +73,7 @@ def test_build_spp_summary_row_pp_uses_base_currency_before_tax_for_usd(mocker):
         base_before_tax="97.024883950", payment_before_tax="999.00"
     )
 
-    result = build_spp_summary_row(_context("USD"), [], [], organization_invoice)
+    result = build_spp_summary_row(_context("USD"), [], [], organization_invoice, DEFAULT_MARKUP)
 
     assert result.pp == Decimal("97.024883950")
 
@@ -79,7 +83,7 @@ def test_build_spp_summary_row_pp_uses_payment_currency_before_tax_for_non_usd(m
         base_before_tax="999.00", payment_before_tax="90.532488395"
     )
 
-    result = build_spp_summary_row(_context("EUR"), [], [], organization_invoice)
+    result = build_spp_summary_row(_context("EUR"), [], [], organization_invoice, DEFAULT_MARKUP)
 
     assert result.pp == Decimal("90.532488395")
 
@@ -90,7 +94,9 @@ def test_build_spp_summary_row_discount_sums_per_service_report_rows(mocker):
         _report_row("-0.00491806710"),
     ]
 
-    result = build_spp_summary_row(_context(), [], billing_report_rows, _organization_invoice())
+    result = build_spp_summary_row(
+        _context(), [], billing_report_rows, _organization_invoice(), DEFAULT_MARKUP
+    )
 
     assert result.spp_discount == Decimal("-0.07933332540") + Decimal("-0.00491806710")
 
@@ -100,7 +106,7 @@ def test_build_spp_summary_row_exchange_rate_taken_from_invoice_entity(mocker):
         entities={"ENT-1": _invoice_entity("0.8664846127")}
     )
 
-    result = build_spp_summary_row(_context(), [], [], organization_invoice)
+    result = build_spp_summary_row(_context(), [], [], organization_invoice, DEFAULT_MARKUP)
 
     assert result.exchange_rate == Decimal("0.8664846127")
 
@@ -113,13 +119,13 @@ def test_build_spp_summary_row_exchange_rate_falls_back_to_another_entity(mocker
         }
     )
 
-    result = build_spp_summary_row(_context(), [], [], organization_invoice)
+    result = build_spp_summary_row(_context(), [], [], organization_invoice, DEFAULT_MARKUP)
 
     assert result.exchange_rate == Decimal("0.8664846127")
 
 
 def test_build_spp_summary_row_defaults_exchange_rate_when_no_entities(mocker):
-    result = build_spp_summary_row(_context(), [], [], _organization_invoice())
+    result = build_spp_summary_row(_context(), [], [], _organization_invoice(), DEFAULT_MARKUP)
 
     assert result.exchange_rate == Decimal("1.0")
 
@@ -127,7 +133,7 @@ def test_build_spp_summary_row_defaults_exchange_rate_when_no_entities(mocker):
 def test_build_spp_summary_row_list_price_taken_from_payment_currency_subtotal(mocker):
     organization_invoice = _organization_invoice(payment_subtotal="123.456789")
 
-    result = build_spp_summary_row(_context(), [], [], organization_invoice)
+    result = build_spp_summary_row(_context(), [], [], organization_invoice, DEFAULT_MARKUP)
 
     assert result.list_price == Decimal("123.456789")
 
@@ -136,7 +142,9 @@ def test_build_spp_summary_row_discount_pct_uses_full_precision(mocker):
     organization_invoice = _organization_invoice(base_before_tax="90.00")
     billing_report_rows = [_report_row("-10.00")]
 
-    result = build_spp_summary_row(_context(), [], billing_report_rows, organization_invoice)
+    result = build_spp_summary_row(
+        _context(), [], billing_report_rows, organization_invoice, DEFAULT_MARKUP
+    )
 
     assert result.spp_discount_pct == Decimal("10.00") / Decimal("90.00")
 
@@ -144,18 +152,17 @@ def test_build_spp_summary_row_discount_pct_uses_full_precision(mocker):
 def test_build_spp_summary_row_zero_pp_guards_percentage(mocker):
     billing_report_rows = [_report_row("-10.00")]
 
-    result = build_spp_summary_row(_context(), [], billing_report_rows, _organization_invoice())
+    result = build_spp_summary_row(
+        _context(), [], billing_report_rows, _organization_invoice(), DEFAULT_MARKUP
+    )
 
     assert result.pp == Decimal(0)
     assert result.spp_discount_pct == Decimal(0)
-    assert result.markup == Decimal(0)
 
 
-def test_build_spp_summary_row_markup_uses_full_precision(mocker):
-    all_lines = [_line(mocker, "100.00")]
-    organization_invoice = _organization_invoice(base_before_tax="90.00")
+def test_build_spp_summary_row_uses_the_markup_it_is_given(mocker):
+    given_markup = Decimal("0.123456789")
 
-    result = build_spp_summary_row(_context(), all_lines, [], organization_invoice)
+    result = build_spp_summary_row(_context(), [], [], _organization_invoice(), given_markup)
 
-    expected_markup = (Decimal("100.00") - Decimal("90.00")) / Decimal("90.00")
-    assert result.markup == expected_markup
+    assert result.markup == given_markup


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

- Extract the journal-vs-invoice reconciliation into `calculate_markup()`: computed once per agreement right after its journal lines are generated, comparing the usage-based journal total (sp) against the AWS invoice purchase price (pp).
- Use that same markup value both to build the SPP Summary report row and to rewrite each journal line's price back down to its invoice-derived purchase price (`apply_markup_to_lines`), rounded to 6 decimals to match the existing currency-conversion convention.
- Gate `PlSDiscountProcessor` ("SWO additional PLS Support discount") on `usage_result.has_enterprise_support()`, mirroring the MPT-23003 fix already applied to `PlSChargeProcessor`.

## Why

The billing platform doesn't support per-service dynamic markups. Journal lines were being uploaded already priced as the final sales amount, with no reconciliation against the actual AWS invoice cost. Uploading the invoice-derived purchase price instead — with the same markup also configured on the agreement — lets the platform recompute the sales price itself and reconstruct the original total exactly.

Separately, `PlSDiscountProcessor` could emit its discount even when AWS reported no Enterprise Support usage for the period, while the equivalent PLES charge processor (`PlSChargeProcessor`) already required it. This closes that gap so both the charge and its matching discount are gated the same way.

## Testing

- `make check` (ruff format, ruff check, flake8, uv lock --check) passes repo-wide.
- Full test suite passes: 1156 passed, 1 xpassed.
- Added/updated unit tests for `calculate_markup`, `apply_markup_to_lines` (including 6-decimal rounding), and `PlSDiscountProcessor`'s new Enterprise Support gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Applies reconciled markup to journal purchase prices before upload.
- Extracts markup calculation and reuses it for SPP summaries and journal line adjustments, with six-decimal rounding.
- Restricts PLS discounts to agreements with Enterprise Support usage.
- Adds comprehensive tests for markup behavior, rounding, and Enterprise Support eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->