### PR TITLE
MPT-23846 use minimum notice period for channel handshake

### DIFF
--- a/migrations/20260806074225_relationship_end_date.py
+++ b/migrations/20260806074225_relationship_end_date.py
@@ -1,0 +1,142 @@
+import logging
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from mpt_api_client.rql.query_builder import RQLQuery
+from mpt_tool.migration import SchemaBaseMigration
+from mpt_tool.migration.mixins import MPTAPIClientMixin
+
+logger = logging.getLogger(__name__)
+
+_RELATIONSHIP_END_DATE_EXTERNAL_ID = "relationshipEndDate"
+
+_relationship_end_date_parameter = {
+    "name": "Relationship End Date",
+    "scope": "Agreement",
+    "phase": "Fulfillment",
+    "context": "None",
+    "description": "Date when the AWS responsibility transfer relationship ends",
+    "multiple": False,
+    "externalId": _RELATIONSHIP_END_DATE_EXTERNAL_ID,
+    "displayOrder": 140,
+    "constraints": {"hidden": True, "readonly": False, "required": False},
+    "options": {
+        "placeholderText": "Relationship End Date",
+        "hintText": "Relationship End Date",
+    },
+    "type": "SingleLineText",
+    "status": "Active",
+}
+
+
+class Migration(SchemaBaseMigration, MPTAPIClientMixin):
+    """Migration to add the relationshipEndDate agreement fulfillment parameter."""
+
+    def run(self) -> None:
+        """Run the migration."""
+        raw_ids = os.environ["MPT_PRODUCTS_IDS"].replace(" ", "").split(",")
+        product_ids = list(filter(None, raw_ids))
+        logger.info(
+            "Starting migration 20260806074225_relationship_end_date for %s product(s)",
+            len(product_ids),
+        )
+
+        if not product_ids:
+            logger.info("No product IDs found in MPT_PRODUCTS_IDS; nothing to migrate")
+
+        for product_id in product_ids:
+            self._migrate_product(product_id)
+
+        logger.info("Migration 20260806074225_relationship_end_date finished")
+
+    def _migrate_product(self, product_id: str) -> None:
+        logger.info("Migrating product '%s'", product_id)
+
+        existing = self._get_product_parameter(product_id, _RELATIONSHIP_END_DATE_EXTERNAL_ID)
+        self._ensure_parameter(product_id, existing, _relationship_end_date_parameter)
+        self._migrate_agreements(product_id)
+
+    def _migrate_agreements(self, product_id: str) -> None:
+        logger.info("Migrating agreements for product '%s'", product_id)
+        query = RQLQuery(product__id=product_id) & RQLQuery(status="Active")
+        agreements = list(
+            self.mpt_client.commerce.agreements.filter(query).select("+parameters").iterate()
+        )
+        logger.info(
+            "Found %s active agreement(s) for product '%s'",
+            len(agreements),
+            product_id,
+        )
+        for agreement in agreements:
+            self._ensure_agreement_relationship_end_date(agreement.to_dict())
+
+    def _ensure_agreement_relationship_end_date(self, agreement: dict[str, Any]) -> None:
+        agreement_id = agreement["id"]
+        fulfillment_params = agreement.get("parameters", {}).get("fulfillment", [])
+        already_present = any(
+            parameter.get("externalId") == _RELATIONSHIP_END_DATE_EXTERNAL_ID
+            for parameter in fulfillment_params
+        )
+        if already_present:
+            logger.info(
+                "Parameter 'relationshipEndDate' already exists for agreement '%s'; skipping",
+                agreement_id,
+            )
+            return
+        logger.info("Adding parameter 'relationshipEndDate' to agreement '%s'", agreement_id)
+        self.mpt_client.commerce.agreements.update(
+            agreement_id,
+            {
+                "parameters": {
+                    "fulfillment": [
+                        {
+                            "externalId": _RELATIONSHIP_END_DATE_EXTERNAL_ID,
+                            "value": "",
+                        }
+                    ]
+                }
+            },
+        )
+
+    def _ensure_parameter(
+        self,
+        product_id: str,
+        existing_parameter: Any | None,
+        parameter_data: Mapping[str, Any],
+    ) -> None:
+        external_id = parameter_data["externalId"]
+        if existing_parameter:
+            logger.info(
+                "Parameter '%s' already exists for product '%s'; skipping",
+                external_id,
+                product_id,
+            )
+            return
+
+        logger.info("Creating parameter '%s' for product '%s'", external_id, product_id)
+        self._create_product_parameter(product_id, parameter_data)
+
+    def _get_product_parameter(self, product_id: str, external_id: str) -> Any | None:
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        parameter_query = RQLQuery(externalId=external_id)
+        status_query = RQLQuery(status="Active")
+        product_parameters = list(
+            product_parameters_service
+            .filter(parameter_query)
+            .filter(status_query)
+            .select()
+            .iterate()
+        )
+        if product_parameters:
+            return product_parameters[0]
+        return None
+
+    def _create_product_parameter(self, product_id: str, parameter_data: Mapping[str, Any]) -> None:
+        logger.info(
+            "Creating product parameter '%s' for product '%s'",
+            parameter_data.get("externalId"),
+            product_id,
+        )
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        product_parameters_service.create(parameter_data)

--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -299,7 +299,7 @@ class AWSClient:
         self,
         pma_identifier: str,
         relationship_identifier: str,
-        end_date: dt.datetime,
+        minimum_notice_days: int,
         note: str,
     ) -> dict:
         """Create channel handshake in Partner Central."""
@@ -312,8 +312,8 @@ class AWSClient:
                 "startServicePeriodPayload": {
                     "programManagementAccountIdentifier": pma_identifier,
                     "note": note,
-                    "servicePeriodType": "FIXED_COMMITMENT_PERIOD",
-                    "endDate": end_date,
+                    "servicePeriodType": "MINIMUM_NOTICE_PERIOD",
+                    "minimumNoticeDays": str(minimum_notice_days),
                 }
             },
         )

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -20,6 +20,8 @@ BASIC_PRICING_PLAN_ARN = "arn:aws:billingconductor::aws:pricingplan/BasicPricing
 CRM_TICKET_RESOLVED_STATE = "Resolved"
 MONTHS_PER_YEAR = 12
 
+CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS = 60
+
 AWS_MARKETPLACE = "AWS Marketplace"
 
 

--- a/swo_aws_extension/flows/steps/create_channel_handshake.py
+++ b/swo_aws_extension/flows/steps/create_channel_handshake.py
@@ -1,13 +1,11 @@
-import datetime as dt
 import logging
 from typing import override
 
-from dateutil.relativedelta import relativedelta
 from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.mpt import update_order
 
 from swo_aws_extension.aws.errors import AWSError
-from swo_aws_extension.constants import PhasesEnum
+from swo_aws_extension.constants import CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS, PhasesEnum
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.base import BasePhaseStep
 from swo_aws_extension.flows.steps.errors import (
@@ -49,7 +47,9 @@ class CreateChannelHandshake(BasePhaseStep):
     @override
     def process(self, client: MPTClient, context: PurchaseContext):
         logger.info(
-            "%s - Action - Creating new channel handshake for 1 year period", context.order_id
+            "%s - Action - Creating new channel handshake with %s days minimum notice period",
+            context.order_id,
+            CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
         )
         pm_identifier = context.aws_apn_client.get_program_management_id_by_account(
             context.pm_account_id
@@ -59,7 +59,7 @@ class CreateChannelHandshake(BasePhaseStep):
             handshake = context.aws_apn_client.create_channel_handshake(
                 pma_identifier=pm_identifier,
                 relationship_identifier=get_relationship_id(context.order),
-                end_date=dt.datetime.now(dt.UTC) + relativedelta(years=1),
+                minimum_notice_days=CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
                 note="Please accept your Service Terms contract with SoftwareOne",
             )
         except AWSError as error:

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 
 import boto3
 import pytest
+import requests
 import responses
 from botocore.exceptions import ClientError
 
@@ -554,12 +555,11 @@ def test_create_channel_handshake_success(config, aws_client_factory):
     mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
     expected_response = {"handshakeIdentifier": "hs-123456"}
     mock_client.create_channel_handshake.return_value = expected_response
-    end_date = dt.datetime(2026, 12, 31, tzinfo=dt.UTC)
 
     result = mock_aws_client.create_channel_handshake(
         pma_identifier="pma-123456",
         relationship_identifier="rel-123456",
-        end_date=end_date,
+        minimum_notice_days=60,
         note="Please accept your Service Terms contract with SoftwareOne",
     )
 
@@ -571,8 +571,8 @@ def test_create_channel_handshake_success(config, aws_client_factory):
         payload={
             "startServicePeriodPayload": {
                 "programManagementAccountIdentifier": "pma-123456",
-                "servicePeriodType": "FIXED_COMMITMENT_PERIOD",
-                "endDate": end_date,
+                "servicePeriodType": "MINIMUM_NOTICE_PERIOD",
+                "minimumNoticeDays": "60",
                 "note": "Please accept your Service Terms contract with SoftwareOne",
             }
         },
@@ -582,13 +582,12 @@ def test_create_channel_handshake_success(config, aws_client_factory):
 def test_create_channel_handshake_error(config, aws_client_factory):
     mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
     mock_client.create_channel_handshake.side_effect = AWSError("Handshake creation failed")
-    end_date = dt.datetime(2026, 12, 31, tzinfo=dt.UTC)
 
     with pytest.raises(AWSError, match="Handshake creation failed"):
         mock_aws_client.create_channel_handshake(
             pma_identifier="pma-123456",
             relationship_identifier="rel-123456",
-            end_date=end_date,
+            minimum_notice_days=60,
             note="Please accept your Service Terms contract with SoftwareOne",
         )
 
@@ -852,6 +851,16 @@ def test_download_invoice_pdf_missing_url_raises(config, aws_client_factory):
     mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {}}
 
     with pytest.raises(AWSError, match="Invoice PDF URL is missing"):
+        mock_aws_client.download_invoice_pdf("INV-001")
+
+
+def test_download_invoice_pdf_unknown_status(config, aws_client_factory, requests_mocker):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    document_url = "https://example.test/invoice.pdf"
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {"DocumentUrl": document_url}}
+    requests_mocker.add(responses.GET, document_url, body=requests.ConnectionError("boom"))
+
+    with pytest.raises(AWSError, match="HTTP status: unknown"):
         mock_aws_client.download_invoice_pdf("INV-001")
 
 

--- a/tests/flows/steps/test_create_channel_handshake.py
+++ b/tests/flows/steps/test_create_channel_handshake.py
@@ -1,11 +1,7 @@
-import datetime as dt
-
 import pytest
-from dateutil.relativedelta import relativedelta
-from freezegun import freeze_time
 
 from swo_aws_extension.aws.errors import AWSError
-from swo_aws_extension.constants import PhasesEnum
+from swo_aws_extension.constants import CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS, PhasesEnum
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.create_channel_handshake import CreateChannelHandshake
 from swo_aws_extension.flows.steps.errors import (
@@ -14,14 +10,6 @@ from swo_aws_extension.flows.steps.errors import (
     UnexpectedStopError,
 )
 from swo_aws_extension.parameters import get_channel_handshake_id, get_phase
-
-FROZEN_DATE_JANUARY = "2026-01-20 10:30:00"
-FROZEN_DATE_DECEMBER = "2026-12-15 10:30:00"
-
-
-def _get_expected_end_date(frozen_date: str) -> dt.datetime:
-    now = dt.datetime.fromisoformat(frozen_date).replace(tzinfo=dt.UTC)
-    return now + relativedelta(years=1)
 
 
 def test_skip_phase_is_not_expected(fulfillment_parameters_factory, order_factory, config):
@@ -65,7 +53,6 @@ def test_pre_step_success(fulfillment_parameters_factory, order_factory, config)
     assert result is None
 
 
-@freeze_time(FROZEN_DATE_JANUARY)
 def test_process_success(
     order_factory,
     aws_client_factory,
@@ -87,7 +74,6 @@ def test_process_success(
     aws_client_mock.create_channel_handshake.return_value = {
         "channelHandshakeDetail": {"id": "hs-new-123456"}
     }
-    expected_end_date = _get_expected_end_date(FROZEN_DATE_JANUARY)
 
     CreateChannelHandshake(config).process(mpt_client, context)  # act
 
@@ -95,43 +81,10 @@ def test_process_success(
     aws_client_mock.create_channel_handshake.assert_called_once_with(
         pma_identifier="pma-identifier-123",
         relationship_identifier="rel-123456",
-        end_date=expected_end_date,
+        minimum_notice_days=CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
         note="Please accept your Service Terms contract with SoftwareOne",
     )
     assert get_channel_handshake_id(context.order) == "hs-new-123456"
-
-
-@freeze_time(FROZEN_DATE_DECEMBER)
-def test_process_end_date_year_boundary(
-    order_factory,
-    aws_client_factory,
-    fulfillment_parameters_factory,
-    config,
-    mpt_client,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            phase=PhasesEnum.CREATE_CHANNEL_HANDSHAKE.value,
-            relationship_id="rel-123456",
-        )
-    )
-    context = PurchaseContext.from_order_data(order)
-    _, aws_client_mock = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = aws_client_mock
-    aws_client_mock.get_program_management_id_by_account.return_value = "pma-identifier-123"
-    aws_client_mock.create_channel_handshake.return_value = {
-        "channelHandshakeDetail": {"id": "hs-new-123456"}
-    }
-    expected_end_date = _get_expected_end_date(FROZEN_DATE_DECEMBER)
-
-    CreateChannelHandshake(config).process(mpt_client, context)  # act
-
-    aws_client_mock.create_channel_handshake.assert_called_once_with(
-        pma_identifier="pma-identifier-123",
-        relationship_identifier="rel-123456",
-        end_date=expected_end_date,
-        note="Please accept your Service Terms contract with SoftwareOne",
-    )
 
 
 def test_process_aws_error(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

- Create the Partner Central channel handshake with a 60-day `MINIMUM_NOTICE_PERIOD` service term instead of a fixed 1-year `FIXED_COMMITMENT_PERIOD` end date, so the relationship is not tied to a fixed commitment window during the purchase flow.
- Add the `CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS = 60` constant and update `AWSClient.create_channel_handshake` to send `minimumNoticeDays` instead of `endDate`.
- Add migration `20260806074225_relationship_end_date.py` that creates the hidden `relationshipEndDate` agreement fulfillment parameter and backfills it (empty value) on existing agreements, to track when the AWS responsibility transfer relationship ends.
- Update the affected unit tests for the AWS client and the channel handshake step.

## Testing

- `make check-all` passes locally: ruff format, ruff check, flake8, `uv lock --check`, and the full test suite (1156 passed, 1 xpassed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Update the Partner Central channel handshake to use a 60-day `MINIMUM_NOTICE_PERIOD`.
- Add `CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS = 60`.
- Replace the `endDate` payload with `minimumNoticeDays`.
- Add and backfill the `relationshipEndDate` agreement fulfillment parameter.
- Update AWS client and channel handshake tests.
- Add coverage for unknown HTTP status errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->