### PR TITLE
MPT-23596 Document shared Airtable service-account token

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,7 +28,7 @@ Deployed workloads receive configuration through Helm config maps and secrets. T
 | `MPT_ORDERS_API_POLLING_INTERVAL_SECS` | `120` | `60` | Order polling interval |
 | `MPT_KEY_VAULT_NAME` | - | `https://mpt-key-vault-name.vault.azure.net/` | Azure Key Vault URL used to resolve secrets |
 | `MPT_TOOL_STORAGE_TYPE` | `local` | `airtable` | `mpt-tool` storage backend |
-| `MPT_TOOL_STORAGE_AIRTABLE_API_KEY` | - | `patXXXXXXXX` | Airtable API key for `mpt-tool` storage |
+| `MPT_TOOL_STORAGE_AIRTABLE_API_KEY` | - | `patXXXXXXXX` | Airtable API key for `mpt-tool` storage; fed by the `AirTableApiToken` Helm secret (shared service-account token) |
 | `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID` | - | `appXXXXXXXX` | Airtable base id for `mpt-tool` storage |
 | `MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME` | - | `MigrationTracking` | Airtable table for `mpt-tool` storage |
 
@@ -69,7 +69,7 @@ Deployed workloads receive configuration through Helm config maps and secrets. T
 | `EXT_FFC_OPERATIONS_API_BASE_URL` | - | `https://api.finops.s1.show/ops/v1/` | FinOps operations API base URL |
 | `EXT_FFC_OPERATIONS_SECRET` | - | `supersecret` | FinOps operations secret |
 | `EXT_AIRTABLE_BASES` | - | `{"PRD-1111-1111":"app..."}` | Per-product Airtable base mapping |
-| `EXT_AIRTABLE_API_TOKEN` | - | `patXXXXXXXX` | Airtable API token used by repository-specific flows |
+| `EXT_AIRTABLE_API_TOKEN` | - | `patXXXXXXXX` | Airtable token used by repository-specific flows; fed by the `AirTableApiToken` Helm secret (shared service-account token, see [external/airtable.md](external/airtable.md)) |
 
 ## Reporting, Notifications, And Storage
 

--- a/docs/external-integrations.md
+++ b/docs/external-integrations.md
@@ -18,7 +18,7 @@ Each integration document covers: purpose, authentication mechanism, required en
 | [Confluence](external/confluence.md) | Billing report attachment to Confluence pages | Basic Auth (username + API token) | [confluence.md](external/confluence.md) |
 | [MS Teams](external/ms-teams.md) | Internal operational notifications | Workflow Webhook (no auth) | [ms-teams.md](external/ms-teams.md) |
 | [AWS SES](external/aws-ses.md) | Customer-facing email delivery | AWS Access Key + Secret Key | [aws-ses.md](external/aws-ses.md) |
-| [Airtable](external/airtable.md) | FinOps entitlements table (per-agreement records) | Personal Access Token | [airtable.md](external/airtable.md) |
+| [Airtable](external/airtable.md) | FinOps entitlements table (per-agreement records) | Shared service-account token (workspace-scoped Airtable PAT, provisioned and rotated by DevOps) | [airtable.md](external/airtable.md) |
 
 ## Code Location
 

--- a/docs/external/airtable.md
+++ b/docs/external/airtable.md
@@ -7,14 +7,17 @@ background jobs.
 
 ## Authentication
 
-Airtable Personal Access Token (PAT). The `FinOpsEntitlementsTable` builds a
+Workspace-scoped Airtable personal access token issued from the shared Airtable
+service account. DevOps provisions and rotates the token, and it reaches the
+extension through the `AirTableApiToken` Helm secret; a rotation is a secret
+swap only, with no manifest changes. The `FinOpsEntitlementsTable` builds a
 `pyairtable` `Api` client with the token and opens the configured base/table.
 
 ## Configuration
 
 | Environment Variable | Description |
 | --- | --- |
-| `EXT_AIRTABLE_API_TOKEN` | Airtable Personal Access Token used by repository-specific flows |
+| `EXT_AIRTABLE_API_TOKEN` | Shared service-account Airtable token used by repository-specific flows |
 | `EXT_AIRTABLE_BASES` | Per-product Airtable base mapping (`{"PRD-...":"app..."}`); the base is resolved per AWS product id |
 
 The table name is `FinOps Entitlements`.


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Documentation-only update for the Airtable shared service-account token migration (MPT-20076 / MPT-23596):

- `docs/external-integrations.md`: the Airtable row's Auth column now says the integration uses a shared service-account token (workspace-scoped Airtable PAT, provisioned and rotated by DevOps) instead of a Personal Access Token.
- `docs/external/airtable.md`: Authentication section describes the shared service-account token, DevOps-managed provisioning/rotation, and delivery via the `AirTableApiToken` Helm secret (rotation = secret swap, no manifest changes).
- `docs/deployment.md`: `MPT_TOOL_STORAGE_AIRTABLE_API_KEY` and `EXT_AIRTABLE_API_TOKEN` descriptions note they are fed by the `AirTableApiToken` Helm secret.

No application code changes.

## Merge timing

⚠️ Merge only after the PROD token swap is verified — scheduled with DevOps for Monday 2026-08-10 (see MPT-23598). TEST and QA already run verified on the shared token.

## Testing

`make check` and `make test` pass (1156 tests, docs-only change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updates Airtable authentication documentation for a shared, workspace-scoped service-account token.
- Documents `AirTableApiToken` Helm secret delivery and DevOps-managed rotation.
- Updates Airtable environment variable descriptions in `docs/deployment.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->