### PR TITLE
MPT-24027 harden exchange-rate resolution for zero and tied rates

### DIFF
--- a/swo_aws_extension/billing/generators/invoice.py
+++ b/swo_aws_extension/billing/generators/invoice.py
@@ -29,8 +29,10 @@ class ExchangeRateResolver:
             return max(entity_rates)
         return max(self._extract_rates(currency), default=DEC_ZERO)
 
-    def get_payment_currency(self, exchange_rate: Decimal) -> str:
-        """Get the payment currency code for the given exchange rate."""
+    def get_payment_currency(self, exchange_rate: Decimal, currency: str) -> str:
+        """Get the payment currency code for the given resolved exchange rate and currency."""
+        if exchange_rate > DEC_ZERO:
+            return currency
         for invoice in self._invoices:
             if invoice.exchange_rate == exchange_rate:
                 return invoice.payment_currency_code or "USD"
@@ -40,7 +42,7 @@ class ExchangeRateResolver:
         return [
             invoice.exchange_rate
             for invoice in self._invoices
-            if invoice.payment_currency_code == currency
+            if invoice.has_payment_rate(currency)
             and (not entity_name or invoice.invoicing_entity == entity_name)
         ]
 
@@ -106,7 +108,9 @@ class OrganizationInvoiceBuilder:
         return InvoiceEntity(
             invoice_id=invoice.invoice_id,
             base_currency_code=invoice.base_currency_code,
-            payment_currency_code=self._resolver.get_payment_currency(exchange_rate),
+            payment_currency_code=self._resolver.get_payment_currency(
+                exchange_rate, self._currency
+            ),
             exchange_rate=exchange_rate,
             billing_entity=invoice.billing_entity,
             primary=invoice.is_primary,

--- a/tests/billing/generators/test_invoice.py
+++ b/tests/billing/generators/test_invoice.py
@@ -362,21 +362,54 @@ def test_exchange_rate_resolver_get_rate(entity, currency, expected):
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    ("rate", "expected_currency"),
-    [
-        (Decimal("0.92"), "EUR"),
-        (Decimal("0.99"), "USD"),
-    ],
-)
-def test_exchange_rate_resolver_get_payment_currency(rate, expected_currency):
+def test_exchange_rate_resolver_get_rate_ignores_zero_entity_rates():
     invoices = [
-        RawInvoice(build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.90")),
+        RawInvoice(build_invoice(invoicing_entity="AWS EMEA", exchange_rate="0")),
         RawInvoice(build_invoice(invoicing_entity="AWS Inc.", exchange_rate="0.95")),
-        RawInvoice(build_invoice(invoicing_entity="AWS EMEA", exchange_rate="0.92")),
     ]
     resolver = ExchangeRateResolver(invoices)
 
-    result = resolver.get_payment_currency(rate)
+    result = resolver.get_rate("AWS EMEA", "EUR")
+
+    assert result == Decimal("0.95")
+
+
+def test_exchange_rate_resolver_get_payment_currency_uses_requested_currency_on_rate_ties():
+    invoices = [
+        RawInvoice(build_invoice(invoicing_entity="AWS UK", payment_currency="GBP")),
+        RawInvoice(build_invoice(invoicing_entity="AWS EMEA", payment_currency="EUR")),
+    ]
+    resolver = ExchangeRateResolver(invoices)
+
+    result = resolver.get_payment_currency(Decimal("0.95"), "EUR")
+
+    assert result == "EUR"
+
+
+@pytest.mark.parametrize(
+    ("payment_currency", "expected_currency"),
+    [
+        ("EUR", "EUR"),
+        (None, "USD"),
+    ],
+)
+def test_exchange_rate_resolver_get_payment_currency_falls_back_on_zero_rate(
+    payment_currency, expected_currency
+):
+    invoice = build_invoice(exchange_rate="0", payment_currency=payment_currency)
+    if payment_currency is None:
+        invoice.pop("PaymentCurrencyAmount")
+    resolver = ExchangeRateResolver([RawInvoice(invoice)])
+
+    result = resolver.get_payment_currency(Decimal(0), "GBP")
 
     assert result == expected_currency
+
+
+def test_exchange_rate_resolver_get_payment_currency_defaults_to_usd_without_matching_rate():
+    invoices = [RawInvoice(build_invoice(exchange_rate="0.95"))]
+    resolver = ExchangeRateResolver(invoices)
+
+    result = resolver.get_payment_currency(Decimal(0), "GBP")
+
+    assert result == "USD"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Follow-up to #428, porting to `main` the review feedback raised on the MPT-24027 hotfix PR (#430) so both branches stay aligned. Two hardenings in `ExchangeRateResolver`:

### 1. Zero entity rates no longer mask the fallback rate

`_extract_rates` matched invoices by payment currency code only. An invoice reporting the payment currency without exchange rate details produced `entity_rates == [0]`, which is truthy, so `get_rate` returned `0` instead of falling back to the positive organization-wide rate — leaving the base amount unconverted (the exact failure mode MPT-24027 fixed). Extraction now filters with `RawInvoice.has_payment_rate`, so only positive rates for the requested currency are considered.

### 2. Payment currency no longer reverse-mapped from the numeric rate

`get_payment_currency` scanned invoices for one whose rate equals the resolved rate. If two currencies share the same rate, the wrong currency could be stamped on the invoice entity, and since `resolve_service_amount` compares currency codes, the journal conversion could be skipped. The resolver now receives the requested currency and returns it directly whenever a positive rate was resolved; the raw-invoice metadata scan is kept only for the zero-rate case.

## Testing

- `make check-all` green: 1175 passed, 1 xpassed.
- 100% statement and branch coverage on `billing/generators/invoice.py`.
- New regression tests: zero entity rate falls back to the org-wide rate, rate ties across currencies resolve to the requested currency, and zero-rate fallback metadata (entity currency present, missing payment block, no zero-rate invoice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-24027](https://softwareone.atlassian.net/browse/MPT-24027)

- Ignore zero-rate invoice entries during exchange-rate resolution.
- Return the requested payment currency when positive rates are tied.
- Preserve raw-invoice metadata lookup for zero-rate cases.
- Add regression tests for zero-rate fallback, tied rates, and fallback metadata.
- `make check-all` passes with 1175 tests passed and one expected failure passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-24027]: https://softwareone.atlassian.net/browse/MPT-24027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ