### PR TITLE
[BACKPORT] MPT-23797 AWS fulfilment modification - service term removal

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ The repository currently has stable coverage in these areas:
 - AWS client and configuration behavior in [`tests/aws/`](../tests/aws)
 - fulfillment, jobs, steps, and validation flows in [`tests/flows/`](../tests/flows)
 - management commands and helpers in [`tests/management/`](../tests/management) and [`tests/commands/`](../tests/commands)
-- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), [`tests/swo_mpt_api/`](../tests/swo_mpt_api), [`tests/swo_ccp_client/`](../tests/swo_ccp_client), [`tests/swo_crm_service_client/`](../tests/swo_crm_service_client), [`tests/swo_finops_client/`](../tests/swo_finops_client), and [`tests/swo_rql/`](../tests/swo_rql)
+- Marketplace, CCP, CRM, FinOps, notification, and query-builder integrations under [`tests/swo/`](../tests/swo), [`tests/swo_mpt_api/`](../tests/swo_mpt_api), [`tests/swo_ccp_client/`](../tests/swo_ccp_client), [`tests/swo_crm_service_client/`](../tests/swo_crm_service_client), [`tests/swo_finops_client/`](../tests/swo_finops_client), and [`tests/swo_rql/`](../tests/swo_rql); agreement sync behavior lives in [`tests/swo/mpt/sync/`](../tests/swo/mpt/sync): `test_syncer.py` covers the agreement syncer and `test_responsibility_transfers.py` covers the responsibility-transfer lookup helpers
 - Airtable, file-builder, processor, and utility behavior in [`tests/airtable/`](../tests/airtable), [`tests/file_builder/`](../tests/file_builder), [`tests/processor/`](../tests/processor), and [`tests/utils/`](../tests/utils)
 
 ## Commands

--- a/migrations/20260806074225_relationship_end_date.py
+++ b/migrations/20260806074225_relationship_end_date.py
@@ -1,0 +1,142 @@
+import logging
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from mpt_api_client.rql.query_builder import RQLQuery
+from mpt_tool.migration import SchemaBaseMigration
+from mpt_tool.migration.mixins import MPTAPIClientMixin
+
+logger = logging.getLogger(__name__)
+
+_RELATIONSHIP_END_DATE_EXTERNAL_ID = "relationshipEndDate"
+
+_relationship_end_date_parameter = {
+    "name": "Relationship End Date",
+    "scope": "Agreement",
+    "phase": "Fulfillment",
+    "context": "None",
+    "description": "Date when the AWS responsibility transfer relationship ends",
+    "multiple": False,
+    "externalId": _RELATIONSHIP_END_DATE_EXTERNAL_ID,
+    "displayOrder": 140,
+    "constraints": {"hidden": True, "readonly": False, "required": False},
+    "options": {
+        "placeholderText": "Relationship End Date",
+        "hintText": "Relationship End Date",
+    },
+    "type": "SingleLineText",
+    "status": "Active",
+}
+
+
+class Migration(SchemaBaseMigration, MPTAPIClientMixin):
+    """Migration to add the relationshipEndDate agreement fulfillment parameter."""
+
+    def run(self) -> None:
+        """Run the migration."""
+        raw_ids = os.environ["MPT_PRODUCTS_IDS"].replace(" ", "").split(",")
+        product_ids = list(filter(None, raw_ids))
+        logger.info(
+            "Starting migration 20260806074225_relationship_end_date for %s product(s)",
+            len(product_ids),
+        )
+
+        if not product_ids:
+            logger.info("No product IDs found in MPT_PRODUCTS_IDS; nothing to migrate")
+
+        for product_id in product_ids:
+            self._migrate_product(product_id)
+
+        logger.info("Migration 20260806074225_relationship_end_date finished")
+
+    def _migrate_product(self, product_id: str) -> None:
+        logger.info("Migrating product '%s'", product_id)
+
+        existing = self._get_product_parameter(product_id, _RELATIONSHIP_END_DATE_EXTERNAL_ID)
+        self._ensure_parameter(product_id, existing, _relationship_end_date_parameter)
+        self._migrate_agreements(product_id)
+
+    def _migrate_agreements(self, product_id: str) -> None:
+        logger.info("Migrating agreements for product '%s'", product_id)
+        query = RQLQuery(product__id=product_id) & RQLQuery(status="Active")
+        agreements = list(
+            self.mpt_client.commerce.agreements.filter(query).select("+parameters").iterate()
+        )
+        logger.info(
+            "Found %s active agreement(s) for product '%s'",
+            len(agreements),
+            product_id,
+        )
+        for agreement in agreements:
+            self._ensure_agreement_relationship_end_date(agreement.to_dict())
+
+    def _ensure_agreement_relationship_end_date(self, agreement: dict[str, Any]) -> None:
+        agreement_id = agreement["id"]
+        fulfillment_params = agreement.get("parameters", {}).get("fulfillment", [])
+        already_present = any(
+            parameter.get("externalId") == _RELATIONSHIP_END_DATE_EXTERNAL_ID
+            for parameter in fulfillment_params
+        )
+        if already_present:
+            logger.info(
+                "Parameter 'relationshipEndDate' already exists for agreement '%s'; skipping",
+                agreement_id,
+            )
+            return
+        logger.info("Adding parameter 'relationshipEndDate' to agreement '%s'", agreement_id)
+        self.mpt_client.commerce.agreements.update(
+            agreement_id,
+            {
+                "parameters": {
+                    "fulfillment": [
+                        {
+                            "externalId": _RELATIONSHIP_END_DATE_EXTERNAL_ID,
+                            "value": "",
+                        }
+                    ]
+                }
+            },
+        )
+
+    def _ensure_parameter(
+        self,
+        product_id: str,
+        existing_parameter: Any | None,
+        parameter_data: Mapping[str, Any],
+    ) -> None:
+        external_id = parameter_data["externalId"]
+        if existing_parameter:
+            logger.info(
+                "Parameter '%s' already exists for product '%s'; skipping",
+                external_id,
+                product_id,
+            )
+            return
+
+        logger.info("Creating parameter '%s' for product '%s'", external_id, product_id)
+        self._create_product_parameter(product_id, parameter_data)
+
+    def _get_product_parameter(self, product_id: str, external_id: str) -> Any | None:
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        parameter_query = RQLQuery(externalId=external_id)
+        status_query = RQLQuery(status="Active")
+        product_parameters = list(
+            product_parameters_service
+            .filter(parameter_query)
+            .filter(status_query)
+            .select()
+            .iterate()
+        )
+        if product_parameters:
+            return product_parameters[0]
+        return None
+
+    def _create_product_parameter(self, product_id: str, parameter_data: Mapping[str, Any]) -> None:
+        logger.info(
+            "Creating product parameter '%s' for product '%s'",
+            parameter_data.get("externalId"),
+            product_id,
+        )
+        product_parameters_service = self.mpt_client.catalog.products.parameters(product_id)
+        product_parameters_service.create(parameter_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ per-file-ignores = [
   "tests/swo/ccp/test_client.py: WPS202 WPS211",
   "tests/aws/test_client.py: WPS432 WPS202 WPS204",
   "tests/test_initializer.py: WPS111 WPS213 WPS218 WPS230 WPS431",
-  "tests/swo/mpt/sync/conftest.py: WPS430 WPS202 WPS118",
+  "tests/swo/mpt/sync/conftest.py: WPS430 WPS202 WPS118 WPS211",
   "tests/swo/rql/test_query_builder.py: AAA01 AAA05 WPS110 WPS111 WPS122 WPS202 WPS204 WPS210 WPS218 WPS221 WPS347 WPS420 WPS431 WPS432 WPS473 WPS604",
   "tests/processor/querying/test_aws_customer_roles.py: WPS118 WPS202 WPS211",
   "tests/flows/steps/crm_tickets/test_ticket_manager.py: WPS118 WPS211",

--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -275,7 +275,7 @@ class AWSClient:
         self,
         pma_identifier: str,
         relationship_identifier: str,
-        end_date: dt.datetime,
+        minimum_notice_days: int,
         note: str,
     ) -> dict:
         """Create channel handshake in Partner Central."""
@@ -288,8 +288,8 @@ class AWSClient:
                 "startServicePeriodPayload": {
                     "programManagementAccountIdentifier": pma_identifier,
                     "note": note,
-                    "servicePeriodType": "FIXED_COMMITMENT_PERIOD",
-                    "endDate": end_date,
+                    "servicePeriodType": "MINIMUM_NOTICE_PERIOD",
+                    "minimumNoticeDays": str(minimum_notice_days),
                 }
             },
         )

--- a/swo_aws_extension/aws/client.py
+++ b/swo_aws_extension/aws/client.py
@@ -234,14 +234,6 @@ class AWSClient:
         )
 
     @wrap_boto3_error
-    def delete_billing_group(self, billing_group_arn: str) -> dict:
-        """Delete a billing group."""
-        billing_conductor_client = self._get_billing_conductor_client()
-        return billing_conductor_client.delete_billing_group(
-            Arn=billing_group_arn,
-        )
-
-    @wrap_boto3_error
     def get_program_management_id_by_account(self, account_id) -> str:
         """Get Program Management Account Identifier by account ID."""
         partner_central_client = self._get_partner_central_client()
@@ -292,16 +284,6 @@ class AWSClient:
                     "minimumNoticeDays": str(minimum_notice_days),
                 }
             },
-        )
-
-    @wrap_boto3_error
-    def delete_pc_relationship(self, pm_identifier: str, relationship_id: str):
-        """Delete relationship in Partner Central."""
-        partner_central_client = self._get_partner_central_client()
-        return partner_central_client.delete_relationship(
-            catalog="AWS",
-            identifier=relationship_id,
-            programManagementAccountIdentifier=pm_identifier,
         )
 
     @wrap_boto3_error

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -131,6 +131,7 @@ class FulfillmentParametersEnum(StrEnum):
     FEATURE_VERSION_DEPLOYMENT_ERROR_NOTIFIED = "featureVersionDeploymentErrorNotified"
     CCO_CONTRACT_NUMBER = "ccoContractNumber"
     ERP_PROJECT_NO = "erpProjectNo"
+    RELATIONSHIP_END_DATE = "relationshipEndDate"
     SERVICE_DISCOUNT_TYPE = "serviceDiscountType"
 
 
@@ -210,13 +211,6 @@ CUSTOMER_ROLES_NOT_DEPLOYED_MESSAGE = (
     "It seems there is an error with the configured SWO access. SWO roles have not "
     "been created yet. The SWO support team will contact you. Please move the order to "
     "'processing' status once the roles are created."
-)
-
-COMMITMENT_ENABLED_ERROR_MESSAGE = (
-    "Order failed due to invalid date in terminate responsibility agreement"
-    " with reason: The selected withdrawal date doesn't meet the terms of your"
-    " partner agreement. Visit AWS Partner Central to view your "
-    "partner agreements or contact your AWS Partner for help."
 )
 
 

--- a/swo_aws_extension/constants.py
+++ b/swo_aws_extension/constants.py
@@ -20,6 +20,8 @@ BASIC_PRICING_PLAN_ARN = "arn:aws:billingconductor::aws:pricingplan/BasicPricing
 CRM_TICKET_RESOLVED_STATE = "Resolved"
 MONTHS_PER_YEAR = 12
 
+CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS = 60
+
 AWS_MARKETPLACE = "AWS Marketplace"
 
 

--- a/swo_aws_extension/flows/fulfillment/pipelines.py
+++ b/swo_aws_extension/flows/fulfillment/pipelines.py
@@ -32,6 +32,9 @@ from swo_aws_extension.flows.steps.setup_context import SetupContext
 from swo_aws_extension.flows.steps.swo_job import SWOJobStep
 from swo_aws_extension.flows.steps.terminate import TerminateResponsibilityTransferStep
 from swo_aws_extension.flows.steps.validate_order import ValidateOrder
+from swo_aws_extension.flows.steps.wait_terminate_responsibility_transfer import (
+    WaitTerminateResponsibilityTransferStep,
+)
 from swo_aws_extension.swo.notifications.teams import (
     notify_one_time_error,
 )
@@ -106,7 +109,8 @@ purchase_existing_aws_environment = Pipeline(
 terminate = Pipeline(
     SetupContext(config),
     TerminateResponsibilityTransferStep(config),
-    TerminateFinOpsEntitlementStep(config),
     CRMTicketTerminateOrder(config),
+    WaitTerminateResponsibilityTransferStep(config),
+    TerminateFinOpsEntitlementStep(config),
     CompleteTerminationOrder(config),
 )

--- a/swo_aws_extension/flows/order.py
+++ b/swo_aws_extension/flows/order.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import logging
 from dataclasses import dataclass
 
@@ -25,6 +26,7 @@ class InitialAWSContext(BaseContext):
     subscriptions: list[dict] | None = None
     order_authorization: dict | None = None
     bootstrap_roles_status: dict | None = None
+    termination_effective_date: dt.datetime | None = None
 
     @property
     def pm_account_id(self):

--- a/swo_aws_extension/flows/order_utils.py
+++ b/swo_aws_extension/flows/order_utils.py
@@ -14,7 +14,6 @@ from mpt_extension_sdk.mpt_http.wrap_http_error import MPTError, wrap_mpt_http_e
 
 from swo_aws_extension.constants import AgreementStatusEnum, MptOrderStatus
 from swo_aws_extension.flows.order import InitialAWSContext
-from swo_aws_extension.flows.steps.errors import OrderStatusChangeError
 from swo_aws_extension.parameters import get_mpa_account_id, set_mpa_account_id
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
 
@@ -22,6 +21,18 @@ logger = logging.getLogger(__name__)
 MPT_ORDER_STATUS_QUERYING = "Querying"
 MPT_ORDER_STATUS_PROCESSING = "Processing"
 MPT_ORDER_STATUS_COMPLETED = "Completed"
+
+
+class OrderStatusChangeError(RuntimeError):
+    """Exception raised when the order status cannot be changed."""
+
+    def __init__(self, target_status, current_status):
+        message = (
+            f"Order is already in `{current_status}` status. "
+            f"Unable to switch the order to `{target_status}` "
+            f"when it is in `{current_status}` status."
+        )
+        super().__init__(message)
 
 
 def set_template(order, template):

--- a/swo_aws_extension/flows/steps/base.py
+++ b/swo_aws_extension/flows/steps/base.py
@@ -17,6 +17,7 @@ from swo_aws_extension.flows.steps.errors import (
     ConfigurationStepError,
     FailStepError,
     QueryStepError,
+    ScheduleStepError,
     SkipStepError,
     UnexpectedStopError,
 )
@@ -89,8 +90,11 @@ class BasePhaseStep(Step, ABC):
         return True
 
     def _run_process(self, context: InitialAWSContext) -> bool:
-        try:
+        try:  # noqa: WPS225
             self.process(self._client, context)
+        except ScheduleStepError as error:
+            logger.info(str(error))
+            return False
         except UnexpectedStopError as error:
             logger.info("%s - Unexpected Stop: %s", context.order_id, error)
             notify_one_time_error(error.title, error.message)

--- a/swo_aws_extension/flows/steps/create_channel_handshake.py
+++ b/swo_aws_extension/flows/steps/create_channel_handshake.py
@@ -1,13 +1,11 @@
-import datetime as dt
 import logging
 from typing import override
 
-from dateutil.relativedelta import relativedelta
 from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.mpt import update_order
 
 from swo_aws_extension.aws.errors import AWSError
-from swo_aws_extension.constants import PhasesEnum
+from swo_aws_extension.constants import CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS, PhasesEnum
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.base import BasePhaseStep
 from swo_aws_extension.flows.steps.errors import (
@@ -49,7 +47,9 @@ class CreateChannelHandshake(BasePhaseStep):
     @override
     def process(self, client: MPTClient, context: PurchaseContext):
         logger.info(
-            "%s - Action - Creating new channel handshake for 1 year period", context.order_id
+            "%s - Action - Creating new channel handshake with %s days minimum notice period",
+            context.order_id,
+            CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
         )
         pm_identifier = context.aws_apn_client.get_program_management_id_by_account(
             context.pm_account_id
@@ -59,7 +59,7 @@ class CreateChannelHandshake(BasePhaseStep):
             handshake = context.aws_apn_client.create_channel_handshake(
                 pma_identifier=pm_identifier,
                 relationship_identifier=get_relationship_id(context.order),
-                end_date=dt.datetime.now(dt.UTC) + relativedelta(years=1),
+                minimum_notice_days=CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
                 note="Please accept your Service Terms contract with SoftwareOne",
             )
         except AWSError as error:

--- a/swo_aws_extension/flows/steps/crm_tickets/templates/terminate_order.py
+++ b/swo_aws_extension/flows/steps/crm_tickets/templates/terminate_order.py
@@ -2,6 +2,27 @@
 
 from swo_aws_extension.flows.steps.crm_tickets.templates.models import CRMTicketTemplate
 
+TRANSFER_END_SCHEDULED_TEMPLATE = CRMTicketTemplate(
+    title="Action Required : Agreement Termination",
+    additional_info="Customer has scheduled the end of the AWS billing transfer",
+    summary=(
+        "Dear MCoE Team,<br><br>"
+        "The customer has scheduled the end of the AWS responsibility transfer.<br><br>"
+        "Termination date: <b>{end_date}</b><br><br>"
+        "<b>Details:</b><br>"
+        "<ul>"
+        "<li><b>Agreement:</b> {agreement_id}</li>"
+        "<li><b>MasterPayerId:</b> {master_payer_id}</li>"
+        "<li><b>PMA:</b> {pma_account_id}</li>"
+        "</ul>"
+        "The agreement will be terminated after that date and AWS offboarding must be"
+        " handled manually."
+        "<br>Thank you for your attention and taking all necessary steps!<br><br>"
+        "Best Regards,<br>"
+        "Marketplace Platform Team"
+    ),
+)
+
 ORDER_TERMINATION_TEMPLATE = CRMTicketTemplate(
     title="Action Required : Agreement Termination",
     additional_info="Customer wants to terminate their current active AWS agreement",
@@ -9,7 +30,7 @@ ORDER_TERMINATION_TEMPLATE = CRMTicketTemplate(
         "Dear MCoE Team,<br><br>"
         "A notification has been generated on the Marketplace Platform for termination of an AWS"
         " account.<br><br>"
-        "Commitment term end date: <b>{end_date}</b><br><br>"
+        "Termination date (end of minimum notice period): <b>{end_date}</b><br><br>"
         "<b>Order Details:</b><br>"
         "<ul>"
         "<li><b>Customer:</b> {customer_name}</li>"

--- a/swo_aws_extension/flows/steps/crm_tickets/terminate_order.py
+++ b/swo_aws_extension/flows/steps/crm_tickets/terminate_order.py
@@ -2,8 +2,7 @@ import datetime as dt
 import logging
 from typing import override
 
-from dateutil.relativedelta import relativedelta
-
+from swo_aws_extension.constants import CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.crm_tickets.base import BaseCRMTicketStep
 from swo_aws_extension.flows.steps.crm_tickets.templates.terminate_order import (
@@ -20,6 +19,7 @@ from swo_aws_extension.parameters import (
     get_support_type,
     set_crm_terminate_order_ticket_id,
 )
+from swo_aws_extension.utils import date_parser
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,11 @@ class CRMTicketTerminateOrder(BaseCRMTicketStep):
     @override
     def _build_summary(self, context: PurchaseContext) -> str:
         contact = get_formatted_technical_contact(context.order)
-        end_date = dt.datetime.now(dt.UTC) + relativedelta(years=1)
+        end_date = context.termination_effective_date
+        if end_date is None:
+            end_date = date_parser.end_of_month(
+                dt.datetime.now(dt.UTC) + dt.timedelta(days=CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS)
+            )
 
         return self.template.summary.format(
             end_date=end_date.strftime("%Y-%m-%d %H:%M:%S"),

--- a/swo_aws_extension/flows/steps/errors.py
+++ b/swo_aws_extension/flows/steps/errors.py
@@ -18,6 +18,10 @@ class SkipStepError(Exception):
     """The step should be skipped."""
 
 
+class ScheduleStepError(Exception):
+    """The step stops the pipeline, keeping the order processing until a later run."""
+
+
 class ConfigurationStepError(Exception):
     """The step cannot proceed due to configuration issues."""
 
@@ -55,15 +59,3 @@ ERR_MISSING_MPA_ID = ValidationError(
     "AWS002",
     "Account id is empty. Please provide an account id.",
 )
-
-
-class OrderStatusChangeError(RuntimeError):
-    """Exception raised when the order status cannot be changed."""
-
-    def __init__(self, target_status, current_status):
-        message = (
-            f"Order is already in `{current_status}` status. "
-            f"Unable to switch and order to `{target_status}` "
-            f"when it is in `{current_status}` status."
-        )
-        super().__init__(message)

--- a/swo_aws_extension/flows/steps/terminate.py
+++ b/swo_aws_extension/flows/steps/terminate.py
@@ -3,11 +3,14 @@ import logging
 from typing import override
 
 from mpt_extension_sdk.mpt_http.base import MPTClient
+from mpt_extension_sdk.mpt_http.mpt import update_order
 
-from swo_aws_extension.aws.errors import AWSError, InvalidDateInTerminateResponsibilityError
+from swo_aws_extension.aws.errors import (
+    AWSError,
+    InvalidDateInTerminateResponsibilityError,
+)
 from swo_aws_extension.constants import (
-    COMMITMENT_ENABLED_ERROR_MESSAGE,
-    ChannelHandshakeStatusEnum,
+    CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
     ResponsibilityTransferStatus,
 )
 from swo_aws_extension.flows.order import InitialAWSContext
@@ -18,19 +21,17 @@ from swo_aws_extension.flows.steps.errors import (
     UnexpectedStopError,
 )
 from swo_aws_extension.parameters import (
-    get_billing_group_arn,
-    get_channel_handshake_id,
-    get_relationship_id,
+    get_relationship_end_date,
     get_responsibility_transfer_id,
+    set_relationship_end_date,
 )
+from swo_aws_extension.utils import date_parser
 
 logger = logging.getLogger(__name__)
 
-MINIMUM_DAYS_MONTH = 28
 
-
-class TerminateResponsibilityTransferStep(BasePhaseStep):  # noqa: WPS214
-    """Handles the termination of responsibility transfer."""
+class TerminateResponsibilityTransferStep(BasePhaseStep):
+    """Schedules the withdrawal of the responsibility transfer."""
 
     def __init__(self, config) -> None:
         self._config = config
@@ -44,68 +45,85 @@ class TerminateResponsibilityTransferStep(BasePhaseStep):  # noqa: WPS214
                 f"{context.order_id} - Responsibility transfer ID is missing in the order. "
                 f"Completing the termination order."
             )
+        saved_end_date = get_relationship_end_date(context.order)
+        if saved_end_date:
+            context.termination_effective_date = date_parser.to_utc(
+                dt.datetime.fromisoformat(saved_end_date)
+            )
+            raise SkipStepError(
+                f"{context.order_id} - Next - Responsibility transfer end date already "
+                f"known: {saved_end_date}. "
+            )
 
     @override
     def process(self, client: MPTClient, context: InitialAWSContext) -> None:
-        """Terminates a responsibility transfer operation."""
+        """Schedules the withdrawal of the responsibility transfer."""
         responsibility_transfer_id = get_responsibility_transfer_id(context.order)
 
         responsibility_transfer = context.aws_client.get_responsibility_transfer_details(
             responsibility_transfer_id,
-        )
-        status = responsibility_transfer.get("ResponsibilityTransfer", {}).get("Status")
-        if status != ResponsibilityTransferStatus.ACCEPTED:
+        ).get("ResponsibilityTransfer", {})
+        status = responsibility_transfer.get("Status")
+        scheduled_end = responsibility_transfer.get("EndTimestamp")
+
+        if scheduled_end:
+            self._set_relationship_end_date(context, scheduled_end)
             logger.info(
-                "%s - Skipping termination as transfer status is %s", context.order_id, status
+                "%s - Responsibility transfer %s already has an end date configured: %s",
+                context.order_id,
+                responsibility_transfer_id,
+                scheduled_end,
             )
             return
+
+        if status != ResponsibilityTransferStatus.ACCEPTED:
+            logger.info(
+                "%s - Skipping termination as transfer status is %s",
+                context.order_id,
+                status,
+            )
+            return
+
+        scheduled_end = date_parser.end_of_month(
+            dt.datetime.now(dt.UTC) + dt.timedelta(days=CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS)
+        )
         logger.info(
-            "%s - Terminating responsibility transfer %s ",
+            "%s - Terminating responsibility transfer %s with end date %s to honor the "
+            "%s days notice period",
             context.order_id,
             responsibility_transfer_id,
+            scheduled_end,
+            CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
         )
-        handshake = self._get_channel_handshake(context)
-
-        end_date = handshake["detail"]["startServicePeriodHandshakeDetail"]["endDate"]
-
-        if end_date < dt.datetime.now(dt.UTC):
-            logger.info(
-                "%s - Terminating responsibility transfer as channel handshake end date %s "
-                "is in the past",
-                context.order_id,
-                end_date,
-            )
-            self._terminate_relationship_transfer(context, responsibility_transfer_id)
-            self._remove_billing_group(context)
-            self._remove_relationship(context)
-
-        else:
-            if handshake.get("status") == ChannelHandshakeStatusEnum.ACCEPTED.value:
-                raise FailStepError(
-                    "INVALID_END_DATE",
-                    COMMITMENT_ENABLED_ERROR_MESSAGE,
-                )
-            logger.info(
-                "%s - Warning - Channel handshake is in status %s, new ticket will be "
-                "created to offboard the customer manually. ",
-                context.order_id,
-                handshake.get("status"),
-            )
+        self._terminate_relationship_transfer(context, responsibility_transfer_id, scheduled_end)
+        self._set_relationship_end_date(context, scheduled_end)
 
     @override
     def post_step(self, client: MPTClient, context: InitialAWSContext) -> None:
-        """Executes actions after a particular step in the process."""
+        """Persists the fulfillment parameters after the step processing."""
+        context.order = update_order(
+            client, context.order_id, parameters=context.order["parameters"]
+        )
         logger.info(
-            "%s - Completed - responsibility transfer termination step completed", context.order_id
+            "%s - Completed - responsibility transfer termination step completed",
+            context.order_id,
         )
 
+    def _set_relationship_end_date(self, context: InitialAWSContext, end_date: dt.datetime) -> None:
+        end_date = date_parser.to_utc(end_date)
+        context.termination_effective_date = end_date
+        context.order = set_relationship_end_date(context.order, end_date.isoformat())
+
     def _terminate_relationship_transfer(
-        self, context: InitialAWSContext, responsibility_transfer_id
+        self,
+        context: InitialAWSContext,
+        responsibility_transfer_id,
+        end_timestamp: dt.datetime,
     ):
         try:
             context.aws_client.terminate_responsibility_transfer(
                 responsibility_transfer_id,
-                end_timestamp=self._get_last_day_of_the_month_timestamp(),
+                end_timestamp=end_timestamp,
             )
         except InvalidDateInTerminateResponsibilityError as exception:
             raise FailStepError(
@@ -127,73 +145,3 @@ class TerminateResponsibilityTransferStep(BasePhaseStep):  # noqa: WPS214
                     f" responsibility transfer."
                 ),
             ) from exception
-
-    def _remove_billing_group(self, context: InitialAWSContext):
-        billing_group_arn = get_billing_group_arn(context.order)
-        try:
-            context.aws_client.delete_billing_group(billing_group_arn)
-        except AWSError as exception:
-            logger.info(
-                "%s - Failed to delete billing group with error: %s",
-                context.order_id,
-                exception,
-            )
-            return
-        else:
-            logger.info("%s - Billing group %s deleted", context.order_id, billing_group_arn)
-
-    def _remove_relationship(self, context: InitialAWSContext):
-        relationship_id = get_relationship_id(context.order)
-        if not relationship_id:
-            logger.info("%s - No APN relationship ID found in the order", context.order_id)
-            return
-        try:
-            pm_identifier = context.aws_apn_client.get_program_management_id_by_account(
-                context.pm_account_id
-            )
-        except AWSError as exception:
-            logger.info(
-                "%s - Failed to get PMA identifier with error: %s", context.order_id, exception
-            )
-            return
-        try:
-            context.aws_apn_client.delete_pc_relationship(pm_identifier, relationship_id)
-        except AWSError as exception:
-            logger.info(
-                "%s - Failed to delete APN relationship with error: %s",
-                context.order_id,
-                exception,
-            )
-            return
-        logger.info("%s - APN relationship %s deleted", context.order_id, relationship_id)
-
-    def _get_last_day_of_the_month_timestamp(self) -> dt.datetime:
-        # The end date must be the end of the last day of the month (23.59.59.999).
-
-        now = dt.datetime.now(dt.UTC)
-
-        first_day_next_month = (
-            now.replace(day=MINIMUM_DAYS_MONTH, hour=0, minute=0, second=0, microsecond=0)
-            + dt.timedelta(days=4)
-        ).replace(day=1)
-
-        return first_day_next_month - dt.timedelta(milliseconds=1)
-
-    def _get_channel_handshake(self, context: InitialAWSContext) -> dict:
-        relationship_id = get_relationship_id(context.order)
-        handshake_id = get_channel_handshake_id(context.order)
-        handshake = context.aws_apn_client.get_channel_handshake_by_id(
-            relationship_id, handshake_id
-        )
-        if not handshake:
-            logger.info(
-                "%s - Error - Channel handshake %s not found",
-                context.order_id,
-                handshake_id,
-            )
-            raise UnexpectedStopError(
-                "Channel handshake not found",
-                f"Channel handshake"
-                f" {handshake_id} does not exist for relationship {relationship_id}.",
-            )
-        return handshake

--- a/swo_aws_extension/flows/steps/wait_terminate_responsibility_transfer.py
+++ b/swo_aws_extension/flows/steps/wait_terminate_responsibility_transfer.py
@@ -1,0 +1,51 @@
+import datetime as dt
+import logging
+from typing import override
+
+from mpt_extension_sdk.mpt_http.base import MPTClient
+
+from swo_aws_extension.flows.order import InitialAWSContext
+from swo_aws_extension.flows.steps.base import BasePhaseStep
+from swo_aws_extension.flows.steps.errors import ScheduleStepError, SkipStepError
+
+logger = logging.getLogger(__name__)
+
+
+class WaitTerminateResponsibilityTransferStep(BasePhaseStep):
+    """Keeps the termination order processing until the transfer end date is reached."""
+
+    def __init__(self, config) -> None:
+        self._config = config
+
+    @override
+    def pre_step(self, context: InitialAWSContext) -> None:
+        """Performs the preliminary step."""
+        if not context.termination_effective_date:
+            raise SkipStepError(
+                f"{context.order_id} - No responsibility transfer end date to wait for. "
+                f"Continuing with the termination order."
+            )
+
+    @override
+    def process(self, client: MPTClient, context: InitialAWSContext) -> None:
+        """Continues the termination once the responsibility transfer end date is reached."""
+        end_date = context.termination_effective_date
+        if end_date > dt.datetime.now(dt.UTC):
+            raise ScheduleStepError(
+                f"{context.order_id} - Wait - Responsibility transfer ends on {end_date}. "
+                f"Keeping the order in processing until that date."
+            )
+        logger.info(
+            "%s - Responsibility transfer end date %s reached. Continuing with the "
+            "termination order.",
+            context.order_id,
+            end_date,
+        )
+
+    @override
+    def post_step(self, client: MPTClient, context: InitialAWSContext) -> None:
+        """Executes actions after a particular step in the process."""
+        logger.info(
+            "%s - Completed - responsibility transfer wait step completed",
+            context.order_id,
+        )

--- a/swo_aws_extension/parameters.py
+++ b/swo_aws_extension/parameters.py
@@ -582,6 +582,26 @@ def set_erp_project_no(order: dict, erp_project_no: str) -> dict[str, Any]:
     return updated_order
 
 
+def get_relationship_end_date(source: dict[str, Any]) -> str | None:
+    """Get the relationship end date from the fulfillment parameter or None if it is not set."""
+    fulfillment_param = get_fulfillment_parameter(
+        FulfillmentParametersEnum.RELATIONSHIP_END_DATE.value,
+        source,
+    )
+    return fulfillment_param.get("value", None)
+
+
+def set_relationship_end_date(order: dict, end_date: str) -> dict[str, Any]:
+    """Set the relationship end date on the fulfillment parameters."""
+    updated_order = copy.deepcopy(order)
+    fulfillment_param = get_fulfillment_parameter(
+        FulfillmentParametersEnum.RELATIONSHIP_END_DATE.value,
+        updated_order,
+    )
+    fulfillment_param["value"] = end_date
+    return updated_order
+
+
 def get_service_discount_type(source: dict[str, Any]) -> str | None:
     """Get the service discount type from the fulfillment parameter or None if it is not set."""
     fulfillment_param = get_fulfillment_parameter(

--- a/swo_aws_extension/swo/mpt/sync/responsibility_transfers.py
+++ b/swo_aws_extension/swo/mpt/sync/responsibility_transfers.py
@@ -1,0 +1,93 @@
+import datetime as dt
+from functools import cache
+
+from swo_aws_extension.aws.client import AWSClient
+from swo_aws_extension.config import get_config
+from swo_aws_extension.constants import ResponsibilityTransferStatus
+
+AVAILABLE_TRANSFER_STATUSES = frozenset((
+    ResponsibilityTransferStatus.ACCEPTED.value,
+    ResponsibilityTransferStatus.WITHDRAWN.value,
+))
+
+
+def transfer_has_ended(transfer: dict) -> bool:
+    """Whether the transfer has an end date that has already been reached."""
+    end_date = transfer.get("EndTimestamp")
+    return bool(end_date) and end_date <= dt.datetime.now(dt.UTC)
+
+
+def select_transfer(current: dict | None, candidate: dict) -> dict:
+    """Pick the transfer that represents a source account when there is more than one.
+
+    An ACCEPTED transfer always wins over WITHDRAWN ones; between WITHDRAWN transfers
+    the one with the latest end date wins.
+    """
+    if current is None:
+        return candidate
+    accepted = ResponsibilityTransferStatus.ACCEPTED.value
+    if current["Status"] == accepted:
+        return current
+    if candidate["Status"] == accepted:
+        return candidate
+    current_end = current.get("EndTimestamp")
+    candidate_end = candidate.get("EndTimestamp")
+    if candidate_end and (not current_end or candidate_end > current_end):
+        return candidate
+    return current
+
+
+@cache
+def get_available_responsibility_transfers(pma_account_id: str) -> dict:
+    """Fetches ongoing inbound responsibility transfers from the specified AWS client.
+
+    Ongoing transfers are the ACCEPTED ones plus the WITHDRAWN ones, because a withdrawn
+    transfer keeps running until its end date is reached. When a source account has more
+    than one transfer, the ACCEPTED one takes precedence and, among WITHDRAWN ones, only
+    the one with the latest end date is kept.
+
+    Args:
+        pma_account_id: The PMA account ID to query transfers from.
+
+    Returns:
+        A dict mapping source ManagementAccountId to the ongoing transfer info.
+    """
+    config = get_config()
+    aws_client = AWSClient(config, pma_account_id, config.management_role_name)
+    result = {}
+    for rt in aws_client.get_inbound_responsibility_transfers():
+        if rt.get("Status") not in AVAILABLE_TRANSFER_STATUSES:
+            continue
+        source_account_id = rt.get("Source", {}).get("ManagementAccountId")
+        if not source_account_id:
+            continue
+        result[source_account_id] = select_transfer(
+            result.get(source_account_id),
+            {
+                "Id": rt["Id"],
+                "Status": rt["Status"],
+                "EndTimestamp": rt.get("EndTimestamp"),
+            },
+        )
+
+    return result
+
+
+def get_available_transfer_for_account(
+    pma_account_id: str, source_management_account_id: str
+) -> dict | None:
+    """
+    Get the ongoing inbound responsibility transfer for a specific source account.
+
+    Ongoing transfers are the ACCEPTED ones plus the WITHDRAWN ones that keep running
+    until their end date is reached.
+
+    Args:
+        pma_account_id: The PMA account ID to query transfers from.
+        source_management_account_id: The source ManagementAccountId to filter by.
+
+    Returns:
+        The ongoing transfer dict if found, None otherwise.
+    """
+    available_transfers = get_available_responsibility_transfers(pma_account_id)
+    return available_transfers.get(source_management_account_id)

--- a/swo_aws_extension/swo/mpt/sync/syncer.py
+++ b/swo_aws_extension/swo/mpt/sync/syncer.py
@@ -1,5 +1,4 @@
 import logging
-from functools import cache
 from typing import Any, override
 
 from mpt_extension_sdk.mpt_http.base import MPTClient
@@ -11,19 +10,24 @@ from mpt_extension_sdk.mpt_http.mpt import (
 )
 from mpt_extension_sdk.mpt_http.wrap_http_error import wrap_mpt_http_error
 
-from swo_aws_extension.aws.client import AWSClient
-from swo_aws_extension.aws.errors import AWSError
-from swo_aws_extension.config import get_config
 from swo_aws_extension.constants import (
     FulfillmentParametersEnum,
     ParamPhasesEnum,
-    ResponsibilityTransferStatus,
     SubscriptionStatus,
 )
+from swo_aws_extension.flows.steps.crm_tickets.templates.terminate_order import (
+    TRANSFER_END_SCHEDULED_TEMPLATE,
+)
 from swo_aws_extension.parameters import (
-    get_billing_group_arn,
-    get_relationship_id,
+    get_crm_terminate_order_ticket_id,
+    get_relationship_end_date,
     get_responsibility_transfer_id,
+)
+from swo_aws_extension.swo.crm_service.client import ServiceRequest, get_service_client
+from swo_aws_extension.swo.crm_service.errors import CRMError
+from swo_aws_extension.swo.mpt.sync.responsibility_transfers import (
+    get_available_transfer_for_account,
+    transfer_has_ended,
 )
 from swo_aws_extension.swo.notifications.teams import TeamsNotificationManager
 from swo_aws_extension.swo.rql.query_builder import RQLQuery
@@ -82,60 +86,43 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
         self._operation_description = "Synchronize AWS agreement subscriptions"
         self.dry_run = dry_run
 
-    def terminate(self, agreement: AgreementType, pma_account_id):
-        """Terminate an agreement."""
+    def terminate(self, agreement: AgreementType):
+        """Terminate an agreement, leaving AWS offboarding to be handled manually."""
         msg = f"{agreement.get('id')} - agreement with an inactive transfer - terminating"
         logger.warning(msg)
         TeamsNotificationManager().send_warning(self._operation_description, msg)
         self.terminate_agreement(agreement)
-        self.delete_billing_group(agreement, pma_account_id)
-        self.remove_apn(agreement, pma_account_id)
 
-    def remove_apn(self, agreement: AgreementType, pma_account_id: str):
-        """Remove the APN from the PMA account."""
-        config = get_config()
-        relationship_id = get_relationship_id(agreement)
-        if not relationship_id:
+    def notify_scheduled_transfer_end(self, agreement: AgreementType, end_date) -> None:
+        """Create the MCoE termination ticket once when the transfer end is scheduled."""
+        ticket_id = get_crm_terminate_order_ticket_id(agreement)
+        if ticket_id:
             logger.info(
-                "%s - Skipping - Agreement apn relationship id not set", agreement.get("id")
+                "%s - Transfer end already notified with ticket %s",
+                agreement.get("id"),
+                ticket_id,
             )
             return
-        aws_apn_client = AWSClient(config, config.apn_account_id, config.apn_role_name)
-        try:
-            pm_identifier = aws_apn_client.get_program_management_id_by_account(pma_account_id)
-        except AWSError:
-            logger.info("%s - Skipping - PM id not found", agreement.get("id"))
-            return
-        if not pm_identifier:
-            logger.info("%s - Skipping - PMA identifier not found", agreement.get("id"))
-            return
+        logger.warning(
+            "%s - Customer has scheduled the end of the responsibility transfer for %s",
+            agreement.get("id"),
+            end_date,
+        )
         if self.dry_run:
             logger.info(
-                "%s - dry run mode - skipping APN relationship deletion:"
-                " relationship_id=%s pm_identifier=%s",
-                agreement.get("id"),
-                relationship_id,
-                pm_identifier,
+                "%s - dry run mode - skipping termination ticket creation", agreement.get("id")
             )
             return
-        try:
-            aws_apn_client.delete_pc_relationship(pm_identifier, relationship_id)
-        except AWSError:
-            logger.info(
-                "%s - Failed to delete APN relationship. relationship_id=%s pm_identifier=%s",
-                agreement.get("id"),
-                relationship_id,
-                pm_identifier,
-            )
-            return
-        logger.info("%s - APN relationship %s deleted", agreement.get("id"), relationship_id)
+        ticket_id = self._create_transfer_end_ticket(agreement, end_date)
+        if ticket_id:
+            self._save_terminate_ticket_id(agreement, ticket_id)
 
-    def get_accepted_transfer(
+    def get_available_transfer(
         self, agreement: AgreementType, mpa_account_id, pma_account_id
     ) -> dict | None:
-        """Retrieve the accepted transfer for the given agreement and accounts."""
+        """Retrieve the available transfer for the given agreement and accounts."""
         try:
-            return get_accepted_transfer_for_account(pma_account_id, mpa_account_id)
+            return get_available_transfer_for_account(pma_account_id, mpa_account_id)
         except Exception as exception:
             msg = f"{agreement.get('id')} - Error occurred while fetching responsibility transfers"
             logger.exception(msg)
@@ -159,40 +146,33 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
             raise AgreementProcessorError(msg, self._operation_description)
         return str(mpa_account_id)
 
-    def delete_billing_group(self, agreement: AgreementType, pma_account_id: str) -> None:
-        """Deletes the billing group associated with the agreement."""
-        billing_group_arn = get_billing_group_arn(agreement)
-        if not billing_group_arn:
+    def sync_relationship_end_date(self, agreement: AgreementType, end_date) -> None:
+        """Store the scheduled end of the responsibility transfer on the agreement."""
+        end_date_value = end_date.isoformat()
+        if get_relationship_end_date(agreement) == end_date_value:
             return
-
-        if self.dry_run:
-            logger.info(
-                "%s - dry run mode - skipping billing group deletion: %s",
-                agreement["id"],
-                billing_group_arn,
-            )
-            return
-
-        config = get_config()
-        aws_client = AWSClient(config, pma_account_id, config.management_role_name)
-        try:
-            aws_client.delete_billing_group(billing_group_arn)
-        except AWSError:
-            logger.exception(
-                "%s - Failed to delete billing group %s",
-                agreement["id"],
-                billing_group_arn,
-            )
-        else:
-            logger.info("%s - Billing group %s deleted", agreement["id"], billing_group_arn)
+        logger.info(
+            "%s - synchronizing relationship end date: %s",
+            agreement["id"],
+            end_date_value,
+        )
+        self._update_fulfillment_parameter(
+            agreement,
+            FulfillmentParametersEnum.RELATIONSHIP_END_DATE.value,
+            end_date_value,
+            error_message=(
+                f"{agreement['id']} - failed to update agreement with "
+                f"relationship end date {end_date_value}"
+            ),
+            notification_title="Synchronize relationship end date",
+        )
 
     def sync_responsibility_transfer_id(
         self,
-        mpt_client: MPTClient,
         agreement: AgreementType,
         responsibility_transfer_id: str,
     ) -> None:
-        """Synchronizes the PMA account ID for a given agreement."""
+        """Synchronizes the responsibility transfer ID for a given agreement."""
         if get_responsibility_transfer_id(agreement) == responsibility_transfer_id:
             return
         logger.info(
@@ -200,30 +180,16 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
             agreement["id"],
             responsibility_transfer_id,
         )
-        agreement_parameters = {
-            ParamPhasesEnum.FULFILLMENT.value: [
-                {
-                    "externalId": FulfillmentParametersEnum.RESPONSIBILITY_TRANSFER_ID.value,
-                    "value": responsibility_transfer_id,
-                }
-            ]
-        }
-        if self.dry_run:
-            logger.info(
-                "%s - dry run mode - skipping update with parameters: %s",
-                agreement["id"],
-                agreement_parameters,
-            )
-        else:
-            try:
-                update_agreement(mpt_client, agreement["id"], parameters=agreement_parameters)
-            except Exception:
-                msg = (
-                    f"{agreement['id']} - failed to update agreement with "
-                    f"responsibility transfer ID {responsibility_transfer_id}"
-                )
-                logger.exception(msg)
-                TeamsNotificationManager().send_exception("Synchronize PMA account id", msg)
+        self._update_fulfillment_parameter(
+            agreement,
+            FulfillmentParametersEnum.RESPONSIBILITY_TRANSFER_ID.value,
+            responsibility_transfer_id,
+            error_message=(
+                f"{agreement['id']} - failed to update agreement with "
+                f"responsibility transfer ID {responsibility_transfer_id}"
+            ),
+            notification_title="Synchronize responsibility transfer ID",
+        )
 
     def terminate_agreement(self, agreement: AgreementType) -> None:
         """Terminates agreement by terminating all its active subscriptions."""
@@ -267,14 +233,86 @@ class AgreementSyncer(AgreementProcessor):  # noqa: WPS214
         mpa_account_id = self.get_mpa(agreement)
         pma_account_id = self.get_pma(agreement)
 
-        accepted_transfer = self.get_accepted_transfer(agreement, mpa_account_id, pma_account_id)
+        available_transfer = self.get_available_transfer(agreement, mpa_account_id, pma_account_id)
 
-        if not accepted_transfer:
-            self.terminate(agreement, pma_account_id)
+        end_date = available_transfer.get("EndTimestamp") if available_transfer else None
+        if end_date:
+            self.sync_relationship_end_date(agreement, end_date)
+
+        if not available_transfer or transfer_has_ended(available_transfer):
+            self.terminate(agreement)
             return
 
-        self.sync_responsibility_transfer_id(self.mpt_client, agreement, accepted_transfer["Id"])
+        if end_date:
+            self.notify_scheduled_transfer_end(agreement, end_date)
+
+        self.sync_responsibility_transfer_id(agreement, available_transfer["Id"])
         logger.info("%s - End - Sync completed", agreement.get("id"))
+
+    def _create_transfer_end_ticket(self, agreement: AgreementType, end_date) -> str | None:
+        agreement_id = agreement["id"]
+        service_request = ServiceRequest(
+            additional_info=TRANSFER_END_SCHEDULED_TEMPLATE.additional_info,
+            summary=TRANSFER_END_SCHEDULED_TEMPLATE.summary.format(
+                end_date=end_date.strftime("%Y-%m-%d %H:%M:%S"),
+                agreement_id=agreement_id,
+                master_payer_id=self.get_mpa(agreement),
+                pma_account_id=self.get_pma(agreement),
+            ),
+            title=TRANSFER_END_SCHEDULED_TEMPLATE.title,
+        )
+        try:
+            response = get_service_client().create_service_request(agreement_id, service_request)
+        except CRMError:
+            msg = f"{agreement_id} - failed to create the transfer end termination ticket"
+            logger.exception(msg)
+            TeamsNotificationManager().send_exception("Transfer end notification", msg)
+            return None
+        ticket_id = response.get("id")
+        logger.info("%s - termination ticket created with ID %s", agreement_id, ticket_id)
+        return ticket_id
+
+    def _save_terminate_ticket_id(self, agreement: AgreementType, ticket_id: str) -> None:
+        self._update_fulfillment_parameter(
+            agreement,
+            FulfillmentParametersEnum.CRM_TERMINATE_ORDER_TICKET_ID.value,
+            ticket_id,
+            error_message=(
+                f"{agreement['id']} - failed to update agreement with "
+                f"termination ticket ID {ticket_id}"
+            ),
+            notification_title="Transfer end notification",
+        )
+
+    def _update_fulfillment_parameter(
+        self,
+        agreement: AgreementType,
+        external_id: str,
+        parameter_value: str,
+        *,
+        error_message: str,
+        notification_title: str,
+    ) -> None:
+        agreement_parameters = {
+            ParamPhasesEnum.FULFILLMENT.value: [
+                {
+                    "externalId": external_id,
+                    "value": parameter_value,
+                }
+            ]
+        }
+        if self.dry_run:
+            logger.info(
+                "%s - dry run mode - skipping update with parameters: %s",
+                agreement["id"],
+                agreement_parameters,
+            )
+            return
+        try:
+            update_agreement(self.mpt_client, agreement["id"], parameters=agreement_parameters)
+        except Exception:
+            logger.exception(error_message)
+            TeamsNotificationManager().send_exception(notification_title, error_message)
 
 
 # TODO: SDK candidate
@@ -301,30 +339,6 @@ def get_subscription_by_external_id(mpt_client, subscription_external_id):  # pr
     response.raise_for_status()
     subscriptions = response.json()
     return subscriptions["data"][0] if subscriptions["data"] else None
-
-
-@cache
-def get_accepted_inbound_responsibility_transfers(pma_account_id: str) -> dict:
-    """Fetches ACCEPTED inbound responsibility transfers from the specified AWS client.
-
-    Args:
-        pma_account_id: The PMA account ID to query transfers from.
-
-    Returns:
-        A dict mapping source ManagementAccountId to the ACCEPTED transfer info.
-    """
-    config = get_config()
-    aws_client = AWSClient(config, pma_account_id, config.management_role_name)
-    result = {}
-    for rt in aws_client.get_inbound_responsibility_transfers():
-        if rt.get("Status") != ResponsibilityTransferStatus.ACCEPTED.value:
-            continue
-        source_account_id = rt.get("Source", {}).get("ManagementAccountId")
-        if not source_account_id:
-            continue
-        result[source_account_id] = {"Id": rt["Id"], "Status": rt["Status"]}
-
-    return result
 
 
 def synchronize_agreements(
@@ -363,20 +377,3 @@ def synchronize_agreements(
     )
     for agreement in get_agreements_by_query(mpt_client, rql_query):
         syncer.process(agreement)
-
-
-def get_accepted_transfer_for_account(
-    pma_account_id: str, source_management_account_id: str
-) -> dict | None:
-    """
-    Get the ACCEPTED inbound responsibility transfer for a specific source account.
-
-    Args:
-        pma_account_id: The PMA account ID to query transfers from.
-        source_management_account_id: The source ManagementAccountId to filter by.
-
-    Returns:
-        The transfer dict if found with ACCEPTED status, None otherwise.
-    """
-    accepted_transfers = get_accepted_inbound_responsibility_transfers(pma_account_id)
-    return accepted_transfers.get(source_management_account_id)

--- a/swo_aws_extension/utils/date_parser.py
+++ b/swo_aws_extension/utils/date_parser.py
@@ -1,5 +1,23 @@
 import datetime as dt
 
+MINIMUM_DAYS_MONTH = 28
+
+
+def end_of_month(reference: dt.datetime) -> dt.datetime:
+    """Return the last instant of the month of the given datetime (23:59:59.999).
+
+    Args:
+        reference: A datetime object within the target month.
+
+    Returns:
+        A datetime object at the end of the last day of the month.
+    """
+    first_day_next_month = (
+        reference.replace(day=MINIMUM_DAYS_MONTH, hour=0, minute=0, second=0, microsecond=0)
+        + dt.timedelta(days=4)
+    ).replace(day=1)
+    return first_day_next_month - dt.timedelta(milliseconds=1)
+
 
 def to_utc(parsed: dt.datetime) -> dt.datetime:
     """Convert a datetime object to UTC timezone.

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 
 import boto3
 import pytest
+import requests
 import responses
 from botocore.exceptions import ClientError
 
@@ -550,12 +551,11 @@ def test_create_channel_handshake_success(config, aws_client_factory):
     mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
     expected_response = {"handshakeIdentifier": "hs-123456"}
     mock_client.create_channel_handshake.return_value = expected_response
-    end_date = dt.datetime(2026, 12, 31, tzinfo=dt.UTC)
 
     result = mock_aws_client.create_channel_handshake(
         pma_identifier="pma-123456",
         relationship_identifier="rel-123456",
-        end_date=end_date,
+        minimum_notice_days=60,
         note="Please accept your Service Terms contract with SoftwareOne",
     )
 
@@ -567,8 +567,8 @@ def test_create_channel_handshake_success(config, aws_client_factory):
         payload={
             "startServicePeriodPayload": {
                 "programManagementAccountIdentifier": "pma-123456",
-                "servicePeriodType": "FIXED_COMMITMENT_PERIOD",
-                "endDate": end_date,
+                "servicePeriodType": "MINIMUM_NOTICE_PERIOD",
+                "minimumNoticeDays": "60",
                 "note": "Please accept your Service Terms contract with SoftwareOne",
             }
         },
@@ -578,13 +578,12 @@ def test_create_channel_handshake_success(config, aws_client_factory):
 def test_create_channel_handshake_error(config, aws_client_factory):
     mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
     mock_client.create_channel_handshake.side_effect = AWSError("Handshake creation failed")
-    end_date = dt.datetime(2026, 12, 31, tzinfo=dt.UTC)
 
     with pytest.raises(AWSError, match="Handshake creation failed"):
         mock_aws_client.create_channel_handshake(
             pma_identifier="pma-123456",
             relationship_identifier="rel-123456",
-            end_date=end_date,
+            minimum_notice_days=60,
             note="Please accept your Service Terms contract with SoftwareOne",
         )
 
@@ -848,6 +847,16 @@ def test_download_invoice_pdf_missing_url_raises(config, aws_client_factory):
     mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {}}
 
     with pytest.raises(AWSError, match="Invoice PDF URL is missing"):
+        mock_aws_client.download_invoice_pdf("INV-001")
+
+
+def test_download_invoice_pdf_unknown_status(config, aws_client_factory, requests_mocker):
+    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
+    document_url = "https://example.test/invoice.pdf"
+    mock_client.get_invoice_pdf.return_value = {"InvoicePDF": {"DocumentUrl": document_url}}
+    requests_mocker.add(responses.GET, document_url, body=requests.ConnectionError("boom"))
+
+    with pytest.raises(AWSError, match="HTTP status: unknown"):
         mock_aws_client.download_invoice_pdf("INV-001")
 
 

--- a/tests/aws/test_client.py
+++ b/tests/aws/test_client.py
@@ -449,33 +449,6 @@ def test_create_billing_group_error(config, aws_client_factory):
     mock_client.create_billing_group.assert_called_once()
 
 
-def test_delete_billing_group_success(config, aws_client_factory):
-    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
-    expected_response = {"Arn": "arn:aws:billingconductor::123:billinggroup/test-billing-group"}
-    mock_client.delete_billing_group.return_value = expected_response
-
-    result = mock_aws_client.delete_billing_group(
-        billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-billing-group",
-    )
-
-    assert result == expected_response
-    mock_client.delete_billing_group.assert_called_once_with(
-        Arn="arn:aws:billingconductor::123:billinggroup/test-billing-group",
-    )
-
-
-def test_delete_billing_group_error(config, aws_client_factory):
-    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
-    mock_client.delete_billing_group.side_effect = AWSError("Billing group deletion failed")
-
-    with pytest.raises(AWSError, match="Billing group deletion failed"):
-        mock_aws_client.delete_billing_group(
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-billing-group",
-        )
-
-    mock_client.delete_billing_group.assert_called_once()
-
-
 def test_get_program_management_id_success(config, aws_client_factory):
     mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
     mock_client.list_program_management_accounts.return_value = {"items": [{"id": "pma-123456"}]}
@@ -646,33 +619,6 @@ def test_get_channel_handshakes_error(config, aws_client_factory, mock_get_paged
         mock_aws_client.get_channel_handshakes_by_resource(resource_identifier="rel-123456")
 
     mock_get_paged_response.assert_called_once()
-
-
-def test_delete_pc_relationship_success(config, aws_client_factory):
-    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
-    mock_delete_relationship = mock_client.delete_relationship
-
-    mock_aws_client.delete_pc_relationship(pm_identifier="pm-1", relationship_id="rel-1")  # act
-
-    mock_delete_relationship.assert_called_once_with(
-        catalog="AWS",
-        identifier="rel-1",
-        programManagementAccountIdentifier="pm-1",
-    )
-
-
-def test_delete_pc_relationship_error(config, aws_client_factory):
-    mock_aws_client, mock_client = aws_client_factory(config, "test_account_id", "test_role_name")
-    mock_client.delete_relationship.side_effect = AWSError("API error")
-
-    with pytest.raises(AWSError, match="API error"):
-        mock_aws_client.delete_pc_relationship(pm_identifier="pm-1", relationship_id="rel-1")
-
-    mock_client.delete_relationship.assert_called_once_with(
-        catalog="AWS",
-        identifier="rel-1",
-        programManagementAccountIdentifier="pm-1",
-    )
 
 
 def test_get_channel_handshake_by_id_found(config, aws_client_factory, mock_get_paged_response):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,6 +374,7 @@ def fulfillment_parameters_factory():
         execution_arn="",
         cco_contract_number="",
         erp_project_no="",
+        relationship_end_date="",
     ):
         return [
             {
@@ -448,6 +449,10 @@ def fulfillment_parameters_factory():
             {
                 "externalId": FulfillmentParametersEnum.ERP_PROJECT_NO.value,
                 "value": erp_project_no,
+            },
+            {
+                "externalId": FulfillmentParametersEnum.RELATIONSHIP_END_DATE.value,
+                "value": relationship_end_date,
             },
         ]
 

--- a/tests/flows/fulfillment/test_pipelines.py
+++ b/tests/flows/fulfillment/test_pipelines.py
@@ -63,8 +63,9 @@ def test_terminate_steps():
     expected_step_classes = [
         "SetupContext",
         "TerminateResponsibilityTransferStep",
-        "TerminateFinOpsEntitlementStep",
         "CRMTicketTerminateOrder",
+        "WaitTerminateResponsibilityTransferStep",
+        "TerminateFinOpsEntitlementStep",
         "CompleteTerminationOrder",
     ]
 

--- a/tests/flows/steps/crm_tickets/test_terminate_order.py
+++ b/tests/flows/steps/crm_tickets/test_terminate_order.py
@@ -1,9 +1,14 @@
+import datetime as dt
+
 import pytest
+from freezegun import freeze_time
 
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.crm_tickets.terminate_order import CRMTicketTerminateOrder
 from swo_aws_extension.flows.steps.errors import SkipStepError
 from swo_aws_extension.parameters import get_crm_terminate_order_ticket_id
+
+TERMINATION_EFFECTIVE_DATE = dt.datetime.fromisoformat("2026-10-31T23:59:59+00:00")
 
 
 def test_pre_step_skips_when_ticket_exists(order_factory, fulfillment_parameters_factory, config):
@@ -51,6 +56,59 @@ def test_process_creates_service_request(
     CRMTicketTerminateOrder(config).process(mpt_client, context)  # act
 
     assert mock_crm_client.return_value.create_service_request.called
+
+
+@freeze_time("2026-07-31 10:00:00")
+def test_process_summary_uses_termination_effective_date_from_context(
+    order_factory,
+    fulfillment_parameters_factory,
+    mpt_client,
+    mock_crm_client,
+    config,
+    buyer,
+):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(),
+    )
+    context = PurchaseContext.from_order_data(order)
+    context.buyer = buyer
+    context.termination_effective_date = TERMINATION_EFFECTIVE_DATE
+    create_request_mock = mock_crm_client.return_value.create_service_request
+    create_request_mock.return_value = {"id": "TICKET-123"}
+
+    CRMTicketTerminateOrder(config).process(mpt_client, context)  # act
+
+    service_request = create_request_mock.call_args.args[1]
+    assert (
+        "Termination date (end of minimum notice period): <b>2026-10-31 23:59:59</b>"
+        in service_request.summary
+    )
+
+
+@freeze_time("2026-07-31 10:00:00")
+def test_process_summary_uses_minimum_notice_period_end_date(
+    order_factory,
+    fulfillment_parameters_factory,
+    mpt_client,
+    mock_crm_client,
+    config,
+    buyer,
+):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(),
+    )
+    context = PurchaseContext.from_order_data(order)
+    context.buyer = buyer
+    create_request_mock = mock_crm_client.return_value.create_service_request
+    create_request_mock.return_value = {"id": "TICKET-123"}
+
+    CRMTicketTerminateOrder(config).process(mpt_client, context)  # act
+
+    service_request = create_request_mock.call_args.args[1]
+    assert (
+        "Termination date (end of minimum notice period): <b>2026-09-30 23:59:59</b>"
+        in service_request.summary
+    )
 
 
 def test_process_sets_ticket_id_on_success(

--- a/tests/flows/steps/test_base_phase_step.py
+++ b/tests/flows/steps/test_base_phase_step.py
@@ -9,6 +9,7 @@ from swo_aws_extension.flows.steps.errors import (
     ConfigurationStepError,
     FailStepError,
     QueryStepError,
+    ScheduleStepError,
     SkipStepError,
     UnexpectedStopError,
 )
@@ -99,6 +100,16 @@ def test_unexpected_stop_notifies_and_stops(mocker, initial_context):
 
     notify_mock.assert_called_once_with(error.title, error.message)
     next_step.assert_not_called()
+
+
+def test_schedule_step_error_stops_pipeline(mocker, initial_context, caplog):
+    step = DummyStep()
+    step.proc_exc = ScheduleStepError("waiting for the end date")
+
+    _, next_step = _run_step(mocker, step, initial_context)  # act
+
+    next_step.assert_not_called()
+    assert "waiting for the end date" in caplog.text
 
 
 def test_query_step_error(mocker, initial_context):

--- a/tests/flows/steps/test_create_channel_handshake.py
+++ b/tests/flows/steps/test_create_channel_handshake.py
@@ -1,11 +1,7 @@
-import datetime as dt
-
 import pytest
-from dateutil.relativedelta import relativedelta
-from freezegun import freeze_time
 
 from swo_aws_extension.aws.errors import AWSError
-from swo_aws_extension.constants import PhasesEnum
+from swo_aws_extension.constants import CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS, PhasesEnum
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.steps.create_channel_handshake import CreateChannelHandshake
 from swo_aws_extension.flows.steps.errors import (
@@ -14,14 +10,6 @@ from swo_aws_extension.flows.steps.errors import (
     UnexpectedStopError,
 )
 from swo_aws_extension.parameters import get_channel_handshake_id, get_phase
-
-FROZEN_DATE_JANUARY = "2026-01-20 10:30:00"
-FROZEN_DATE_DECEMBER = "2026-12-15 10:30:00"
-
-
-def _get_expected_end_date(frozen_date: str) -> dt.datetime:
-    now = dt.datetime.fromisoformat(frozen_date).replace(tzinfo=dt.UTC)
-    return now + relativedelta(years=1)
 
 
 def test_skip_phase_is_not_expected(fulfillment_parameters_factory, order_factory, config):
@@ -65,7 +53,6 @@ def test_pre_step_success(fulfillment_parameters_factory, order_factory, config)
     assert result is None
 
 
-@freeze_time(FROZEN_DATE_JANUARY)
 def test_process_success(
     order_factory,
     aws_client_factory,
@@ -87,7 +74,6 @@ def test_process_success(
     aws_client_mock.create_channel_handshake.return_value = {
         "channelHandshakeDetail": {"id": "hs-new-123456"}
     }
-    expected_end_date = _get_expected_end_date(FROZEN_DATE_JANUARY)
 
     CreateChannelHandshake(config).process(mpt_client, context)  # act
 
@@ -95,43 +81,10 @@ def test_process_success(
     aws_client_mock.create_channel_handshake.assert_called_once_with(
         pma_identifier="pma-identifier-123",
         relationship_identifier="rel-123456",
-        end_date=expected_end_date,
+        minimum_notice_days=CHANNEL_HANDSHAKE_MINIMUM_NOTICE_DAYS,
         note="Please accept your Service Terms contract with SoftwareOne",
     )
     assert get_channel_handshake_id(context.order) == "hs-new-123456"
-
-
-@freeze_time(FROZEN_DATE_DECEMBER)
-def test_process_end_date_year_boundary(
-    order_factory,
-    aws_client_factory,
-    fulfillment_parameters_factory,
-    config,
-    mpt_client,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            phase=PhasesEnum.CREATE_CHANNEL_HANDSHAKE.value,
-            relationship_id="rel-123456",
-        )
-    )
-    context = PurchaseContext.from_order_data(order)
-    _, aws_client_mock = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = aws_client_mock
-    aws_client_mock.get_program_management_id_by_account.return_value = "pma-identifier-123"
-    aws_client_mock.create_channel_handshake.return_value = {
-        "channelHandshakeDetail": {"id": "hs-new-123456"}
-    }
-    expected_end_date = _get_expected_end_date(FROZEN_DATE_DECEMBER)
-
-    CreateChannelHandshake(config).process(mpt_client, context)  # act
-
-    aws_client_mock.create_channel_handshake.assert_called_once_with(
-        pma_identifier="pma-identifier-123",
-        relationship_identifier="rel-123456",
-        end_date=expected_end_date,
-        note="Please accept your Service Terms contract with SoftwareOne",
-    )
 
 
 def test_process_aws_error(

--- a/tests/flows/steps/test_terminate.py
+++ b/tests/flows/steps/test_terminate.py
@@ -4,21 +4,47 @@ import pytest
 from freezegun import freeze_time
 
 from swo_aws_extension.aws.errors import AWSError, InvalidDateInTerminateResponsibilityError
-from swo_aws_extension.constants import (
-    ChannelHandshakeStatusEnum,
-    ResponsibilityTransferStatus,
-)
+from swo_aws_extension.constants import ResponsibilityTransferStatus
 from swo_aws_extension.flows.order import InitialAWSContext
-from swo_aws_extension.flows.steps.errors import FailStepError, SkipStepError, UnexpectedStopError
+from swo_aws_extension.flows.steps.errors import (
+    FailStepError,
+    SkipStepError,
+    UnexpectedStopError,
+)
 from swo_aws_extension.flows.steps.terminate import TerminateResponsibilityTransferStep
+from swo_aws_extension.parameters import get_relationship_end_date
 
 JUNE_YEAR = 2025
-DECEMBER_YEAR = 2026
 
 
 def _get_end_of_month(year, month):
     first_day = dt.datetime(year, month, 1, 0, 0, 0, tzinfo=dt.UTC)
     return first_day - dt.timedelta(milliseconds=1)
+
+
+def _build_context(
+    order_factory,
+    fulfillment_parameters_factory,
+    mock_aws_client,
+    transfer_status=ResponsibilityTransferStatus.ACCEPTED,
+    scheduled_end=None,
+    relationship_end_date="",
+):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(
+            responsibility_transfer_id="rt-8lr3q6sn",
+            relationship_end_date=relationship_end_date,
+        )
+    )
+    context = InitialAWSContext.from_order_data(order)
+    context.aws_client = mock_aws_client
+    responsibility_transfer = {"Status": transfer_status}
+    if scheduled_end:
+        responsibility_transfer["EndTimestamp"] = scheduled_end
+    mock_aws_client.get_responsibility_transfer_details.return_value = {
+        "ResponsibilityTransfer": responsibility_transfer
+    }
+    return context
 
 
 def test_pre_step_skips_when_no_transfer_id(
@@ -63,565 +89,166 @@ def test_pre_step_proceeds_with_transfer_id(
 
 
 @freeze_time("2025-06-15")
-def test_process_terminates_when_end_date_past(
+def test_process_schedules_withdrawal_with_notice_period(
     order_factory,
     fulfillment_parameters_factory,
     config,
     mock_aws_client,
     mpt_client,
-    aws_client_factory,
 ):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-group",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
+    context = _build_context(
+        order_factory,
+        fulfillment_parameters_factory,
+        mock_aws_client,
     )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
     step = TerminateResponsibilityTransferStep(config)
 
     step.process(mpt_client, context)  # act
 
-    expected_end = _get_end_of_month(JUNE_YEAR, 7)
+    expected_end = _get_end_of_month(JUNE_YEAR, 9)
     mock_aws_client.terminate_responsibility_transfer.assert_called_once_with(
         "rt-8lr3q6sn",
         end_timestamp=expected_end,
     )
-    mock_aws_client.delete_billing_group.assert_called_once_with(
-        "arn:aws:billingconductor::123:billinggroup/test-group"
-    )
+    assert context.termination_effective_date == expected_end
+    assert get_relationship_end_date(context.order) == expected_end.isoformat()
 
 
-@freeze_time("2025-12-15")
-def test_process_success_december(
+def test_process_uses_end_date_already_configured(
     order_factory,
     fulfillment_parameters_factory,
     config,
     mock_aws_client,
     mpt_client,
-    aws_client_factory,
 ):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-group",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
+    scheduled_end = _get_end_of_month(JUNE_YEAR, 10)
+    context = _build_context(
+        order_factory,
+        fulfillment_parameters_factory,
+        mock_aws_client,
+        scheduled_end=scheduled_end,
     )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-12-01T00:00:00+00:00"),
-            }
-        },
-    }
-    step = TerminateResponsibilityTransferStep(config)
-
-    step.process(mpt_client, context)  # act
-
-    expected_end = _get_end_of_month(DECEMBER_YEAR, 1)
-    mock_aws_client.terminate_responsibility_transfer.assert_called_once_with(
-        "rt-8lr3q6sn",
-        end_timestamp=expected_end,
-    )
-    mock_aws_client.delete_billing_group.assert_called_once_with(
-        "arn:aws:billingconductor::123:billinggroup/test-group"
-    )
-
-
-@freeze_time("2025-06-15")
-def test_process_skips_non_accepted_transfer(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    agreement_factory,
-    mpt_client,
-    caplog,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-        )
-    )
-    agreement = agreement_factory()
-    context = InitialAWSContext(aws_client=mock_aws_client, order=order, agreement=agreement)
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": "Pending"}
-    }
     step = TerminateResponsibilityTransferStep(config)
 
     step.process(mpt_client, context)  # act
 
     mock_aws_client.terminate_responsibility_transfer.assert_not_called()
-    mock_aws_client.delete_billing_group.assert_not_called()
-    assert "Skipping termination as transfer status is Pending" in caplog.text
+    assert context.termination_effective_date == scheduled_end
+    assert get_relationship_end_date(context.order) == scheduled_end.isoformat()
 
 
-@freeze_time("2025-06-15")
-def test_process_delete_billing_group_error(
+def test_pre_step_already_processed_with_saved_end_date(
+    order_factory,
+    fulfillment_parameters_factory,
+    config,
+    mock_aws_client,
+):
+    saved_end = _get_end_of_month(JUNE_YEAR, 10)
+    context = _build_context(
+        order_factory,
+        fulfillment_parameters_factory,
+        mock_aws_client,
+        relationship_end_date=saved_end.isoformat(),
+    )
+    step = TerminateResponsibilityTransferStep(config)
+
+    with pytest.raises(SkipStepError) as exc_info:
+        step.pre_step(context)
+
+    assert "end date already known" in str(exc_info.value)
+    assert context.termination_effective_date == saved_end
+
+
+def test_process_skips_non_accepted_transfer(
     order_factory,
     fulfillment_parameters_factory,
     config,
     mock_aws_client,
     mpt_client,
-    caplog,
-    aws_client_factory,
 ):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-group",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
+    context = _build_context(
+        order_factory,
+        fulfillment_parameters_factory,
+        mock_aws_client,
+        transfer_status=ResponsibilityTransferStatus.REQUESTED,
     )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
-    mock_aws_client.delete_billing_group.side_effect = AWSError("Billing group deletion failed")
     step = TerminateResponsibilityTransferStep(config)
 
     step.process(mpt_client, context)  # act
 
-    mock_aws_client.terminate_responsibility_transfer.assert_called_once()
-    mock_aws_client.delete_billing_group.assert_called_once_with(
-        "arn:aws:billingconductor::123:billinggroup/test-group"
-    )
-    assert "Failed to delete billing group with error" in caplog.text
+    mock_aws_client.terminate_responsibility_transfer.assert_not_called()
+    assert context.termination_effective_date is None
 
 
 @freeze_time("2025-06-15")
-def test_process_exception_handling(
+def test_process_fails_on_invalid_termination_date(
     order_factory,
     fulfillment_parameters_factory,
     config,
     mock_aws_client,
     mpt_client,
-    aws_client_factory,
 ):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
+    context = _build_context(
+        order_factory,
+        fulfillment_parameters_factory,
+        mock_aws_client,
     )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
+    mock_aws_client.terminate_responsibility_transfer.side_effect = (
+        InvalidDateInTerminateResponsibilityError("Invalid date", _get_end_of_month(JUNE_YEAR, 9))
+    )
+    step = TerminateResponsibilityTransferStep(config)
+
+    with pytest.raises(FailStepError) as exc_info:
+        step.process(mpt_client, context)
+
+    assert "invalid date in terminate responsibility agreement" in str(exc_info.value)
+
+
+@freeze_time("2025-06-15")
+def test_process_stops_on_aws_error(
+    order_factory,
+    fulfillment_parameters_factory,
+    config,
+    mock_aws_client,
+    mpt_client,
+):
+    context = _build_context(
+        order_factory,
+        fulfillment_parameters_factory,
+        mock_aws_client,
+    )
     mock_aws_client.terminate_responsibility_transfer.side_effect = AWSError("AWS API error")
     step = TerminateResponsibilityTransferStep(config)
 
     with pytest.raises(UnexpectedStopError) as exc_info:
         step.process(mpt_client, context)
 
-    assert "Terminate responsibility transfer" in exc_info.value.title
+    assert "unhandled exception while terminating responsibility transfer" in str(exc_info.value)
 
 
-@freeze_time("2025-06-15")
-def test_process_wrong_date(
+def test_post_step_persists_parameters(
+    mocker,
     order_factory,
     fulfillment_parameters_factory,
     config,
     mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
-    mock_aws_client.terminate_responsibility_transfer.side_effect = (
-        InvalidDateInTerminateResponsibilityError(
-            "Invalid date provided for termination",
-            dt.datetime.now(tz=dt.UTC),
-        )
-    )
-    step = TerminateResponsibilityTransferStep(config)
-
-    with pytest.raises(FailStepError):
-        step.process(mpt_client, context)  # act
-
-
-@freeze_time("2025-06-15")
-def test_post_step_logs_success(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    agreement_factory,
     mpt_client,
     caplog,
 ):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-        )
+    context = _build_context(
+        order_factory,
+        fulfillment_parameters_factory,
+        mock_aws_client,
     )
-    agreement = agreement_factory()
-    context = InitialAWSContext(aws_client=mock_aws_client, order=order, agreement=agreement)
+    mock_update_order = mocker.patch(
+        "swo_aws_extension.flows.steps.terminate.update_order",
+        return_value=context.order,
+    )
     step = TerminateResponsibilityTransferStep(config)
 
     step.post_step(mpt_client, context)  # act
 
+    mock_update_order.assert_called_once_with(
+        mpt_client, context.order_id, parameters=context.order["parameters"]
+    )
     assert "responsibility transfer termination step completed" in caplog.text
-
-
-@freeze_time("2025-06-15")
-def test_process_fails_when_future_date_accepted(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-07-01T00:00:00+00:00"),
-            }
-        },
-    }
-    step = TerminateResponsibilityTransferStep(config)
-
-    with pytest.raises(FailStepError) as exc_info:
-        step.process(mpt_client, context)  # act
-
-    assert exc_info.value.id == "INVALID_END_DATE"
-    mock_aws_client.terminate_responsibility_transfer.assert_not_called()
-
-
-@freeze_time("2025-06-15")
-def test_process_warns_future_date_pending(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-    caplog,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.PENDING.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-07-01T00:00:00+00:00"),
-            }
-        },
-    }
-    step = TerminateResponsibilityTransferStep(config)
-
-    step.process(mpt_client, context)  # act
-
-    assert "Warning - Channel handshake is in status PENDING" in caplog.text
-    mock_aws_client.terminate_responsibility_transfer.assert_not_called()
-
-
-@freeze_time("2025-06-15")
-def test_process_fails_handshake_not_found(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = None
-    step = TerminateResponsibilityTransferStep(config)
-
-    with pytest.raises(UnexpectedStopError) as exc_info:
-        step.process(mpt_client, context)  # act
-
-    assert "Channel handshake not found" in exc_info.value.title
-
-
-@freeze_time("2025-06-15")
-def test_process_skips_removal_when_no_id(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-    caplog,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-group",
-            channel_handshake_id="hs-123456",
-            relationship_id="",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
-    step = TerminateResponsibilityTransferStep(config)
-
-    step.process(mpt_client, context)  # act
-
-    assert "No APN relationship ID found in the order" in caplog.text
-    mock_apn_client.get_program_management_id_by_account.assert_not_called()
-
-
-@freeze_time("2025-06-15")
-def test_process_logs_error_when_get_pma_id_fails(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-    caplog,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-group",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
-    mock_apn_client.get_program_management_id_by_account.side_effect = AWSError(
-        "Failed to get PMA ID"
-    )
-    step = TerminateResponsibilityTransferStep(config)
-
-    step.process(mpt_client, context)  # act
-
-    assert "Failed to get PMA identifier with error" in caplog.text
-    mock_apn_client.delete_pc_relationship.assert_not_called()
-
-
-@freeze_time("2025-06-15")
-def test_process_logs_error_when_delete_fails(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-    caplog,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-group",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
-    mock_apn_client.get_program_management_id_by_account.return_value = "pm-123456"
-    mock_apn_client.delete_pc_relationship.side_effect = AWSError("Failed to delete relationship")
-    step = TerminateResponsibilityTransferStep(config)
-
-    step.process(mpt_client, context)  # act
-
-    assert "Failed to delete APN relationship with error" in caplog.text
-
-
-@freeze_time("2025-06-15")
-def test_process_logs_success_when_deleted(
-    order_factory,
-    fulfillment_parameters_factory,
-    config,
-    mock_aws_client,
-    mpt_client,
-    aws_client_factory,
-    caplog,
-):
-    order = order_factory(
-        fulfillment_parameters=fulfillment_parameters_factory(
-            responsibility_transfer_id="rt-8lr3q6sn",
-            billing_group_arn="arn:aws:billingconductor::123:billinggroup/test-group",
-            channel_handshake_id="hs-123456",
-            relationship_id="rel-123456",
-        )
-    )
-    context = InitialAWSContext.from_order_data(order)
-    context.aws_client = mock_aws_client
-    _, mock_apn_client = aws_client_factory(config, "pma-id", "role-name")
-    context.aws_apn_client = mock_apn_client
-    mock_aws_client.get_responsibility_transfer_details.return_value = {
-        "ResponsibilityTransfer": {"Status": ResponsibilityTransferStatus.ACCEPTED}
-    }
-    mock_apn_client.get_channel_handshake_by_id.return_value = {
-        "id": "hs-123456",
-        "status": ChannelHandshakeStatusEnum.ACCEPTED.value,
-        "detail": {
-            "startServicePeriodHandshakeDetail": {
-                "endDate": dt.datetime.fromisoformat("2025-06-01T00:00:00+00:00"),
-            }
-        },
-    }
-    mock_apn_client.get_program_management_id_by_account.return_value = "pm-123456"
-    step = TerminateResponsibilityTransferStep(config)
-
-    step.process(mpt_client, context)  # act
-
-    mock_apn_client.delete_pc_relationship.assert_called_once_with("pm-123456", "rel-123456")
-    assert "APN relationship rel-123456 deleted" in caplog.text

--- a/tests/flows/steps/test_wait_terminate_responsibility_transfer.py
+++ b/tests/flows/steps/test_wait_terminate_responsibility_transfer.py
@@ -1,0 +1,83 @@
+import datetime as dt
+
+import pytest
+from freezegun import freeze_time
+
+from swo_aws_extension.flows.order import InitialAWSContext
+from swo_aws_extension.flows.steps.errors import ScheduleStepError, SkipStepError
+from swo_aws_extension.flows.steps.wait_terminate_responsibility_transfer import (
+    WaitTerminateResponsibilityTransferStep,
+)
+
+END_YEAR = 2025
+END_MONTH = 9
+
+
+def _get_end_of_month(year, month):
+    first_day = dt.datetime(year, month, 1, tzinfo=dt.UTC)
+    return first_day - dt.timedelta(milliseconds=1)
+
+
+END_DATE = _get_end_of_month(END_YEAR, END_MONTH)
+
+
+def _build_context(order_factory, termination_effective_date=None):
+    context = InitialAWSContext.from_order_data(order_factory())
+    context.termination_effective_date = termination_effective_date
+    return context
+
+
+def test_pre_step_skips_without_end_date(order_factory, config):
+    context = _build_context(order_factory)
+    step = WaitTerminateResponsibilityTransferStep(config)
+
+    with pytest.raises(SkipStepError) as exc_info:
+        step.pre_step(context)
+
+    assert "No responsibility transfer end date to wait for" in str(exc_info.value)
+
+
+def test_pre_step_proceeds_with_end_date(order_factory, config):
+    context = _build_context(order_factory, termination_effective_date=END_DATE)
+    step = WaitTerminateResponsibilityTransferStep(config)
+
+    step.pre_step(context)  # act
+
+    assert context.order is not None
+
+
+@freeze_time("2025-06-15")
+def test_process_schedules_wait_before_end_date(order_factory, config, mpt_client):
+    context = _build_context(order_factory, termination_effective_date=END_DATE)
+    step = WaitTerminateResponsibilityTransferStep(config)
+
+    with pytest.raises(ScheduleStepError) as exc_info:
+        step.process(mpt_client, context)
+
+    assert "Keeping the order in processing until that date" in str(exc_info.value)
+
+
+@freeze_time("2025-06-15")
+def test_call_waits_until_end_date(mocker, order_factory, config, mpt_client, caplog):
+    context = _build_context(order_factory, termination_effective_date=END_DATE)
+    step = WaitTerminateResponsibilityTransferStep(config)
+    next_step = mocker.MagicMock()
+
+    step(mpt_client, context, next_step)  # act
+
+    next_step.assert_not_called()
+    assert "Keeping the order in processing until that date" in caplog.text
+
+
+@freeze_time("2025-09-15")
+def test_call_continues_after_end_date(mocker, order_factory, config, mpt_client, caplog):
+    context = _build_context(order_factory, termination_effective_date=END_DATE)
+    step = WaitTerminateResponsibilityTransferStep(config)
+    next_step = mocker.MagicMock()
+
+    step(mpt_client, context, next_step)  # act
+
+    next_step.assert_called_once_with(mpt_client, context)
+    assert "end date" in caplog.text
+    assert "reached" in caplog.text
+    assert "responsibility transfer wait step completed" in caplog.text

--- a/tests/flows/test_order_utils.py
+++ b/tests/flows/test_order_utils.py
@@ -1,9 +1,15 @@
+import pytest
 from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.wrap_http_error import MPTError
 
-from swo_aws_extension.constants import OrderCompletedTemplate, OrderQueryingTemplateEnum
+from swo_aws_extension.constants import (
+    MptOrderStatus,
+    OrderCompletedTemplate,
+    OrderQueryingTemplateEnum,
+)
 from swo_aws_extension.flows.order import PurchaseContext
 from swo_aws_extension.flows.order_utils import (
+    OrderStatusChangeError,
     has_previous_order,
     set_order_template,
     strip_whitespace_from_mpa_account,
@@ -191,6 +197,18 @@ def test_switch_order_status_to_complete(
         parameters=context.order["parameters"],
         template=new_template,
     )
+
+
+def test_switch_order_status_to_complete_already_completed(mocker, order_factory):
+    client = mocker.MagicMock(spec=MPTClient)
+    order = order_factory(status=MptOrderStatus.COMPLETED.value)
+    context = PurchaseContext.from_order_data(order)
+    complete_order_mock = mocker.patch("swo_aws_extension.flows.order_utils.complete_order")
+
+    with pytest.raises(OrderStatusChangeError, match="already in"):
+        switch_order_status_to_complete(client, context, "TemplateName")
+
+    complete_order_mock.assert_not_called()
 
 
 def test_update_processing_template(

--- a/tests/swo/mpt/sync/conftest.py
+++ b/tests/swo/mpt/sync/conftest.py
@@ -6,6 +6,9 @@ from swo_aws_extension.aws.client import AWSClient
 from swo_aws_extension.swo.mpt.sync.syncer import AgreementSyncer
 from swo_aws_extension.swo.notifications.teams import TeamsNotificationManager
 
+_SYNCER_MOD = "swo_aws_extension.swo.mpt.sync.syncer"
+_TRANSFERS_MOD = "swo_aws_extension.swo.mpt.sync.responsibility_transfers"
+
 
 @pytest.fixture
 def mock_terminate_subscription(mocker):
@@ -48,14 +51,14 @@ def mock_get_agreements_by_query(mocker):
 @pytest.fixture
 def mock_awsclient(mocker):
     mock = mocker.Mock(spec=AWSClient)
-    mocker.patch("swo_aws_extension.swo.mpt.sync.syncer.AWSClient", return_value=mock)
+    mocker.patch(f"{_TRANSFERS_MOD}.AWSClient", return_value=mock)
     return mock
 
 
 @pytest.fixture
-def mock_get_accepted_transfer_for_account(mocker):
+def mock_get_available_transfer_for_account(mocker):
     return mocker.patch(
-        "swo_aws_extension.swo.mpt.sync.syncer.get_accepted_transfer_for_account",
+        f"{_SYNCER_MOD}.get_available_transfer_for_account",
         spec=True,
     )
 
@@ -82,18 +85,23 @@ def responsibility_transfer_factory():
         source="225989344502",
         target="651706759263",
         start_timestamp="2025-11-01T00:00:00Z",
+        end_timestamp=None,
+        transfer_id="rt-8lr3q6sn",
     ):
-        return {
+        transfer = {
             "Arn": "arn:aws:organizations::651706759263:transfer/o-g88u5pukze/billing/inbound/"
             "rt-8lr3q6sn",
             "Name": "AWS_Transfer_Billing_Test_2",
-            "Id": "rt-8lr3q6sn",
+            "Id": transfer_id,
             "Type": "BILLING",
             "Status": status,
             "Source": {"ManagementAccountId": source},
             "Target": {"ManagementAccountId": target},
             "StartTimestamp": dt.datetime.fromisoformat(start_timestamp),
         }
+        if end_timestamp:
+            transfer["EndTimestamp"] = dt.datetime.fromisoformat(end_timestamp)
+        return transfer
 
     return _responsibility_transfer
 
@@ -104,13 +112,18 @@ def mock_update_agreement(mocker):
 
 
 @pytest.fixture
-def mock_get_billing_group_arn(mocker):
-    return mocker.patch("swo_aws_extension.swo.mpt.sync.syncer.get_billing_group_arn")
+def mock_get_responsibility_transfer_id(mocker):
+    return mocker.patch("swo_aws_extension.swo.mpt.sync.syncer.get_responsibility_transfer_id")
 
 
 @pytest.fixture
-def mock_get_responsibility_transfer_id(mocker):
-    return mocker.patch("swo_aws_extension.swo.mpt.sync.syncer.get_responsibility_transfer_id")
+def mock_get_crm_terminate_order_ticket_id(mocker):
+    return mocker.patch(f"{_SYNCER_MOD}.get_crm_terminate_order_ticket_id")
+
+
+@pytest.fixture
+def mock_crm_service_client(mocker):
+    return mocker.patch(f"{_SYNCER_MOD}.get_service_client").return_value
 
 
 @pytest.fixture
@@ -119,17 +132,13 @@ def mock_get_mpa_method(mocker):
 
 
 @pytest.fixture
-def mock_get_accepted_transfer_method(mocker):
-    return mocker.patch(
-        "swo_aws_extension.swo.mpt.sync.syncer.AgreementSyncer.get_accepted_transfer"
-    )
+def mock_get_available_transfer_method(mocker):
+    return mocker.patch(f"{_SYNCER_MOD}.AgreementSyncer.get_available_transfer")
 
 
 @pytest.fixture
 def mock_get_responsibility_transfers(mocker):
-    return mocker.patch(
-        "swo_aws_extension.swo.mpt.sync.syncer.get_accepted_inbound_responsibility_transfers"
-    )
+    return mocker.patch(f"{_TRANSFERS_MOD}.get_available_responsibility_transfers")
 
 
 @pytest.fixture
@@ -153,13 +162,6 @@ def mock_agreement_syncer(mocker):
 
 
 @pytest.fixture
-def mock_delete_billing_group_method(mocker):
-    return mocker.patch(
-        "swo_aws_extension.swo.mpt.sync.syncer.AgreementSyncer.delete_billing_group"
-    )
-
-
-@pytest.fixture
 def mock_sync_responsibility_transfer_id_method(mocker):
     return mocker.patch(
         "swo_aws_extension.swo.mpt.sync.syncer.AgreementSyncer.sync_responsibility_transfer_id"
@@ -169,13 +171,3 @@ def mock_sync_responsibility_transfer_id_method(mocker):
 @pytest.fixture
 def mock_terminate_agreement_method(mocker):
     return mocker.patch("swo_aws_extension.swo.mpt.sync.syncer.AgreementSyncer.terminate_agreement")
-
-
-@pytest.fixture
-def mock_get_relationship_id(mocker):
-    return mocker.patch("swo_aws_extension.swo.mpt.sync.syncer.get_relationship_id")
-
-
-@pytest.fixture
-def mock_remove_apn_method(mocker):
-    return mocker.patch("swo_aws_extension.swo.mpt.sync.syncer.AgreementSyncer.remove_apn")

--- a/tests/swo/mpt/sync/test_responsibility_transfers.py
+++ b/tests/swo/mpt/sync/test_responsibility_transfers.py
@@ -1,0 +1,216 @@
+import datetime as dt
+
+import pytest
+
+from swo_aws_extension.constants import ResponsibilityTransferStatus
+from swo_aws_extension.swo.mpt.sync.responsibility_transfers import (
+    get_available_responsibility_transfers,
+    get_available_transfer_for_account,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_function_cache():
+    """Clear cache for cached functions between tests."""
+    yield
+    get_available_responsibility_transfers.cache_clear()
+
+
+def test_get_available_transfers_success(config, mock_awsclient, responsibility_transfer_factory):
+    pma_account_id = "123456789012"
+    withdrawn_end = "2026-10-31T23:59:59+00:00"
+    transfers = [
+        responsibility_transfer_factory(
+            source="225989344502", status=ResponsibilityTransferStatus.ACCEPTED.value
+        ),
+        responsibility_transfer_factory(
+            source="651706759263", status=ResponsibilityTransferStatus.REQUESTED.value
+        ),
+        responsibility_transfer_factory(
+            source="651706759264", status=ResponsibilityTransferStatus.DECLINED.value
+        ),
+        responsibility_transfer_factory(
+            source="651706759265",
+            status=ResponsibilityTransferStatus.WITHDRAWN.value,
+            end_timestamp=withdrawn_end,
+        ),
+    ]
+    mock_awsclient.get_inbound_responsibility_transfers.return_value = transfers
+
+    result = get_available_responsibility_transfers(pma_account_id)  # act
+
+    assert result == {
+        "225989344502": {
+            "Id": "rt-8lr3q6sn",
+            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+            "EndTimestamp": None,
+        },
+        "651706759265": {
+            "Id": "rt-8lr3q6sn",
+            "Status": ResponsibilityTransferStatus.WITHDRAWN.value,
+            "EndTimestamp": dt.datetime.fromisoformat(withdrawn_end),
+        },
+    }
+    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
+
+
+def test_get_available_transfers_multiple_withdrawn_keeps_latest(
+    config, mock_awsclient, responsibility_transfer_factory
+):
+    pma_account_id = "123456789012"
+    withdrawn = ResponsibilityTransferStatus.WITHDRAWN.value
+    transfers = [
+        responsibility_transfer_factory(transfer_id="rt-no-end", status=withdrawn),
+        responsibility_transfer_factory(
+            transfer_id="rt-old",
+            status=withdrawn,
+            end_timestamp="2026-06-30T23:59:59+00:00",
+        ),
+        responsibility_transfer_factory(
+            transfer_id="rt-latest",
+            status=withdrawn,
+            end_timestamp="2026-10-31T23:59:59+00:00",
+        ),
+        responsibility_transfer_factory(
+            transfer_id="rt-mid",
+            status=withdrawn,
+            end_timestamp="2026-08-31T23:59:59+00:00",
+        ),
+    ]
+    mock_awsclient.get_inbound_responsibility_transfers.return_value = transfers
+
+    result = get_available_responsibility_transfers(pma_account_id)  # act
+
+    assert result == {
+        "225989344502": {
+            "Id": "rt-latest",
+            "Status": withdrawn,
+            "EndTimestamp": dt.datetime.fromisoformat("2026-10-31T23:59:59+00:00"),
+        },
+    }
+
+
+@pytest.mark.parametrize("accepted_first", [True, False])
+def test_get_available_transfers_accepted_wins(
+    config, mock_awsclient, responsibility_transfer_factory, accepted_first
+):
+    pma_account_id = "123456789012"
+    accepted = responsibility_transfer_factory(
+        transfer_id="rt-accepted", status=ResponsibilityTransferStatus.ACCEPTED.value
+    )
+    withdrawn = responsibility_transfer_factory(
+        transfer_id="rt-withdrawn",
+        status=ResponsibilityTransferStatus.WITHDRAWN.value,
+        end_timestamp="2026-10-31T23:59:59+00:00",
+    )
+    transfers = [accepted, withdrawn] if accepted_first else [withdrawn, accepted]
+    mock_awsclient.get_inbound_responsibility_transfers.return_value = transfers
+
+    result = get_available_responsibility_transfers(pma_account_id)  # act
+
+    assert result["225989344502"]["Id"] == "rt-accepted"
+
+
+def test_get_available_transfers_empty(config, mock_awsclient, responsibility_transfer_factory):
+    pma_account_id = "123456789012"
+    mock_awsclient.get_inbound_responsibility_transfers.return_value = []
+
+    result = get_available_responsibility_transfers(pma_account_id)
+
+    assert result == {}
+    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
+
+
+def test_get_available_transfers_error(config, mock_awsclient):
+    pma_account_id = "123456789012"
+    mock_awsclient.get_inbound_responsibility_transfers.side_effect = Exception("Error occurred")
+
+    with pytest.raises(Exception, match="Error occurred"):
+        get_available_responsibility_transfers(pma_account_id)
+
+    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
+
+
+def test_get_available_transfers_all_inactive(
+    config, mock_awsclient, responsibility_transfer_factory
+):
+    pma_account_id = "123456789012"
+    transfers = [
+        responsibility_transfer_factory(
+            source="source1", status=ResponsibilityTransferStatus.DECLINED.value
+        ),
+        responsibility_transfer_factory(
+            source="source2", status=ResponsibilityTransferStatus.CANCELED.value
+        ),
+        responsibility_transfer_factory(
+            source="source3", status=ResponsibilityTransferStatus.EXPIRED.value
+        ),
+        responsibility_transfer_factory(
+            source="source4", status=ResponsibilityTransferStatus.REQUESTED.value
+        ),
+    ]
+    mock_awsclient.get_inbound_responsibility_transfers.return_value = transfers
+
+    result = get_available_responsibility_transfers(pma_account_id)
+
+    assert result == {}
+    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
+
+
+def test_get_available_transfers_no_source(config, mock_awsclient, responsibility_transfer_factory):
+    pma_account_id = "123456789012"
+    transfer_with_source = responsibility_transfer_factory(
+        source="225989344502", status=ResponsibilityTransferStatus.ACCEPTED.value
+    )
+    transfer_without_source = {
+        "Id": "rt-nosource",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        "Target": {"ManagementAccountId": "651706759263"},
+    }
+    mock_awsclient.get_inbound_responsibility_transfers.return_value = [
+        transfer_with_source,
+        transfer_without_source,
+    ]
+
+    result = get_available_responsibility_transfers(pma_account_id)
+
+    assert result == {
+        "225989344502": {
+            "Id": "rt-8lr3q6sn",
+            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+            "EndTimestamp": None,
+        },
+    }
+
+
+def test_get_transfer_for_account_found(
+    mock_get_responsibility_transfers,
+):
+    mock_get_responsibility_transfers.return_value = {
+        "225989344502": {
+            "Id": "rt-8lr3q6sn",
+            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        },
+    }
+
+    result = get_available_transfer_for_account("651706759263", "225989344502")
+
+    assert result == {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+    }
+
+
+def test_get_transfer_for_account_not_found(
+    mock_get_responsibility_transfers,
+):
+    mock_get_responsibility_transfers.return_value = {
+        "225989344502": {
+            "Id": "rt-8lr3q6sn",
+            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        },
+    }
+
+    result = get_available_transfer_for_account("651706759263", "999999999999")
+
+    assert result is None

--- a/tests/swo/mpt/sync/test_syncer.py
+++ b/tests/swo/mpt/sync/test_syncer.py
@@ -1,41 +1,33 @@
-import pytest
+import datetime as dt
 
-from swo_aws_extension.aws.errors import AWSError
+import pytest
+from freezegun import freeze_time
+
 from swo_aws_extension.constants import (
     ResponsibilityTransferStatus,
 )
+from swo_aws_extension.swo.crm_service.errors import CRMError
 from swo_aws_extension.swo.mpt.sync.syncer import (
     AgreementProcessorError,
-    get_accepted_inbound_responsibility_transfers,
-    get_accepted_transfer_for_account,
     synchronize_agreements,
 )
 
 
-@pytest.fixture(autouse=True)
-def clear_function_cache():
-    """Clear cache for cached functions between tests."""
-    yield
-    get_accepted_inbound_responsibility_transfers.cache_clear()
-
-
 def test_agreement_syncer_sync_success(
     agreement,
-    mock_get_accepted_transfer_for_account,
+    mock_get_available_transfer_for_account,
     mock_sync_responsibility_transfer_id_method,
     syncer,
 ):
-    mock_get_accepted_transfer_for_account.return_value = {
+    mock_get_available_transfer_for_account.return_value = {
         "Id": "rt-8lr3q6sn",
         "Status": ResponsibilityTransferStatus.ACCEPTED.value,
     }
 
     syncer.process(agreement)  # act
 
-    mock_get_accepted_transfer_for_account.assert_called_once_with("651706759263", "225989344502")
-    mock_sync_responsibility_transfer_id_method.assert_called_once_with(
-        syncer.mpt_client, agreement, "rt-8lr3q6sn"
-    )
+    mock_get_available_transfer_for_account.assert_called_once_with("651706759263", "225989344502")
+    mock_sync_responsibility_transfer_id_method.assert_called_once_with(agreement, "rt-8lr3q6sn")
 
 
 @pytest.mark.parametrize(
@@ -73,10 +65,10 @@ def test_agreement_syncer_sync_missing_accounts(
 def test_agreement_syncer_sync_aws_exception(
     agreement,
     mock_send_warning,
-    mock_get_accepted_transfer_for_account,
+    mock_get_available_transfer_for_account,
     syncer,
 ):
-    mock_get_accepted_transfer_for_account.side_effect = Exception("error")
+    mock_get_available_transfer_for_account.side_effect = Exception("error")
 
     syncer.process(agreement)  # act
 
@@ -88,15 +80,13 @@ def test_agreement_syncer_sync_aws_exception(
 
 def test_agreement_syncer_sync_no_active_transfer(
     agreement_factory,
-    mock_get_accepted_transfer_method,
+    mock_get_available_transfer_method,
     mock_send_warning,
     mock_terminate_agreement_method,
-    mock_delete_billing_group_method,
-    mock_remove_apn_method,
     syncer,
 ):
     mock_agreement = agreement_factory()
-    mock_get_accepted_transfer_method.return_value = None
+    mock_get_available_transfer_method.return_value = None
 
     syncer.process(mock_agreement)  # act
 
@@ -105,186 +95,279 @@ def test_agreement_syncer_sync_no_active_transfer(
         f"{mock_agreement.get('id')} - agreement with an inactive transfer - terminating",
     )
     mock_terminate_agreement_method.assert_called_once_with(mock_agreement)
-    mock_delete_billing_group_method.assert_called_once_with(mock_agreement, "651706759263")
-    mock_remove_apn_method.assert_called_once_with(mock_agreement, "651706759263")
+
+
+@freeze_time("2026-08-06")
+def test_agreement_syncer_notifies_scheduled_transfer_end(
+    mocker,
+    agreement,
+    mock_get_available_transfer_for_account,
+    mock_sync_responsibility_transfer_id_method,
+    mock_get_crm_terminate_order_ticket_id,
+    mock_crm_service_client,
+    mock_update_agreement,
+    mock_terminate_agreement_method,
+    syncer,
+):
+    end_date = dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00")
+    mock_get_available_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        "EndTimestamp": end_date,
+    }
+    mock_get_crm_terminate_order_ticket_id.return_value = ""
+    mock_crm_service_client.create_service_request.return_value = {"id": "TICKET-123"}
+
+    syncer.process(agreement)  # act
+
+    service_request = mock_crm_service_client.create_service_request.call_args.args[1]
+    expected_end_date = end_date.strftime("%Y-%m-%d %H:%M:%S")
+    assert f"Termination date: <b>{expected_end_date}</b>" in service_request.summary
+    assert mock_update_agreement.call_args_list == [
+        mocker.call(
+            syncer.mpt_client,
+            agreement["id"],
+            parameters={
+                "fulfillment": [
+                    {"externalId": "relationshipEndDate", "value": end_date.isoformat()}
+                ]
+            },
+        ),
+        mocker.call(
+            syncer.mpt_client,
+            agreement["id"],
+            parameters={
+                "fulfillment": [{"externalId": "crmTerminateOrderTicketId", "value": "TICKET-123"}]
+            },
+        ),
+    ]
+    mock_terminate_agreement_method.assert_not_called()
+    mock_sync_responsibility_transfer_id_method.assert_called_once_with(agreement, "rt-8lr3q6sn")
+
+
+@freeze_time("2026-08-06")
+def test_agreement_syncer_notifies_transfer_end_only_once(
+    agreement,
+    mock_get_available_transfer_for_account,
+    mock_sync_responsibility_transfer_id_method,
+    mock_get_crm_terminate_order_ticket_id,
+    mock_crm_service_client,
+    mock_update_agreement,
+    syncer,
+):
+    mock_get_available_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        "EndTimestamp": dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00"),
+    }
+    mock_get_crm_terminate_order_ticket_id.return_value = "TICKET-123"
+
+    syncer.process(agreement)  # act
+
+    mock_crm_service_client.create_service_request.assert_not_called()
+    assert mock_update_agreement.call_count == 1
+    updated_parameters = mock_update_agreement.call_args.kwargs["parameters"]
+    assert updated_parameters["fulfillment"][0]["externalId"] == "relationshipEndDate"
+    mock_sync_responsibility_transfer_id_method.assert_called_once_with(agreement, "rt-8lr3q6sn")
+
+
+@freeze_time("2026-08-06")
+def test_agreement_syncer_notify_transfer_end_dry_run(
+    agreement,
+    mock_get_available_transfer_for_account,
+    mock_sync_responsibility_transfer_id_method,
+    mock_get_crm_terminate_order_ticket_id,
+    mock_crm_service_client,
+    mock_update_agreement,
+    syncer_dry_run,
+):
+    mock_get_available_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        "EndTimestamp": dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00"),
+    }
+    mock_get_crm_terminate_order_ticket_id.return_value = ""
+
+    syncer_dry_run.process(agreement)  # act
+
+    mock_crm_service_client.create_service_request.assert_not_called()
+    mock_update_agreement.assert_not_called()
+
+
+@freeze_time("2026-08-06")
+def test_agreement_syncer_notify_transfer_end_crm_error(
+    agreement,
+    mock_get_available_transfer_for_account,
+    mock_sync_responsibility_transfer_id_method,
+    mock_get_crm_terminate_order_ticket_id,
+    mock_crm_service_client,
+    mock_update_agreement,
+    mock_send_exception,
+    syncer,
+):
+    mock_get_available_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        "EndTimestamp": dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00"),
+    }
+    mock_get_crm_terminate_order_ticket_id.return_value = ""
+    mock_crm_service_client.create_service_request.side_effect = CRMError("error")
+
+    syncer.process(agreement)  # act
+
+    assert mock_update_agreement.call_count == 1  # only the relationship end date sync
+    mock_send_exception.assert_called_once_with(
+        "Transfer end notification",
+        f"{agreement['id']} - failed to create the transfer end termination ticket",
+    )
+
+
+@freeze_time("2026-08-06")
+def test_agreement_syncer_notify_transfer_end_update_agreement_error(
+    agreement,
+    mock_get_available_transfer_for_account,
+    mock_sync_responsibility_transfer_id_method,
+    mock_get_crm_terminate_order_ticket_id,
+    mock_crm_service_client,
+    mock_update_agreement,
+    mock_send_exception,
+    syncer,
+):
+    mock_get_available_transfer_for_account.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+        "EndTimestamp": dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00"),
+    }
+    mock_get_crm_terminate_order_ticket_id.return_value = ""
+    mock_crm_service_client.create_service_request.return_value = {"id": "TICKET-123"}
+    mock_update_agreement.side_effect = [None, Exception("error")]
+
+    syncer.process(agreement)  # act
+
+    mock_send_exception.assert_called_once_with(
+        "Transfer end notification",
+        f"{agreement['id']} - failed to update agreement with termination ticket ID TICKET-123",
+    )
+
+
+@freeze_time("2026-08-06")
+def test_agreement_syncer_terminates_when_transfer_end_date_reached(
+    agreement_factory,
+    mock_get_available_transfer_method,
+    mock_send_warning,
+    mock_terminate_agreement_method,
+    mock_crm_service_client,
+    mock_update_agreement,
+    syncer,
+):
+    end_date = dt.datetime.fromisoformat("2026-07-31T23:59:59+00:00")
+    mock_agreement = agreement_factory()
+    mock_get_available_transfer_method.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.WITHDRAWN.value,
+        "EndTimestamp": end_date,
+    }
+
+    syncer.process(mock_agreement)  # act
+
+    mock_update_agreement.assert_called_once_with(
+        syncer.mpt_client,
+        mock_agreement["id"],
+        parameters={
+            "fulfillment": [{"externalId": "relationshipEndDate", "value": end_date.isoformat()}]
+        },
+    )
+    mock_terminate_agreement_method.assert_called_once_with(mock_agreement)
+    mock_crm_service_client.create_service_request.assert_not_called()
+    mock_send_warning.assert_called_once_with(
+        "Synchronize AWS agreement subscriptions",
+        f"{mock_agreement.get('id')} - agreement with an inactive transfer - terminating",
+    )
+
+
+def test_sync_relationship_end_date_skips_if_unchanged(
+    agreement_factory,
+    fulfillment_parameters_factory,
+    mock_update_agreement,
+    syncer,
+):
+    end_date = dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00")
+    agreement = agreement_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(
+            relationship_end_date=end_date.isoformat(),
+        )
+    )
+
+    syncer.sync_relationship_end_date(agreement, end_date)  # act
+
+    mock_update_agreement.assert_not_called()
+
+
+def test_sync_relationship_end_date_dry_run(agreement, mock_update_agreement, syncer_dry_run):
+    end_date = dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00")
+
+    syncer_dry_run.sync_relationship_end_date(agreement, end_date)  # act
+
+    mock_update_agreement.assert_not_called()
+
+
+def test_sync_relationship_end_date_error(
+    agreement, mock_update_agreement, mock_send_exception, syncer
+):
+    end_date = dt.datetime.fromisoformat("2026-09-30T23:59:59+00:00")
+    mock_update_agreement.side_effect = Exception("error")
+
+    syncer.sync_relationship_end_date(agreement, end_date)  # act
+
+    mock_send_exception.assert_called_once_with(
+        "Synchronize relationship end date",
+        f"{agreement['id']} - failed to update agreement with "
+        f"relationship end date {end_date.isoformat()}",
+    )
 
 
 def test_sync_agreements_with_active_transfer(
     agreement,
     mock_get_agreements_by_query,
-    mock_get_accepted_transfer_method,
+    mock_get_available_transfer_method,
     mock_terminate_agreement_method,
-    mock_delete_billing_group_method,
     mock_sync_responsibility_transfer_id_method,
     mpt_client,
 ):
     mock_get_agreements_by_query.return_value = [agreement]
-    mock_get_accepted_transfer_method.return_value = {
+    mock_get_available_transfer_method.return_value = {
         "Id": "rt-8lr3q6sn",
         "Status": ResponsibilityTransferStatus.ACCEPTED.value,
     }
 
     synchronize_agreements(mpt_client, ["AGR-123-456"], ["PROD-123-456"], dry_run=False)  # act
 
-    assert mock_get_accepted_transfer_method.call_count == 1
+    assert mock_get_available_transfer_method.call_count == 1
     mock_terminate_agreement_method.assert_not_called()
-    mock_delete_billing_group_method.assert_not_called()
-    mock_get_accepted_transfer_method.assert_called_once_with(
+    mock_get_available_transfer_method.assert_called_once_with(
         agreement, "225989344502", "651706759263"
     )
-    mock_sync_responsibility_transfer_id_method.assert_called_once_with(
-        mpt_client, agreement, "rt-8lr3q6sn"
-    )
+    mock_sync_responsibility_transfer_id_method.assert_called_once_with(agreement, "rt-8lr3q6sn")
 
 
-def test_synchronize_agreements_exception(
+def test_process_unhandled_exception_notifies(
     agreement,
-    mock_get_accepted_transfer_method,
+    mock_get_available_transfer_method,
     mock_terminate_agreement_method,
     syncer,
     mock_send_exception,
 ):
-    mock_get_accepted_transfer_method.return_value = None
+    mock_get_available_transfer_method.return_value = None
     error_msg = "Test sync error"
     mock_terminate_agreement_method.side_effect = Exception(error_msg)
 
     syncer.process(agreement)  # act
 
-    assert mock_get_accepted_transfer_method.call_count == 1
-    mock_get_accepted_transfer_method.assert_called_once_with(
+    assert mock_get_available_transfer_method.call_count == 1
+    mock_get_available_transfer_method.assert_called_once_with(
         agreement, "225989344502", "651706759263"
     )
     mock_send_exception.assert_called_once()
-
-
-def test_get_accepted_transfers_success(config, mock_awsclient, responsibility_transfer_factory):
-    pma_account_id = "123456789012"
-    transfers = [
-        responsibility_transfer_factory(
-            source="225989344502", status=ResponsibilityTransferStatus.ACCEPTED.value
-        ),
-        responsibility_transfer_factory(
-            source="651706759263", status=ResponsibilityTransferStatus.REQUESTED.value
-        ),
-        responsibility_transfer_factory(
-            source="651706759264", status=ResponsibilityTransferStatus.DECLINED.value
-        ),
-    ]
-    mock_awsclient.get_inbound_responsibility_transfers.return_value = transfers
-
-    result = get_accepted_inbound_responsibility_transfers(pma_account_id)  # act
-
-    assert result == {
-        "225989344502": {
-            "Id": "rt-8lr3q6sn",
-            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
-        },
-    }
-    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
-
-
-def test_get_accepted_transfers_empty(config, mock_awsclient, responsibility_transfer_factory):
-    pma_account_id = "123456789012"
-    mock_awsclient.get_inbound_responsibility_transfers.return_value = []
-
-    result = get_accepted_inbound_responsibility_transfers(pma_account_id)
-
-    assert result == {}
-    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
-
-
-def test_get_accepted_transfers_error(config, mock_awsclient):
-    pma_account_id = "123456789012"
-    mock_awsclient.get_inbound_responsibility_transfers.side_effect = Exception("Error occurred")
-
-    with pytest.raises(Exception, match="Error occurred"):
-        get_accepted_inbound_responsibility_transfers(pma_account_id)
-
-    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
-
-
-def test_get_accepted_transfers_all_inactive(
-    config, mock_awsclient, responsibility_transfer_factory
-):
-    pma_account_id = "123456789012"
-    transfers = [
-        responsibility_transfer_factory(
-            source="source1", status=ResponsibilityTransferStatus.DECLINED.value
-        ),
-        responsibility_transfer_factory(
-            source="source2", status=ResponsibilityTransferStatus.CANCELED.value
-        ),
-        responsibility_transfer_factory(
-            source="source3", status=ResponsibilityTransferStatus.EXPIRED.value
-        ),
-        responsibility_transfer_factory(
-            source="source4", status=ResponsibilityTransferStatus.WITHDRAWN.value
-        ),
-    ]
-    mock_awsclient.get_inbound_responsibility_transfers.return_value = transfers
-
-    result = get_accepted_inbound_responsibility_transfers(pma_account_id)
-
-    assert result == {}
-    assert mock_awsclient.get_inbound_responsibility_transfers.call_count == 1
-
-
-def test_get_accepted_transfers_no_source(config, mock_awsclient, responsibility_transfer_factory):
-    pma_account_id = "123456789012"
-    transfer_with_source = responsibility_transfer_factory(
-        source="225989344502", status=ResponsibilityTransferStatus.ACCEPTED.value
-    )
-    transfer_without_source = {
-        "Id": "rt-nosource",
-        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
-        "Target": {"ManagementAccountId": "651706759263"},
-    }
-    mock_awsclient.get_inbound_responsibility_transfers.return_value = [
-        transfer_with_source,
-        transfer_without_source,
-    ]
-
-    result = get_accepted_inbound_responsibility_transfers(pma_account_id)
-
-    assert result == {
-        "225989344502": {
-            "Id": "rt-8lr3q6sn",
-            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
-        },
-    }
-
-
-def test_get_transfer_for_account_found(
-    mock_get_responsibility_transfers,
-):
-    mock_get_responsibility_transfers.return_value = {
-        "225989344502": {
-            "Id": "rt-8lr3q6sn",
-            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
-        },
-    }
-
-    result = get_accepted_transfer_for_account("651706759263", "225989344502")
-
-    assert result == {
-        "Id": "rt-8lr3q6sn",
-        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
-    }
-
-
-def test_get_transfer_for_account_not_found(
-    mock_get_responsibility_transfers,
-):
-    mock_get_responsibility_transfers.return_value = {
-        "225989344502": {
-            "Id": "rt-8lr3q6sn",
-            "Status": ResponsibilityTransferStatus.ACCEPTED.value,
-        },
-    }
-
-    result = get_accepted_transfer_for_account("651706759263", "999999999999")
-
-    assert result is None
 
 
 def test_terminate_agr(agreement_factory, mock_terminate_subscription, syncer):
@@ -327,9 +410,7 @@ def test_sync_transfer_id_no_change(
     agreement = agreement_factory()
     responsibility_transfer_id = agreement["parameters"]["fulfillment"][1]["value"]
 
-    syncer.sync_responsibility_transfer_id(
-        syncer.mpt_client, agreement, responsibility_transfer_id
-    )  # act
+    syncer.sync_responsibility_transfer_id(agreement, responsibility_transfer_id)  # act
 
     mock_update_agreement.assert_not_called()
     mock_send_exception.assert_not_called()
@@ -341,7 +422,7 @@ def test_sync_transfer_id_update(
     agreement = agreement_factory()
     pma_account_id = "PMA-123456"
 
-    syncer.sync_responsibility_transfer_id(syncer.mpt_client, agreement, pma_account_id)  # act
+    syncer.sync_responsibility_transfer_id(agreement, pma_account_id)  # act
 
     assert mock_update_agreement.call_count == 1
     mock_update_agreement.assert_called_once_with(
@@ -358,103 +439,9 @@ def test_sync_transfer_id_dry_run(agreement_factory, mock_update_agreement, sync
     agreement = agreement_factory()
     pma_account_id = "PMA-123456"
 
-    syncer_dry_run.sync_responsibility_transfer_id(
-        syncer_dry_run.mpt_client, agreement, pma_account_id
-    )  # act
+    syncer_dry_run.sync_responsibility_transfer_id(agreement, pma_account_id)  # act
 
     mock_update_agreement.assert_not_called()
-
-
-def test_delete_billing_group_success(
-    agreement, mock_awsclient, mock_get_billing_group_arn, syncer
-):
-    mock_get_billing_group_arn.return_value = (
-        "arn:aws:billingconductor::123456789012:billinggroup/bg-1"
-    )
-
-    syncer.delete_billing_group(agreement, "123456789")  # act
-
-    mock_awsclient.delete_billing_group.assert_called_once_with(
-        "arn:aws:billingconductor::123456789012:billinggroup/bg-1"
-    )
-
-
-def test_delete_billing_group_no_arn(agreement, mock_awsclient, mock_get_billing_group_arn, syncer):
-    mock_get_billing_group_arn.return_value = ""
-
-    syncer.delete_billing_group(agreement, "123456789")  # act
-
-    mock_awsclient.delete_billing_group.assert_not_called()
-
-
-def test_delete_billing_group_dry_run(
-    agreement, mock_awsclient, mock_get_billing_group_arn, syncer_dry_run
-):
-    arn = "arn:aws:billingconductor::123456789012:billinggroup/bg-1"
-    mock_get_billing_group_arn.return_value = arn
-
-    syncer_dry_run.delete_billing_group(agreement, "123456789")  # act
-
-    mock_awsclient.delete_billing_group.assert_not_called()
-
-
-def test_delete_billing_group_aws_error(
-    agreement, mock_awsclient, mock_get_billing_group_arn, syncer
-):
-    arn = "arn:aws:billingconductor::123456789012:billinggroup/bg-1"
-    mock_get_billing_group_arn.return_value = arn
-    mock_awsclient.delete_billing_group.side_effect = AWSError("error")
-
-    syncer.delete_billing_group(agreement, "123456789")  # act
-
-    mock_awsclient.delete_billing_group.assert_called_once_with(arn)
-
-
-def test_remove_apn_success(agreement, mock_awsclient, mock_get_relationship_id, syncer):
-    mock_get_relationship_id.return_value = "rel-123"
-    mock_awsclient.get_program_management_id_by_account.return_value = "pm-123"
-
-    syncer.remove_apn(agreement, "123456789012")  # act
-
-    mock_awsclient.get_program_management_id_by_account.assert_called_once_with("123456789012")
-    mock_awsclient.delete_pc_relationship.assert_called_once_with("pm-123", "rel-123")
-
-
-def test_remove_apn_no_relationship_id(agreement, mock_awsclient, mock_get_relationship_id, syncer):
-    mock_get_relationship_id.return_value = None
-
-    syncer.remove_apn(agreement, "123456789012")  # act
-
-    mock_awsclient.get_program_management_id_by_account.assert_not_called()
-
-
-def test_remove_apn_pm_id_not_found(agreement, mock_awsclient, mock_get_relationship_id, syncer):
-    mock_get_relationship_id.return_value = "rel-123"
-    mock_awsclient.get_program_management_id_by_account.side_effect = AWSError("not found")
-
-    syncer.remove_apn(agreement, "123456789012")  # act
-
-    mock_awsclient.delete_pc_relationship.assert_not_called()
-
-
-def test_remove_apn_delete_error(agreement, mock_awsclient, mock_get_relationship_id, syncer):
-    mock_get_relationship_id.return_value = "rel-123"
-    mock_awsclient.get_program_management_id_by_account.return_value = "pm-123"
-    mock_awsclient.delete_pc_relationship.side_effect = AWSError("error")
-
-    syncer.remove_apn(agreement, "123456789012")  # act
-
-    mock_awsclient.delete_pc_relationship.assert_called_once()
-
-
-def test_remove_apn_dry_run(agreement, mock_awsclient, mock_get_relationship_id, syncer_dry_run):
-    mock_get_relationship_id.return_value = "rel-123"
-    mock_awsclient.get_program_management_id_by_account.return_value = "pm-123"
-
-    syncer_dry_run.remove_apn(agreement, "123456789012")  # act
-
-    mock_awsclient.get_program_management_id_by_account.assert_called_once_with("123456789012")
-    mock_awsclient.delete_pc_relationship.assert_not_called()
 
 
 def test_agreement_error(agreement, mock_get_mpa_method, mock_send_warning, syncer):
@@ -475,7 +462,7 @@ def test_sync_responsibility_transfer_id_error(
     mock_update_agreement.side_effect = Exception("error")
     mock_get_responsibility_transfer_id.return_value = "old"
 
-    syncer.sync_responsibility_transfer_id(syncer.mpt_client, agreement, "new")  # act
+    syncer.sync_responsibility_transfer_id(agreement, "new")  # act
 
     mock_send_exception.assert_called_once()
 
@@ -490,3 +477,22 @@ def test_get_pma(agreement, syncer):
     result = syncer.get_pma(agreement)
 
     assert result == "651706759263"
+
+
+def test_synchronize_agreements_no_agreement_ids(
+    agreement,
+    mock_get_agreements_by_query,
+    mock_get_available_transfer_method,
+    mock_sync_responsibility_transfer_id_method,
+    mpt_client,
+):
+    mock_get_agreements_by_query.return_value = [agreement]
+    mock_get_available_transfer_method.return_value = {
+        "Id": "rt-8lr3q6sn",
+        "Status": ResponsibilityTransferStatus.ACCEPTED.value,
+    }
+
+    synchronize_agreements(mpt_client, [], ["PROD-123-456"], dry_run=False)  # act
+
+    mock_get_agreements_by_query.assert_called_once()
+    mock_get_available_transfer_method.assert_called_once()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,7 +1,58 @@
-from swo_aws_extension.constants import AccountTypesEnum
+from swo_aws_extension.constants import AccountTypesEnum, OrderParametersEnum
 from swo_aws_extension.parameters import (
+    get_formatted_technical_contact,
+    get_relationship_end_date,
     reset_ordering_parameters_error,
+    set_relationship_end_date,
 )
+
+
+def test_get_relationship_end_date(order_factory, fulfillment_parameters_factory):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(
+            relationship_end_date="2026-10-31T23:59:59.999000+00:00"
+        )
+    )
+
+    result = get_relationship_end_date(order)
+
+    assert result == "2026-10-31T23:59:59.999000+00:00"
+
+
+def test_set_relationship_end_date(order_factory, fulfillment_parameters_factory):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(relationship_end_date="")
+    )
+
+    result = set_relationship_end_date(order, "2026-10-31T23:59:59.999000+00:00")
+
+    assert get_relationship_end_date(result) == "2026-10-31T23:59:59.999000+00:00"
+
+
+def test_get_formatted_technical_contact_with_phone_object():
+    source = {
+        "parameters": {
+            "ordering": [
+                {
+                    "externalId": OrderParametersEnum.CONTACT.value,
+                    "value": {
+                        "firstName": "John",
+                        "lastName": "Doe",
+                        "email": "john.doe@example.com",
+                        "phone": {"prefix": "+34", "number": "600111222"},
+                    },
+                }
+            ]
+        }
+    }
+
+    result = get_formatted_technical_contact(source)
+
+    assert result == {
+        "name": "John Doe",
+        "email": "john.doe@example.com",
+        "phone": "+34600111222",
+    }
 
 
 def test_reset_ordering_parameters_error(order_factory, order_parameters_factory):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Backport of [MPT-23797](https://softwareone.atlassian.net/browse/MPT-23797) (AWS fulfilment modification - service term removal) to `release/5`, combining the two sub-task changes already merged to `main`:

- Cherry-pick of #423 ([MPT-23846](https://softwareone.atlassian.net/browse/MPT-23846), commit `7238287`): create the Partner Central channel handshake with a 60-day `MINIMUM_NOTICE_PERIOD` service term instead of a fixed 1-year `FIXED_COMMITMENT_PERIOD` end date, and add the migration that creates and backfills the hidden `relationshipEndDate` agreement fulfillment parameter.
- Cherry-pick of #424 ([MPT-23867](https://softwareone.atlassian.net/browse/MPT-23867), commit `42f21b7`): remove the service term from the AWS termination flow — schedule the responsibility transfer withdrawal honoring the notice period, create the MCoE CRM ticket with the effective date, keep the termination order processing until that date, and drop automatic deletion of the billing group, APN relationship, and channel partner relationship (offboarding is handled manually by MCoE). The syncer now stores the relationship end date, creates the MCoE termination ticket once when the customer schedules the transfer end, and only terminates agreements in MPP when the transfer is inactive or its end date is reached.

## Conflict resolutions

`release/5` has diverged from `main`, so the second cherry-pick required manual resolution keeping only the release-branch equivalent of the original fix:

- Kept the release-branch single-module `swo/mpt/sync/syncer.py` layout (no `agreement_syncer.py` / `agreement_subscription_syncer.py` split, no `mpt_api_client` dependency) while applying the termination-flow changes and porting the corresponding tests.
- Excluded `main`-only features not present on `release/5`: `terminationDate` / `splitBillingPolicy` parameters and helpers, `ValidateTerminationOrder` step, and `docs/architecture.md`.
- Added `WPS211` to the existing `tests/swo/mpt/sync/conftest.py` per-file-ignores entry (on `main` the generic tests ignore list already covers it).

## Testing

`make check-all` passes: 1098 passed, 1 xpassed, with 100% coverage on the modified `syncer.py` and the new `responsibility_transfers.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-23797]: https://softwareone.atlassian.net/browse/MPT-23797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23846]: https://softwareone.atlassian.net/browse/MPT-23846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23867]: https://softwareone.atlassian.net/browse/MPT-23867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23797](https://softwareone.atlassian.net/browse/MPT-23797)

- Create Partner Central channel handshakes with a 60-day minimum notice period.
- Add and backfill the hidden `relationshipEndDate` fulfillment parameter.
- Schedule responsibility-transfer withdrawal and create CRM tickets with the effective termination date.
- Wait until the responsibility-transfer end date before completing AWS termination.
- Remove automated deletion of billing groups, APN relationships, and channel partner relationships.
- Track relationship end dates and terminate MPP agreements only when transfers end or become inactive.
- Add responsibility-transfer synchronization helpers, date handling, migration logic, and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->